### PR TITLE
refactor: omit `.value` in token reference

### DIFF
--- a/proprietary/amsterdam-design-tokens/src/common/action-variant.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/common/action-variant.tokens.json
@@ -7,10 +7,10 @@
         },
         "fill": {
           "background-color": {
-            "value": "{amsterdam.action.primary.color.value}"
+            "value": "{amsterdam.action.primary.color}"
           },
           "color": {
-            "value": "{amsterdam.color.white.value}"
+            "value": "{amsterdam.color.white}"
           }
         }
       },
@@ -20,20 +20,20 @@
         },
         "fill": {
           "background-color": {
-            "value": "{amsterdam.action.secondary.color.value}"
+            "value": "{amsterdam.action.secondary.color}"
           },
           "color": {
-            "value": "{amsterdam.color.white.value}"
+            "value": "{amsterdam.color.white}"
           }
         }
       },
       "disabled": {
         "fill": {
           "background-color": {
-            "value": "{amsterdam.color.grey.90.value}"
+            "value": "{amsterdam.color.grey.90}"
           },
           "color": {
-            "value": "{amsterdam.color.grey.70.value}"
+            "value": "{amsterdam.color.grey.70}"
           }
         }
       }

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/badge-counter.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/badge-counter.tokens.json
@@ -2,13 +2,13 @@
   "utrecht": {
     "badge-counter": {
       "background-color": {
-        "value": "{amsterdam.color.red.50.value}"
+        "value": "{amsterdam.color.red.50}"
       },
       "border-radius": {
         "value": "3ex"
       },
       "color": {
-        "value": "{amsterdam.color.white.value}"
+        "value": "{amsterdam.color.white}"
       },
       "font-weight": {},
       "padding-block": {

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/badge.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/badge.tokens.json
@@ -2,22 +2,22 @@
   "utrecht": {
     "badge": {
       "background-color": {
-        "value": "{amsterdam.color.grey.50.value}"
+        "value": "{amsterdam.color.grey.50}"
       },
       "border-radius": {
         "value": "0"
       },
       "color": {
-        "value": "{amsterdam.color.white.value}"
+        "value": "{amsterdam.color.white}"
       },
       "font-weight": {
-        "value": "{amsterdam.typography.weight-scale.semi-bold.font-weight.value}"
+        "value": "{amsterdam.typography.weight-scale.semi-bold.font-weight}"
       },
       "padding-block": {
         "value": "6px"
       },
       "padding-inline": {
-        "value": "{utrecht.space.inline.md.value}"
+        "value": "{utrecht.space.inline.md}"
       }
     }
   }

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/button.tokens.json
@@ -3,21 +3,21 @@
     "button": {
       "border-width": { "value": "0" },
       "border-radius": { "value": "0" },
-      "font-family": { "value": "{amsterdam.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{amsterdam.typography.scale.md.font-size.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
+      "font-family": { "value": "{amsterdam.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{amsterdam.typography.scale.md.font-size}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
       "margin-inline-start": { "value": "0" },
       "margin-inline-end": { "value": "0" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "background-color": { "value": "{amsterdam.action.primary.fill.background-color.value}" },
-      "color": { "value": "{amsterdam.action.primary.fill.color.value}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "background-color": { "value": "{amsterdam.action.primary.fill.background-color}" },
+      "color": { "value": "{amsterdam.action.primary.fill.color}" },
       "primary-action": {
-        "background-color": { "value": "{amsterdam.action.primary.fill.background-color.value}" },
-        "color": { "value": "{amsterdam.action.primary.fill.color.value}" },
+        "background-color": { "value": "{amsterdam.action.primary.fill.background-color}" },
+        "color": { "value": "{amsterdam.action.primary.fill.color}" },
         "hover": {
           "background-color": {},
           "color": {},
@@ -25,8 +25,8 @@
         }
       },
       "secondary-action": {
-        "background-color": { "value": "{amsterdam.action.secondary.fill.background-color.value}" },
-        "color": { "value": "{amsterdam.action.secondary.fill.color.value}" },
+        "background-color": { "value": "{amsterdam.action.secondary.fill.background-color}" },
+        "color": { "value": "{amsterdam.action.secondary.fill.color}" },
         "border-color": {},
         "border-width": {},
         "hover": {
@@ -35,13 +35,13 @@
         }
       },
       "focus": {
-        "border-color": { "value": "{amsterdam.color.black.value}" },
+        "border-color": { "value": "{amsterdam.color.black}" },
         "border-width": {},
         "transform-scale": {}
       },
       "disabled": {
-        "background-color": { "value": "{amsterdam.action.disabled.fill.background-color.value}" },
-        "color": { "value": "{amsterdam.action.disabled.fill.color.value}" }
+        "background-color": { "value": "{amsterdam.action.disabled.fill.background-color}" },
+        "color": { "value": "{amsterdam.action.disabled.fill.color}" }
       }
     }
   }

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/custom-checkbox.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/custom-checkbox.tokens.json
@@ -2,10 +2,10 @@
   "utrecht": {
     "custom-checkbox": {
       "size": { "value": "24px" },
-      "border-color": { "value": "{amsterdam.color.grey.50.value}" },
-      "color": { "value": "{amsterdam.color.black.value}" },
+      "border-color": { "value": "{amsterdam.color.grey.50}" },
+      "color": { "value": "{amsterdam.color.black}" },
       "border-width": { "value": "1px" },
-      "background-color": { "value": "{amsterdam.color.white.value}" },
+      "background-color": { "value": "{amsterdam.color.white}" },
       "border-radius": { "value": "0" },
       "padding": { "value": "0" },
       "active": {
@@ -20,16 +20,16 @@
         "background-color": {}
       },
       "disabled": {
-        "border-color": { "value": "{amsterdam.color.grey.70.value}" },
+        "border-color": { "value": "{amsterdam.color.grey.70}" },
         "border-width": { "value": "2px" },
         "background-color": {},
-        "color": { "value": "{amsterdam.color.grey.70.value}" }
+        "color": { "value": "{amsterdam.color.grey.70}" }
       },
       "checked": {
-        "border-color": { "value": "{amsterdam.color.black.value}" },
+        "border-color": { "value": "{amsterdam.color.black}" },
         "border-width": {},
-        "background-color": { "value": "{amsterdam.color.black.value}" },
-        "color": { "value": "{amsterdam.color.white.value}" },
+        "background-color": { "value": "{amsterdam.color.black}" },
+        "color": { "value": "{amsterdam.color.white}" },
         "active": {
           "border-color": {},
           "background-color": {}
@@ -39,11 +39,11 @@
         "size": { "value": "15px" }
       },
       "indeterminate": {
-        "background-color": { "value": "{amsterdam.color.black.value}" },
-        "color": { "value": "{amsterdam.color.white.value}" }
+        "background-color": { "value": "{amsterdam.color.black}" },
+        "color": { "value": "{amsterdam.color.white}" }
       },
       "invalid": {
-        "border-color": { "value": "{amsterdam.color.red.50.value}" },
+        "border-color": { "value": "{amsterdam.color.red.50}" },
         "border-width": {},
         "background-color": {},
         "color": {},

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{amsterdam.color.white.value}" },
-      "color": { "value": "{amsterdam.color.black.value}" },
-      "font-family": { "value": "{amsterdam.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{amsterdam.color.white}" },
+      "color": { "value": "{amsterdam.color.black}" },
+      "font-family": { "value": "{amsterdam.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "22px" }
     }

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{amsterdam.color.black.value}" },
-      "border-color": { "value": "{amsterdam.color.grey.50.value}" },
-      "font-family": { "value": "{amsterdam.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{amsterdam.color.black}" },
+      "border-color": { "value": "{amsterdam.color.grey.50}" },
+      "font-family": { "value": "{amsterdam.typography.sans-serif.font-family}" },
       "line-height": { "value": "18px" },
       "placeholder": {
-        "color": { "value": "{amsterdam.color.grey.70.value}" }
+        "color": { "value": "{amsterdam.color.grey.70}" }
       },
       "focus": {
         "border-color": {}

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,7 +4,7 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{amsterdam.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{amsterdam.typography.weight-scale.normal.font-weight}" }
       },
       "checkbox-checked": {
         "font-weight": {
@@ -12,7 +12,7 @@
         }
       },
       "radio": {
-        "font-weight": { "value": "{amsterdam.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{amsterdam.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,17 +1,17 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{amsterdam.color.grey.100.value}" },
+      "background-color": { "value": "{amsterdam.color.grey.100}" },
       "background-image": { "comment": "TODO: amsterdam.icon.dropdown-expand.value" },
-      "border-color": { "value": "{amsterdam.color.grey.50.value}" },
+      "border-color": { "value": "{amsterdam.color.grey.50}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{amsterdam.color.grey.0.value}" },
+      "color": { "value": "{amsterdam.color.grey.0}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{amsterdam.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{amsterdam.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
       "color": {},

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{amsterdam.color.blue.30.value}" },
+      "color": { "value": "{amsterdam.color.blue.30}" },
       "text-decoration": { "value": "underline" },
       "active": {
         "color": {}
@@ -11,7 +11,7 @@
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{amsterdam.color.red.50.value}" },
+        "color": { "value": "{amsterdam.color.red.50}" },
         "text-decoration": {}
       },
       "visited": {

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/page-footer.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/page-footer.tokens.json
@@ -1,13 +1,13 @@
 {
   "utrecht": {
     "page-footer": {
-      "background-color": { "value": "{amsterdam.color.grey.50.value}", "comment": "FIXME new" },
-      "color": { "value": "{amsterdam.color.grey.100.value}", "comment": "FIXME new" },
+      "background-color": { "value": "{amsterdam.color.grey.50}", "comment": "FIXME new" },
+      "color": { "value": "{amsterdam.color.grey.100}", "comment": "FIXME new" },
       "padding-block-start": { "value": "30px" },
       "padding-block-end": { "value": "30px" },
       "content": {
         "max-inline-size": {
-          "value": "{utrecht.page.max-inline-size.value}"
+          "value": "{utrecht.page.max-inline-size}"
         }
       }
     }

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": {},
-      "font-size": { "value": "{amsterdam.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{amsterdam.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{amsterdam.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{amsterdam.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "22px" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{amsterdam.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{amsterdam.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/textarea.tokens.json
@@ -2,19 +2,19 @@
   "utrecht": {
     "textarea": {
       "border-bottom-width": {},
-      "border-color": { "value": "{utrecht.textbox.border-color.value}" },
-      "border-radius": { "value": "{utrecht.textbox.border-radius.value}" },
-      "border-width": { "value": "{utrecht.textbox.border-width.value}" },
-      "color": { "value": "{utrecht.textbox.color.value}" },
-      "font-family": { "value": "{utrecht.textbox.font-family.value}" },
-      "font-size": { "value": "{utrecht.textbox.font-size.value}" },
-      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size.value}" },
-      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size.value}" },
+      "border-color": { "value": "{utrecht.textbox.border-color}" },
+      "border-radius": { "value": "{utrecht.textbox.border-radius}" },
+      "border-width": { "value": "{utrecht.textbox.border-width}" },
+      "color": { "value": "{utrecht.textbox.color}" },
+      "font-family": { "value": "{utrecht.textbox.font-family}" },
+      "font-size": { "value": "{utrecht.textbox.font-size}" },
+      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size}" },
+      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size}" },
       "min-block-size": { "value": "95px" },
-      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end.value}" },
-      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start.value}" },
-      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end.value}" },
-      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start.value}" }
+      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end}" },
+      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start}" },
+      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end}" },
+      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start}" }
     }
   }
 }

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/textbox.tokens.json
@@ -1,19 +1,19 @@
 {
   "utrecht": {
     "textbox": {
-      "border-bottom-width": { "value": "{utrecht.textbox.border-width.value}" },
-      "border-color": { "value": "{utrecht.form-input.border-color.value}" },
+      "border-bottom-width": { "value": "{utrecht.textbox.border-width}" },
+      "border-color": { "value": "{utrecht.form-input.border-color}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{utrecht.form-input.color.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
-      "font-size": { "value": "{amsterdam.typography.scale.md.font-size.value}" },
+      "color": { "value": "{utrecht.form-input.color}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
+      "font-size": { "value": "{amsterdam.typography.scale.md.font-size}" },
       "min-inline-size": { "value": "70px" },
       "max-inline-size": { "value": "620px" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xs}" },
       "disabled": {
         "border-color": {},
         "color": {}

--- a/proprietary/amsterdam-design-tokens/src/component/utrecht/unordered-list.tokens.json
+++ b/proprietary/amsterdam-design-tokens/src/component/utrecht/unordered-list.tokens.json
@@ -9,7 +9,7 @@
         "margin-block-end": { "value": "8px" }
       },
       "marker": {
-        "color": { "value": "{amsterdam.color.grey.50.value}" },
+        "color": { "value": "{amsterdam.color.grey.50}" },
         "content": { "value": "■", "comment": "FIXME new" }
       }
     }

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,37 +1,37 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{bodegraven.color.blue.40.value}" },
+      "background-color": { "value": "{bodegraven.color.blue.40}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{bodegraven.color.grey.100.value}" },
-      "font-family": { "value": "{bodegraven.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{bodegraven.typography.scale.md.font-size.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "color": { "value": "{bodegraven.color.grey.100}" },
+      "font-family": { "value": "{bodegraven.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{bodegraven.typography.scale.md.font-size}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
       "hover": {
-        "background-color": { "value": "{bodegraven.color.blue.30.value}" },
+        "background-color": { "value": "{bodegraven.color.blue.30}" },
         "color": {},
         "border-color": {}
       },
       "secondary-action": {
-        "background-color": { "value": "{bodegraven.color.blue.40.value}" },
-        "color": { "value": "{bodegraven.color.grey.100.value}" },
+        "background-color": { "value": "{bodegraven.color.blue.40}" },
+        "color": { "value": "{bodegraven.color.grey.100}" },
         "border-color": {},
         "border-width": {},
         "hover": {
-          "background-color": { "value": "{bodegraven.color.blue.30.value}" },
+          "background-color": { "value": "{bodegraven.color.blue.30}" },
           "color": {}
         }
       },
       "focus": {
-        "background-color": { "value": "{bodegraven.color.blue.30.value}" },
+        "background-color": { "value": "{bodegraven.color.blue.30}" },
         "border-color": {},
         "border-width": {},
         "transform-scale": {}

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{bodegraven.color.grey.100.value}" },
-      "color": { "value": "{bodegraven.color.grey.10.value}" },
-      "font-family": { "value": "{bodegraven.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{bodegraven.color.grey.100}" },
+      "color": { "value": "{bodegraven.color.grey.10}" },
+      "font-family": { "value": "{bodegraven.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "1.5" }
     }

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,10 +2,10 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{bodegraven.color.grey.10.value}" },
-      "border-color": { "value": "{bodegraven.color.blue.40.value}" },
+      "color": { "value": "{bodegraven.color.grey.10}" },
+      "border-color": { "value": "{bodegraven.color.blue.40}" },
       "border-width": { "value": "1px" },
-      "font-family": { "value": "{bodegraven.typography.sans-serif.font-family.value}" },
+      "font-family": { "value": "{bodegraven.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": {},
       "padding-inline-start": { "value": "15px" },
@@ -14,13 +14,13 @@
       "padding-block-end": { "value": "10px" },
       "max-inline-size": { "value": "460px" },
       "placeholder": {
-        "color": { "value": "{bodegraven.color.grey.30.value}" }
+        "color": { "value": "{bodegraven.color.grey.30}" }
       },
       "focus": {
-        "border-color": { "value": "{bodegraven.color.blue.30.value}" }
+        "border-color": { "value": "{bodegraven.color.blue.30}" }
       },
       "hover": {
-        "border-color": { "value": "{bodegraven.color.blue.30.value}" }
+        "border-color": { "value": "{bodegraven.color.blue.30}" }
       }
     }
   }

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,11 +4,11 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{bodegraven.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{bodegraven.typography.weight-scale.normal.font-weight}" }
       },
 
       "radio": {
-        "font-weight": { "value": "{bodegraven.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{bodegraven.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{bodegraven.color.grey.100.value}" },
-      "border-color": { "value": "{bodegraven.color.blue.40.value}" },
+      "background-color": { "value": "{bodegraven.color.grey.100}" },
+      "border-color": { "value": "{bodegraven.color.blue.40}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{bodegraven.color.grey.0.value}" },
+      "color": { "value": "{bodegraven.color.grey.0}" },
       "font-size": { "value": "16px" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/heading-1.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/heading-1.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading-1": {
-      "color": { "value": "{bodegraven.color.green.30.value}" },
+      "color": { "value": "{bodegraven.color.green.30}" },
       "font-family": {},
       "font-size": { "value": "32px" },
       "font-weight": { "value": "700" },

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/heading-2.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/heading-2.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading-2": {
-      "color": { "value": "{bodegraven.color.blue.40.value}" },
+      "color": { "value": "{bodegraven.color.blue.40}" },
       "font-family": {},
       "font-size": { "value": "23px" },
       "font-weight": {},

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/heading-3.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/heading-3.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading-3": {
-      "color": { "value": "{bodegraven.color.grey.10.value}" },
+      "color": { "value": "{bodegraven.color.grey.10}" },
       "font-family": {},
       "font-size": { "value": "20px" },
       "font-weight": {},

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{bodegraven.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{bodegraven.typography.weight-scale.bold.font-weight}" }
     }
   }
 }

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,17 +1,17 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{bodegraven.color.blue.40.value}" },
+      "color": { "value": "{bodegraven.color.blue.40}" },
       "text-decoration": { "value": "underline" },
       "active": {
         "color": {}
       },
       "focus": {
-        "color": { "value": "{bodegraven.color.blue.30.value}" },
+        "color": { "value": "{bodegraven.color.blue.30}" },
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{bodegraven.color.blue.30.value}" },
+        "color": { "value": "{bodegraven.color.blue.30}" },
         "text-decoration": {}
       },
       "visited": {

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/page-footer.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/page-footer.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "page-footer": {
-      "background-color": { "value": "{bodegraven.color.blue.45.value}" },
-      "color": { "value": "{bodegraven.color.grey.100.value}" },
+      "background-color": { "value": "{bodegraven.color.blue.45}" },
+      "color": { "value": "{bodegraven.color.grey.100}" },
       "padding-block-start": { "value": "15px" },
       "padding-block-end": { "value": "15px" },
       "padding-inline-start": { "value": "15px" },

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/page-header.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/page-header.tokens.json
@@ -2,7 +2,7 @@
   "utrecht": {
     "page-header": {
       "background-color": {
-        "value": "{bodegraven.color.grey.100.value}"
+        "value": "{bodegraven.color.grey.100}"
       },
       "color": {
         "value": "#2d2e87"

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -3,12 +3,12 @@
     "paragraph": {
       "font-family": {},
       "font-size": { "value": "16px" },
-      "font-weight": { "value": "{bodegraven.typography.weight-scale.normal.font-weight.value}" },
+      "font-weight": { "value": "{bodegraven.typography.weight-scale.normal.font-weight}" },
       "line-height": {},
       "margin-block-start": {},
       "margin-block-end": { "value": "30px" },
       "lead": {
-        "color": { "value": "{bodegraven.color.blue.45.value}" },
+        "color": { "value": "{bodegraven.color.blue.45}" },
         "font-size": { "value": "18px" },
         "font-weight": { "value": "700" },
         "line-height": { "value": "27px" }

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/separator.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/separator.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "separator": {
-      "color": { "value": "{bodegraven.color.blue.40.value}" },
+      "color": { "value": "{bodegraven.color.blue.40}" },
       "margin-block-start": { "value": "30px" },
       "margin-block-end": { "value": "30px" },
       "block-size": { "value": "2px" }

--- a/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/src/component/utrecht/table.tokens.json
@@ -34,7 +34,7 @@
         "border-color": {}
       },
       "row": {
-        "border-block-end-color": { "value": "{bodegraven.color.blue.45.value}" },
+        "border-block-end-color": { "value": "{bodegraven.color.blue.45}" },
         "border-block-end-width": { "value": "1px" },
         "padding-inline-end": {},
         "padding-inline-start": {},
@@ -43,7 +43,7 @@
           "color": {}
         },
         "alternate-even": {
-          "background-color": { "value": "{bodegraven.color.grey.100.value}" },
+          "background-color": { "value": "{bodegraven.color.grey.100}" },
           "color": {}
         }
       }

--- a/proprietary/borne-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/borne-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{borne.color.blue.20.value}" },
-      "color": { "value": "{borne.color.grey.100.value}" },
+      "background-color": { "value": "{borne.color.blue.20}" },
+      "color": { "value": "{borne.color.grey.100}" },
       "border-radius": { "value": "2px" }
     }
   }

--- a/proprietary/borne-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/borne-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{borne.color.grey.100.value}" },
-      "color": { "value": "{borne.color.blue.20.value}" },
-      "font-family": { "value": "{borne.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{borne.color.grey.100}" },
+      "color": { "value": "{borne.color.blue.20}" },
+      "font-family": { "value": "{borne.typography.sans-serif.font-family}" },
       "font-size": { "value": "14px" },
       "line-height": { "value": "1.56" }
     }

--- a/proprietary/borne-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/borne-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -1,14 +1,14 @@
 {
   "utrecht": {
     "form-input": {
-      "background-color": { "value": "{borne.color.grey.100.value}" },
-      "border-color": { "value": "{borne.color.grey.100.value}" },
+      "background-color": { "value": "{borne.color.grey.100}" },
+      "border-color": { "value": "{borne.color.grey.100}" },
       "border-width": { "value": "1px" },
       "border-radius": { "value": "2px" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.md.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.md.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-inline-end": { "value": "{utrecht.space.inline.md}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.md}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/borne-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/borne-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{borne.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{borne.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
       "color": {},

--- a/proprietary/borne-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/borne-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{borne.color.blue.20.value}" },
+      "color": { "value": "{borne.color.blue.20}" },
       "text-decoration": {},
       "active": {
         "color": {}
@@ -11,7 +11,7 @@
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{borne.color.blue.20.value}" },
+        "color": { "value": "{borne.color.blue.20}" },
         "text-decoration": { "value": "underline" }
       },
       "visited": {

--- a/proprietary/borne-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/borne-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": {},
-      "font-size": { "value": "{borne.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{borne.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{borne.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{borne.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "22px" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{borne.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{borne.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/borne-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/borne-design-tokens/src/component/utrecht/table.tokens.json
@@ -7,7 +7,7 @@
         "font-weight": {},
         "font-family": {},
         "font-size": {},
-        "color": { "value": "{borne.color.blue.20.value}" },
+        "color": { "value": "{borne.color.blue.20}" },
         "line-height": {},
         "text-align": {},
         "margin-block-end": {}
@@ -16,7 +16,7 @@
         "font-weight": { "value": "bold" },
         "color": {},
         "text-transform": {},
-        "border-block-end-color": { "value": "{borne.color.blue.20.value}" },
+        "border-block-end-color": { "value": "{borne.color.blue.20}" },
         "border-block-end-width": { "value": "0.5px" }
       },
       "heading": {

--- a/proprietary/demodam-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/demodam-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,10 +1,10 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{demodam.color.grey.40.value}" },
+      "background-color": { "value": "{demodam.color.grey.40}" },
       "border-width": { "value": "0" },
       "border-radius": { "value": ".125rem" },
-      "color": { "value": "{demodam.color.grey.30.value}" },
+      "color": { "value": "{demodam.color.grey.30}" },
       "margin-block-end": { "value": "0.5rem" },
       "font-size": { "value": "1.125rem" },
       "font-weight": { "value": "600" },
@@ -15,14 +15,14 @@
       "padding-inline-end": { "value": "2.14rem" },
       "text-transform": { "value": "uppercase" },
       "disabled": {
-        "background-color": { "value": "{demodam.color.grey.20.value}" },
-        "color": { "value": "{demodam.color.grey.30.value}" }
+        "background-color": { "value": "{demodam.color.grey.20}" },
+        "color": { "value": "{demodam.color.grey.30}" }
       },
       "hover": {
-        "background-color": { "value": "{demodam.color.green.10.value}" }
+        "background-color": { "value": "{demodam.color.green.10}" }
       },
       "focus": {
-        "background-color": { "value": "{demodam.color.green.10.value}" }
+        "background-color": { "value": "{demodam.color.green.10}" }
       }
     }
   }

--- a/proprietary/demodam-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/demodam-design-tokens/src/component/utrecht/document.tokens.json
@@ -3,7 +3,7 @@
     "document": {
       "background-color": { "value": "white" },
       "color": { "value": "#212121" },
-      "font-family": { "value": "{demodam.typography.sans-serif.font-family.value}" },
+      "font-family": { "value": "{demodam.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "font-weight": { "value": "300" },
       "line-height": { "value": "1.5" }

--- a/proprietary/demodam-design-tokens/src/component/utrecht/font-label.tokens.json
+++ b/proprietary/demodam-design-tokens/src/component/utrecht/font-label.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "form-label": {
-      "color": { "value": "{demodam.color.grey.40.value}" },
+      "color": { "value": "{demodam.color.grey.40}" },
       "font-weight": { "value": "600" }
     }
   }

--- a/proprietary/demodam-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/demodam-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,8 +2,8 @@
   "utrecht": {
     "form-input": {
       "background-color": { "value": "transparent" },
-      "color": { "value": "{utrecht.document.color.value}" },
-      "border-color": { "value": "{demodam.color.grey.40.value}" },
+      "color": { "value": "{utrecht.document.color}" },
+      "border-color": { "value": "{demodam.color.grey.40}" },
       "border-width": { "value": "0" },
       "font-size": { "value": "16px" },
       "font-weight": { "value": "600" },
@@ -12,13 +12,13 @@
       "padding-inline-start": { "value": "0" },
       "padding-inline-end": { "value": "0" },
       "placeholder": {
-        "color": { "value": "{demodam.color.grey.20.value}" }
+        "color": { "value": "{demodam.color.grey.20}" }
       },
       "disabled": {
-        "border-color": { "value": "{demodam.color.grey.20.value}" }
+        "border-color": { "value": "{demodam.color.grey.20}" }
       },
       "focus": {
-        "border-color": { "value": "{demodam.color.grey.20.value}" }
+        "border-color": { "value": "{demodam.color.grey.20}" }
       }
     }
   }

--- a/proprietary/demodam-design-tokens/src/component/utrecht/heading-1.tokens.json
+++ b/proprietary/demodam-design-tokens/src/component/utrecht/heading-1.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading-1": {
-      "color": { "value": "{demodam.color.grey.40.value}" },
+      "color": { "value": "{demodam.color.grey.40}" },
       "font-size": { "value": "2.375rem" },
       "margin-block-end": { "value": "0.5rem" }
     }

--- a/proprietary/demodam-design-tokens/src/component/utrecht/heading-2.tokens.json
+++ b/proprietary/demodam-design-tokens/src/component/utrecht/heading-2.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading-2": {
-      "color": { "value": "{demodam.color.grey.40.value}" },
+      "color": { "value": "{demodam.color.grey.40}" },
       "font-size": { "value": "2.25rem" },
       "margin-block-end": { "value": "0.5rem" }
     }

--- a/proprietary/demodam-design-tokens/src/component/utrecht/heading-3.tokens.json
+++ b/proprietary/demodam-design-tokens/src/component/utrecht/heading-3.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading-3": {
-      "color": { "value": "{demodam.color.grey.40.value}" },
+      "color": { "value": "{demodam.color.grey.40}" },
       "font-size": { "value": "1.75rem" },
       "margin-block-end": { "value": "0.5rem" }
     }

--- a/proprietary/demodam-design-tokens/src/component/utrecht/heading-4.tokens.json
+++ b/proprietary/demodam-design-tokens/src/component/utrecht/heading-4.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading-4": {
-      "color": { "value": "{demodam.color.grey.40.value}" },
+      "color": { "value": "{demodam.color.grey.40}" },
       "font-size": { "value": "1.75rem" },
       "margin-block-end": { "value": "0.5rem" }
     }

--- a/proprietary/demodam-design-tokens/src/component/utrecht/heading-6.tokens.json
+++ b/proprietary/demodam-design-tokens/src/component/utrecht/heading-6.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading-6": {
-      "color": { "value": "{demodam.color.grey.40.value}" },
+      "color": { "value": "{demodam.color.grey.40}" },
       "font-size": { "value": "1.5rem" },
       "margin-block-end": { "value": "0.5rem" }
     }

--- a/proprietary/demodam-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/demodam-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,13 +1,13 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{demodam.color.grey.40.value}" },
+      "color": { "value": "{demodam.color.grey.40}" },
       "text-decoration": { "value": "none" },
       "focus": {
-        "color": { "value": "{demodam.color.green.10.value}" }
+        "color": { "value": "{demodam.color.green.10}" }
       },
       "hover": {
-        "color": { "value": "{demodam.color.green.10.value}" }
+        "color": { "value": "{demodam.color.green.10}" }
       }
     }
   }

--- a/proprietary/demodam-design-tokens/src/component/utrecht/page-footer.tokens.json
+++ b/proprietary/demodam-design-tokens/src/component/utrecht/page-footer.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "page-footer": {
-      "background-color": { "value": "{demodam.color.grey.30.value}" },
-      "color": { "value": "{demodam.color.grey.10.value}" },
+      "background-color": { "value": "{demodam.color.grey.30}" },
+      "color": { "value": "{demodam.color.grey.10}" },
       "padding-block-start": { "value": "60px" }
     }
   }

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/button.tokens.json
@@ -3,26 +3,26 @@
     "button": {
       "border-width": { "value": "0" },
       "border-radius": { "value": "0" },
-      "font-family": { "value": "{drechterland.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{drechterland.typography.scale.md.font-size.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
+      "font-family": { "value": "{drechterland.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{drechterland.typography.scale.md.font-size}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
       "margin-inline-start": { "value": "0" },
       "margin-inline-end": { "value": "0" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "background-color": { "value": "{drechterland.color.blue.40.value}" },
-      "color": { "value": "{drechterland.color.grey.100.value}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "background-color": { "value": "{drechterland.color.blue.40}" },
+      "color": { "value": "{drechterland.color.grey.100}" },
       "hover": {
         "background-color": {},
         "color": {},
         "border-color": {}
       },
       "secondary-action": {
-        "background-color": { "value": "{drechterland.color.orange.value}" },
-        "color": { "value": "{drechterland.color.grey.0.value}" },
+        "background-color": { "value": "{drechterland.color.orange}" },
+        "color": { "value": "{drechterland.color.grey.0}" },
         "border-color": {},
         "border-width": {},
         "hover": {
@@ -31,7 +31,7 @@
         }
       },
       "focus": {
-        "border-color": { "value": "{drechterland.color.grey.0.value}" },
+        "border-color": { "value": "{drechterland.color.grey.0}" },
         "border-width": {},
         "transform-scale": {}
       }

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{drechterland.color.grey.98.value}" },
-      "color": { "value": "{drechterland.color.grey.0.value}" },
-      "font-family": { "value": "{drechterland.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{drechterland.color.grey.98}" },
+      "color": { "value": "{drechterland.color.grey.0}" },
+      "font-family": { "value": "{drechterland.typography.sans-serif.font-family}" },
       "font-size": { "value": "1em" },
       "line-height": { "value": "1.75" }
     }

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{drechterland.color.grey.60.value}" },
-      "border-color": { "value": "{drechterland.color.grey.88.value}" },
-      "font-family": { "value": "{drechterland.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{drechterland.color.grey.60}" },
+      "border-color": { "value": "{drechterland.color.grey.88}" },
+      "font-family": { "value": "{drechterland.typography.sans-serif.font-family}" },
       "line-height": { "value": "1.75" },
       "placeholder": {
-        "color": { "value": "{drechterland.color.grey.60.value}" }
+        "color": { "value": "{drechterland.color.grey.60}" }
       },
       "focus": {
         "border-color": {}

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,11 +4,11 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{drechterland.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{drechterland.typography.weight-scale.normal.font-weight}" }
       },
 
       "radio": {
-        "font-weight": { "value": "{drechterland.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{drechterland.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{drechterland.color.grey.100.value}" },
-      "border-color": { "value": "{drechterland.color.grey.88.value}" },
+      "background-color": { "value": "{drechterland.color.grey.100}" },
+      "border-color": { "value": "{drechterland.color.grey.88}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{drechterland.color.grey.60.value}" },
+      "color": { "value": "{drechterland.color.grey.60}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,10 +3,10 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{drechterland.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{drechterland.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
-      "color": { "value": "{drechterland.color.blue.40.value}" },
+      "color": { "value": "{drechterland.color.blue.40}" },
       "font-family": {},
       "font-size": { "value": "2.1em" },
       "font-weight": {},

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{drechterland.color.blue.40.value}" },
+      "color": { "value": "{drechterland.color.blue.40}" },
       "text-decoration": {},
       "active": {
         "color": {}
@@ -11,7 +11,7 @@
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{drechterland.color.blue.40.value}" },
+        "color": { "value": "{drechterland.color.blue.40}" },
         "text-decoration": { "value": "underline" }
       },
       "visited": {

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": {},
-      "font-size": { "value": "{drechterland.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{drechterland.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{drechterland.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{drechterland.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "1.75" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{drechterland.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{drechterland.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/table.tokens.json
@@ -15,10 +15,10 @@
       "header": {
         "font-weight": { "value": "bold" },
         "background-color": {
-          "value": "{drechterland.color.blue.40.value}",
+          "value": "{drechterland.color.blue.40}",
           "comment": "Deze website heeft geen tabel voorbeeld"
         },
-        "color": { "value": "{drechterland.color.grey.100.value}" },
+        "color": { "value": "{drechterland.color.grey.100}" },
         "text-transform": {},
         "border-block-end-color": {},
         "border-block-end-width": {}

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/textarea.tokens.json
@@ -2,19 +2,19 @@
   "utrecht": {
     "textarea": {
       "border-bottom-width": {},
-      "border-color": { "value": "{utrecht.textbox.border-color.value}" },
-      "border-radius": { "value": "{utrecht.textbox.border-radius.value}" },
-      "border-width": { "value": "{utrecht.textbox.border-width.value}" },
-      "color": { "value": "{utrecht.textbox.color.value}" },
-      "font-family": { "value": "{utrecht.textbox.font-family.value}" },
-      "font-size": { "value": "{utrecht.textbox.font-size.value}" },
-      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size.value}" },
-      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size.value}" },
+      "border-color": { "value": "{utrecht.textbox.border-color}" },
+      "border-radius": { "value": "{utrecht.textbox.border-radius}" },
+      "border-width": { "value": "{utrecht.textbox.border-width}" },
+      "color": { "value": "{utrecht.textbox.color}" },
+      "font-family": { "value": "{utrecht.textbox.font-family}" },
+      "font-size": { "value": "{utrecht.textbox.font-size}" },
+      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size}" },
+      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size}" },
       "min-block-size": { "value": "95px" },
-      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end.value}" },
-      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start.value}" },
-      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end.value}" },
-      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start.value}" }
+      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end}" },
+      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start}" },
+      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end}" },
+      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start}" }
     }
   }
 }

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/textbox.tokens.json
@@ -2,18 +2,18 @@
   "utrecht": {
     "textbox": {
       "border-bottom-width": { "value": "1px" },
-      "border-color": { "value": "{utrecht.form-input.border-color.value}" },
+      "border-color": { "value": "{utrecht.form-input.border-color}" },
       "border-radius": { "value": "2px" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{utrecht.form-input.color.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
-      "font-size": { "value": "{drechterland.typography.scale.md.font-size.value}" },
+      "color": { "value": "{utrecht.form-input.color}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
+      "font-size": { "value": "{drechterland.typography.scale.md.font-size}" },
       "min-inline-size": { "value": "70px" },
       "max-inline-size": { "value": "620px" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xs}" },
       "disabled": {
         "border-color": {},
         "color": {}

--- a/proprietary/drechterland-design-tokens/src/component/utrecht/unordered-list.tokens.json
+++ b/proprietary/drechterland-design-tokens/src/component/utrecht/unordered-list.tokens.json
@@ -9,7 +9,7 @@
         "margin-block-end": { "value": "8px" }
       },
       "marker": {
-        "color": { "value": "{drechterland.color.grey.0.value}" },
+        "color": { "value": "{drechterland.color.grey.0}" },
         "content": { "value": "■", "comment": "FIXME new" }
       }
     }

--- a/proprietary/duiven-design-tokens/src/component/utrecht/blockquote.tokens.json
+++ b/proprietary/duiven-design-tokens/src/component/utrecht/blockquote.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "blockquote": {
-      "border-color": { "value": "{duiven.color.blue.95.value}" },
+      "border-color": { "value": "{duiven.color.blue.95}" },
       "border-inline-start-width": { "value": "5px" }
     }
   }

--- a/proprietary/duiven-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/duiven-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,25 +1,25 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{duiven.color.blue.40.value}" },
-      "color": { "value": "{duiven.color.white.value}" },
+      "background-color": { "value": "{duiven.color.blue.40}" },
+      "color": { "value": "{duiven.color.white}" },
       "hover": {
-        "background-color": { "value": "{duiven.color.blue.20.value}" },
-        "color": { "value": "{duiven.color.white.value}" }
+        "background-color": { "value": "{duiven.color.blue.20}" },
+        "color": { "value": "{duiven.color.white}" }
       },
       "focus": {
-        "background-color": { "value": "{duiven.color.blue.20.value}" },
-        "color": { "value": "{duiven.color.white.value}" }
+        "background-color": { "value": "{duiven.color.blue.20}" },
+        "color": { "value": "{duiven.color.white}" }
       },
       "secondary-action": {
-        "background-color": { "value": "{duiven.color.blue.20.value}" },
-        "color": { "value": "{duiven.color.white.value}" },
-        "border-color": { "value": "{duiven.color.black.value}" },
+        "background-color": { "value": "{duiven.color.blue.20}" },
+        "color": { "value": "{duiven.color.white}" },
+        "border-color": { "value": "{duiven.color.black}" },
         "border-width": {},
         "hover": {
-          "background-color": { "value": "{duiven.color.blue.40.value}" },
-          "color": { "value": "{duiven.color.white.value}" },
-          "border-color": { "value": "{duiven.color.blue.40.value}" }
+          "background-color": { "value": "{duiven.color.blue.40}" },
+          "color": { "value": "{duiven.color.white}" },
+          "border-color": { "value": "{duiven.color.blue.40}" }
         }
       }
     }

--- a/proprietary/duiven-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/duiven-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{duiven.color.white.value}" },
-      "color": { "value": "{duiven.color.blue.20.value}" },
-      "font-family": { "value": "{duiven.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{duiven.color.white}" },
+      "color": { "value": "{duiven.color.blue.20}" },
+      "font-family": { "value": "{duiven.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "22px" }
     }

--- a/proprietary/duiven-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/duiven-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -1,11 +1,11 @@
 {
   "utrecht": {
     "form-input": {
-      "color": { "value": "{duiven.color.blue.20.value}" },
-      "border-color": { "value": "{duiven.color.grey.70.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
+      "color": { "value": "{duiven.color.blue.20}" },
+      "border-color": { "value": "{duiven.color.grey.70}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
       "focus": {
-        "border-color": { "value": "{duiven.color.blue.40.value}" }
+        "border-color": { "value": "{duiven.color.blue.40}" }
       }
     }
   }

--- a/proprietary/duiven-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/duiven-design-tokens/src/component/utrecht/heading.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading": {
-      "color": { "value": "{duiven.color.blue.20.value}" }
+      "color": { "value": "{duiven.color.blue.20}" }
     }
   }
 }

--- a/proprietary/duiven-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/duiven-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,12 +1,12 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{duiven.color.blue.40.value}" },
+      "color": { "value": "{duiven.color.blue.40}" },
       "focus": {
-        "color": { "value": "{duiven.color.blue.35.value}" }
+        "color": { "value": "{duiven.color.blue.35}" }
       },
       "hover": {
-        "color": { "value": "{duiven.color.blue.35.value}" }
+        "color": { "value": "{duiven.color.blue.35}" }
       }
     }
   }

--- a/proprietary/duiven-design-tokens/src/component/utrecht/page-footer.tokens.json
+++ b/proprietary/duiven-design-tokens/src/component/utrecht/page-footer.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "page-footer": {
-      "background-color": { "value": "{duiven.color.orange.30.value}" },
-      "color": { "value": "{duiven.color.grey.100.value}" }
+      "background-color": { "value": "{duiven.color.orange.30}" },
+      "color": { "value": "{duiven.color.grey.100}" }
     }
   }
 }

--- a/proprietary/duiven-design-tokens/src/component/utrecht/separator.tokens.json
+++ b/proprietary/duiven-design-tokens/src/component/utrecht/separator.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "separator": {
-      "color": { "value": "{duiven.color.blue.40.value}" }
+      "color": { "value": "{duiven.color.blue.40}" }
     }
   }
 }

--- a/proprietary/duiven-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/duiven-design-tokens/src/component/utrecht/table.tokens.json
@@ -3,10 +3,10 @@
     "table": {
       "row": {
         "alternate-odd": {
-          "background-color": { "value": "{duiven.color.blue.95.value}" }
+          "background-color": { "value": "{duiven.color.blue.95}" }
         },
         "alternate-even": {
-          "background-color": { "value": "{duiven.color.grey.100.value}" }
+          "background-color": { "value": "{duiven.color.grey.100}" }
         }
       }
     }

--- a/proprietary/duiven-design-tokens/src/component/utrecht/unordered-list.tokens.json
+++ b/proprietary/duiven-design-tokens/src/component/utrecht/unordered-list.tokens.json
@@ -2,7 +2,7 @@
   "utrecht": {
     "unordered-list": {
       "marker": {
-        "color": { "value": "{duiven.color.blue.20.value}" }
+        "color": { "value": "{duiven.color.blue.20}" }
       }
     }
   }

--- a/proprietary/duo-design-tokens/src/component/utrecht/badge-counter.tokens.json
+++ b/proprietary/duo-design-tokens/src/component/utrecht/badge-counter.tokens.json
@@ -2,13 +2,13 @@
   "utrecht": {
     "badge-counter": {
       "background-color": {
-        "value": "{dso.color.yellow.value}"
+        "value": "{dso.color.yellow}"
       },
       "border-radius": {
         "value": "6px"
       },
       "color": {
-        "value": "{dso.color.grijs.0.value}"
+        "value": "{dso.color.grijs.0}"
       },
       "font-weight": {},
       "padding-block": {

--- a/proprietary/duo-design-tokens/src/component/utrecht/badge.tokens.json
+++ b/proprietary/duo-design-tokens/src/component/utrecht/badge.tokens.json
@@ -2,22 +2,22 @@
   "utrecht": {
     "badge": {
       "background-color": {
-        "value": "{amsterdam.color.grey.50.value}"
+        "value": "{amsterdam.color.grey.50}"
       },
       "border-radius": {
         "value": "0"
       },
       "color": {
-        "value": "{amsterdam.color.white.value}"
+        "value": "{amsterdam.color.white}"
       },
       "font-weight": {
-        "value": "{amsterdam.typography.weight-scale.semi-bold.font-weight.value}"
+        "value": "{amsterdam.typography.weight-scale.semi-bold.font-weight}"
       },
       "padding-block": {
         "value": "6px"
       },
       "padding-inline": {
-        "value": "{utrecht.space.inline.md.value}"
+        "value": "{utrecht.space.inline.md}"
       }
     }
   }

--- a/proprietary/duo-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/duo-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,23 +1,23 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{duo.color.green.value}" },
+      "background-color": { "value": "{duo.color.green}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{duo.color.white.value}" },
-      "font-family": { "value": "{duo.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{duo.typography.scale.md.font-size.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "color": { "value": "{duo.color.white}" },
+      "font-family": { "value": "{duo.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{duo.typography.scale.md.font-size}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
       "secondary-action": {
-        "background-color": { "value": "{duo.color.green.value}" },
-        "color": { "value": "{duo.color.white.value}" },
+        "background-color": { "value": "{duo.color.green}" },
+        "color": { "value": "{duo.color.white}" },
         "border-color": {},
         "border-width": {},
         "hover": {
@@ -26,13 +26,13 @@
         }
       },
       "focus": {
-        "border-color": { "value": "{duo.color.black.value}" },
+        "border-color": { "value": "{duo.color.black}" },
         "border-width": {},
         "transform-scale": {}
       },
       "disabled": {
-        "background-color": { "value": "{duo.color.blue.40.value}" },
-        "color": { "value": "{duo.color.black.value}" }
+        "background-color": { "value": "{duo.color.blue.40}" },
+        "color": { "value": "{duo.color.black}" }
       }
     }
   }

--- a/proprietary/duo-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/duo-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{duo.color.white.value}" },
-      "color": { "value": "{duo.color.black.value}" },
-      "font-family": { "value": "{duo.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{duo.color.white}" },
+      "color": { "value": "{duo.color.black}" },
+      "font-family": { "value": "{duo.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "22px" }
     }

--- a/proprietary/duo-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/duo-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/duo-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/duo-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{duo.color.black.value}" },
-      "border-color": { "value": "{amsterdam.color.grey.50.value}" },
-      "font-family": { "value": "{amsterdam.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{duo.color.black}" },
+      "border-color": { "value": "{amsterdam.color.grey.50}" },
+      "font-family": { "value": "{amsterdam.typography.sans-serif.font-family}" },
       "line-height": { "value": "18px" },
       "placeholder": {
-        "color": { "value": "{amsterdam.color.grey.70.value}" }
+        "color": { "value": "{amsterdam.color.grey.70}" }
       },
       "focus": {
         "border-color": {}

--- a/proprietary/duo-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/duo-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,7 +4,7 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{amsterdam.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{amsterdam.typography.weight-scale.normal.font-weight}" }
       },
       "checkbox-checked": {
         "font-weight": {
@@ -12,7 +12,7 @@
         }
       },
       "radio": {
-        "font-weight": { "value": "{amsterdam.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{amsterdam.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/duo-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/duo-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,17 +1,17 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{amsterdam.color.grey.100.value}" },
+      "background-color": { "value": "{amsterdam.color.grey.100}" },
       "background-image": { "comment": "TODO: amsterdam.icon.dropdown-expand.value" },
-      "border-color": { "value": "{amsterdam.color.grey.50.value}" },
+      "border-color": { "value": "{amsterdam.color.grey.50}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{amsterdam.color.grey.0.value}" },
+      "color": { "value": "{amsterdam.color.grey.0}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/duo-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/duo-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{duo.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{duo.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
       "color": {},

--- a/proprietary/duo-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/duo-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{duo.color.blue.40.value}" },
+      "color": { "value": "{duo.color.blue.40}" },
       "text-decoration": { "value": "underline" },
       "active": {
         "color": {}
@@ -11,7 +11,7 @@
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{duo.color.blue.30.value}" },
+        "color": { "value": "{duo.color.blue.30}" },
         "text-decoration": {}
       },
       "visited": {

--- a/proprietary/duo-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/duo-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": { "value": "Verdana" },
-      "font-size": { "value": "{duo.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{duo.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{duo.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{duo.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "22px" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{duo.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{duo.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/duo-design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/duo-design-tokens/src/component/utrecht/textarea.tokens.json
@@ -2,19 +2,19 @@
   "utrecht": {
     "textarea": {
       "border-bottom-width": {},
-      "border-color": { "value": "{utrecht.textbox.border-color.value}" },
-      "border-radius": { "value": "{utrecht.textbox.border-radius.value}" },
-      "border-width": { "value": "{utrecht.textbox.border-width.value}" },
-      "color": { "value": "{utrecht.textbox.color.value}" },
-      "font-family": { "value": "{utrecht.textbox.font-family.value}" },
-      "font-size": { "value": "{utrecht.textbox.font-size.value}" },
-      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size.value}" },
-      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size.value}" },
+      "border-color": { "value": "{utrecht.textbox.border-color}" },
+      "border-radius": { "value": "{utrecht.textbox.border-radius}" },
+      "border-width": { "value": "{utrecht.textbox.border-width}" },
+      "color": { "value": "{utrecht.textbox.color}" },
+      "font-family": { "value": "{utrecht.textbox.font-family}" },
+      "font-size": { "value": "{utrecht.textbox.font-size}" },
+      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size}" },
+      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size}" },
       "min-block-size": { "value": "95px" },
-      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end.value}" },
-      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start.value}" },
-      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end.value}" },
-      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start.value}" }
+      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end}" },
+      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start}" },
+      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end}" },
+      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start}" }
     }
   }
 }

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,23 +1,23 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{enkhuizen.color.blue.value}" },
+      "background-color": { "value": "{enkhuizen.color.blue}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{enkhuizen.color.white.value}" },
-      "font-family": { "value": "{enkhuizen.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{enkhuizen.typography.scale.md.font-size.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "color": { "value": "{enkhuizen.color.white}" },
+      "font-family": { "value": "{enkhuizen.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{enkhuizen.typography.scale.md.font-size}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
       "secondary-action": {
-        "background-color": { "value": "{enkhuizen.color.yellow.value}" },
-        "color": { "value": "{enkhuizen.color.black.value}" },
+        "background-color": { "value": "{enkhuizen.color.yellow}" },
+        "color": { "value": "{enkhuizen.color.black}" },
         "border-color": {},
         "border-width": {},
         "hover": {
@@ -26,7 +26,7 @@
         }
       },
       "focus": {
-        "border-color": { "value": "{enkhuizen.color.blue.value}" },
+        "border-color": { "value": "{enkhuizen.color.blue}" },
         "border-width": {},
         "transform-scale": {}
       }

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{enkhuizen.color.white.value}" },
-      "color": { "value": "{enkhuizen.color.black.value}" },
-      "font-family": { "value": "{enkhuizen.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{enkhuizen.color.white}" },
+      "color": { "value": "{enkhuizen.color.black}" },
+      "font-family": { "value": "{enkhuizen.typography.sans-serif.font-family}" },
       "font-size": { "value": "1em" },
       "line-height": { "value": "1.75" }
     }

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{enkhuizen.color.grey.60.value}" },
-      "border-color": { "value": "{enkhuizen.color.grey.88.value}" },
-      "font-family": { "value": "{enkhuizen.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{enkhuizen.color.grey.60}" },
+      "border-color": { "value": "{enkhuizen.color.grey.88}" },
+      "font-family": { "value": "{enkhuizen.typography.sans-serif.font-family}" },
       "line-height": { "value": "28px" },
       "placeholder": {
-        "color": { "value": "{enkhuizen.color.grey.60.value}" }
+        "color": { "value": "{enkhuizen.color.grey.60}" }
       },
       "focus": {
         "border-color": {}

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,11 +4,11 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{enkhuizen.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{enkhuizen.typography.weight-scale.normal.font-weight}" }
       },
 
       "radio": {
-        "font-weight": { "value": "{enkhuizen.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{enkhuizen.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{enkhuizen.color.white.value}" },
-      "border-color": { "value": "{enkhuizen.color.grey.60.value}" },
+      "background-color": { "value": "{enkhuizen.color.white}" },
+      "border-color": { "value": "{enkhuizen.color.grey.60}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{enkhuizen.color.grey.60.value}" },
+      "color": { "value": "{enkhuizen.color.grey.60}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,10 +3,10 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{enkhuizen.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{enkhuizen.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
-      "color": { "value": "{enkhuizen.color.blue.value}" },
+      "color": { "value": "{enkhuizen.color.blue}" },
       "font-family": {},
       "font-size": { "value": "2.1rem" },
       "font-weight": {},

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{enkhuizen.color.blue.value}" },
+      "color": { "value": "{enkhuizen.color.blue}" },
       "text-decoration": {},
       "active": {
         "color": {}
@@ -11,7 +11,7 @@
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{enkhuizen.color.blue.value}" },
+        "color": { "value": "{enkhuizen.color.blue}" },
         "text-decoration": { "value": "underline" }
       },
       "visited": {

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": {},
-      "font-size": { "value": "{enkhuizen.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{enkhuizen.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{enkhuizen.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{enkhuizen.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "1.75" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{enkhuizen.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{enkhuizen.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/table.tokens.json
@@ -15,10 +15,10 @@
       "header": {
         "font-weight": { "value": "bold" },
         "background-color": {
-          "value": "{enkhuizen.color.blue.value}",
+          "value": "{enkhuizen.color.blue}",
           "comment": "Deze site heeft geen tabel zover ik kon vinden"
         },
-        "color": { "value": "{enkhuizen.color.white.value}" },
+        "color": { "value": "{enkhuizen.color.white}" },
         "text-transform": {},
         "border-block-end-color": {},
         "border-block-end-width": {}

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/textarea.tokens.json
@@ -2,19 +2,19 @@
   "utrecht": {
     "textarea": {
       "border-bottom-width": {},
-      "border-color": { "value": "{utrecht.textbox.border-color.value}" },
-      "border-radius": { "value": "{utrecht.textbox.border-radius.value}" },
-      "border-width": { "value": "{utrecht.textbox.border-width.value}" },
-      "color": { "value": "{utrecht.textbox.color.value}" },
-      "font-family": { "value": "{utrecht.textbox.font-family.value}" },
-      "font-size": { "value": "{utrecht.textbox.font-size.value}" },
-      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size.value}" },
-      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size.value}" },
+      "border-color": { "value": "{utrecht.textbox.border-color}" },
+      "border-radius": { "value": "{utrecht.textbox.border-radius}" },
+      "border-width": { "value": "{utrecht.textbox.border-width}" },
+      "color": { "value": "{utrecht.textbox.color}" },
+      "font-family": { "value": "{utrecht.textbox.font-family}" },
+      "font-size": { "value": "{utrecht.textbox.font-size}" },
+      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size}" },
+      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size}" },
       "min-block-size": { "value": "95px" },
-      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end.value}" },
-      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start.value}" },
-      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end.value}" },
-      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start.value}" }
+      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end}" },
+      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start}" },
+      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end}" },
+      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start}" }
     }
   }
 }

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/textbox.tokens.json
@@ -2,18 +2,18 @@
   "utrecht": {
     "textbox": {
       "border-bottom-width": { "value": "1px" },
-      "border-color": { "value": "{utrecht.form-input.border-color.value}" },
+      "border-color": { "value": "{utrecht.form-input.border-color}" },
       "border-radius": { "value": "2px" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{utrecht.form-input.color.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
-      "font-size": { "value": "{enkhuizen.typography.scale.md.font-size.value}" },
+      "color": { "value": "{utrecht.form-input.color}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
+      "font-size": { "value": "{enkhuizen.typography.scale.md.font-size}" },
       "min-inline-size": { "value": "70px" },
       "max-inline-size": { "value": "620px" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xs}" },
       "disabled": {
         "border-color": {},
         "color": {}

--- a/proprietary/enkhuizen-design-tokens/src/component/utrecht/unordered-list.tokens.json
+++ b/proprietary/enkhuizen-design-tokens/src/component/utrecht/unordered-list.tokens.json
@@ -9,7 +9,7 @@
         "margin-block-end": { "value": "8px" }
       },
       "marker": {
-        "color": { "value": "{enkhuizen.color.black.value}" },
+        "color": { "value": "{enkhuizen.color.black}" },
         "content": { "value": "■", "comment": "FIXME new" }
       }
     }

--- a/proprietary/groningen-design-tokens/src/component/utrecht/badge-counter.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/badge-counter.tokens.json
@@ -2,13 +2,13 @@
   "utrecht": {
     "badge-counter": {
       "background-color": {
-        "value": "{groningen.color.grey.95.value}"
+        "value": "{groningen.color.grey.95}"
       },
       "border-radius": {
         "value": "3ex"
       },
       "color": {
-        "value": "{groningen.color.black.value}"
+        "value": "{groningen.color.black}"
       },
       "font-weight": {},
       "padding-block": {

--- a/proprietary/groningen-design-tokens/src/component/utrecht/badge.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/badge.tokens.json
@@ -2,22 +2,22 @@
   "utrecht": {
     "badge": {
       "background-color": {
-        "value": "{groningen.color.grey.95.value}"
+        "value": "{groningen.color.grey.95}"
       },
       "border-radius": {
         "value": "0"
       },
       "color": {
-        "value": "{groningen.color.black.value}"
+        "value": "{groningen.color.black}"
       },
       "font-weight": {
-        "value": "{groningen.typography.weight-scale.semi-bold.font-weight.value}"
+        "value": "{groningen.typography.weight-scale.semi-bold.font-weight}"
       },
       "padding-block": {
         "value": "6px"
       },
       "padding-inline": {
-        "value": "{utrecht.space.inline.md.value}"
+        "value": "{utrecht.space.inline.md}"
       }
     }
   }

--- a/proprietary/groningen-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,23 +1,23 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{groningen.color.green.40.value}" },
+      "background-color": { "value": "{groningen.color.green.40}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{groningen.color.white.value}" },
-      "font-family": { "value": "{groningen.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{groningen.typography.scale.md.font-size.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "color": { "value": "{groningen.color.white}" },
+      "font-family": { "value": "{groningen.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{groningen.typography.scale.md.font-size}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
       "secondary-action": {
-        "background-color": { "value": "{groningen.color.green.40.value}" },
-        "color": { "value": "{groningen.color.white.value}" },
+        "background-color": { "value": "{groningen.color.green.40}" },
+        "color": { "value": "{groningen.color.white}" },
         "border-color": {},
         "border-width": {},
         "hover": {
@@ -26,7 +26,7 @@
         }
       },
       "focus": {
-        "border-color": { "value": "{groningen.color.black.value}" },
+        "border-color": { "value": "{groningen.color.black}" },
         "border-width": {},
         "transform-scale": {}
       }

--- a/proprietary/groningen-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{groningen.color.white.value}" },
-      "color": { "value": "{groningen.color.black.value}" },
-      "font-family": { "value": "{groningen.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{groningen.color.white}" },
+      "color": { "value": "{groningen.color.black}" },
+      "font-family": { "value": "{groningen.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "22px" }
     }

--- a/proprietary/groningen-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/groningen-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,13 +2,13 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{groningen.color.black.value}" },
-      "border-color": { "value": "{groningen.color.white.value}" },
+      "color": { "value": "{groningen.color.black}" },
+      "border-color": { "value": "{groningen.color.white}" },
       "border-width": { "value": "1px", "comment": "fix me new" },
-      "font-family": { "value": "{groningen.typography.sans-serif.font-family.value}" },
+      "font-family": { "value": "{groningen.typography.sans-serif.font-family}" },
       "line-height": { "value": "18px" },
       "placeholder": {
-        "color": { "value": "{groningen.color.black.value}" }
+        "color": { "value": "{groningen.color.black}" }
       },
       "focus": {
         "border-color": {}

--- a/proprietary/groningen-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,16 +4,16 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{groningen.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{groningen.typography.weight-scale.normal.font-weight}" }
       },
       "checkbox-checked": {
         "font-weight": {
-          "value": "{groningen.typography.weight-scale.bold.font-weight.value}",
+          "value": "{groningen.typography.weight-scale.bold.font-weight}",
           "comment": "FIXME: new"
         }
       },
       "radio": {
-        "font-weight": { "value": "{groningen.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{groningen.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/groningen-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{groningen.color.white.value}" },
-      "border-color": { "value": "{groningen.color.white.value}" },
+      "background-color": { "value": "{groningen.color.white}" },
+      "border-color": { "value": "{groningen.color.white}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{groningen.color.black.value}" },
+      "color": { "value": "{groningen.color.black}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/groningen-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{groningen.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{groningen.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
       "color": {},

--- a/proprietary/groningen-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{groningen.color.black.value}" },
+      "color": { "value": "{groningen.color.black}" },
       "text-decoration": { "value": "underline" },
       "active": {
         "color": {}
@@ -11,7 +11,7 @@
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{groningen.color.green.40.value}" },
+        "color": { "value": "{groningen.color.green.40}" },
         "text-decoration": { "value": "underline" }
       },
       "visited": {

--- a/proprietary/groningen-design-tokens/src/component/utrecht/page-footer.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/page-footer.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "page-footer": {
-      "background-color": { "value": "{groningen.color.green.40.value}", "comment": "FIXME new" },
-      "color": { "value": "{groningen.color.white.value}", "comment": "FIXME new" }
+      "background-color": { "value": "{groningen.color.green.40}", "comment": "FIXME new" },
+      "color": { "value": "{groningen.color.white}", "comment": "FIXME new" }
     }
   }
 }

--- a/proprietary/groningen-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": {},
-      "font-size": { "value": "{groningen.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{groningen.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{groningen.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{groningen.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "22px" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{groningen.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{groningen.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/groningen-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/table.tokens.json
@@ -16,7 +16,7 @@
         "font-weight": { "value": "400" },
         "color": {},
         "text-transform": {},
-        "border-block-end-color": { "value": "{groningen.color.white.value}" },
+        "border-block-end-color": { "value": "{groningen.color.white}" },
         "border-block-end-width": { "value": "0.5px" }
       },
       "heading": {

--- a/proprietary/groningen-design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/groningen-design-tokens/src/component/utrecht/textbox.tokens.json
@@ -2,18 +2,18 @@
   "utrecht": {
     "textbox": {
       "border-bottom-width": { "value": "1px" },
-      "border-color": { "value": "{utrecht.form-input.border-color.value}" },
+      "border-color": { "value": "{utrecht.form-input.border-color}" },
       "border-radius": { "value": "3px" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{utrecht.form-input.color.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
-      "font-size": { "value": "{groningen.typography.scale.md.font-size.value}" },
+      "color": { "value": "{utrecht.form-input.color}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
+      "font-size": { "value": "{groningen.typography.scale.md.font-size}" },
       "min-inline-size": { "value": "70px" },
       "max-inline-size": { "value": "620px" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xs}" },
       "disabled": {
         "border-color": {},
         "color": {}

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,14 +1,14 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{haarlemmermeer.color.blue.30.value}" },
+      "background-color": { "value": "{haarlemmermeer.color.blue.30}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{haarlemmermeer.color.grey.100.value}" },
-      "font-family": { "value": "{haarlemmermeer.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{haarlemmermeer.color.grey.100}" },
+      "font-family": { "value": "{haarlemmermeer.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
       "padding-block-end": { "value": "10px" },
@@ -16,22 +16,22 @@
       "padding-inline-end": { "value": "15px" },
       "padding-inline-start": { "value": "15px" },
       "hover": {
-        "background-color": { "value": "{haarlemmermeer.color.purple.value}" },
+        "background-color": { "value": "{haarlemmermeer.color.purple}" },
         "color": {},
         "border-color": {}
       },
       "secondary-action": {
-        "background-color": { "value": "{haarlemmermeer.color.blue.30.value}" },
-        "color": { "value": "{haarlemmermeer.color.grey.100.value}" },
+        "background-color": { "value": "{haarlemmermeer.color.blue.30}" },
+        "color": { "value": "{haarlemmermeer.color.grey.100}" },
         "border-color": {},
         "border-width": {},
         "hover": {
-          "background-color": { "value": "{haarlemmermeer.color.purple.value}" },
+          "background-color": { "value": "{haarlemmermeer.color.purple}" },
           "color": {}
         }
       },
       "focus": {
-        "border-color": { "value": "{haarlemmermeer.color.grey.0.value}" },
+        "border-color": { "value": "{haarlemmermeer.color.grey.0}" },
         "border-width": {},
         "transform-scale": {}
       }

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{haarlemmermeer.color.grey.100.value}" },
-      "color": { "value": "{haarlemmermeer.color.grey.0.value}" },
-      "font-family": { "value": "{haarlemmermeer.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{haarlemmermeer.color.grey.100}" },
+      "color": { "value": "{haarlemmermeer.color.grey.0}" },
+      "font-family": { "value": "{haarlemmermeer.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "1.35" }
     }

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,10 +2,10 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "border-color": { "value": "{haarlemmermeer.color.blue.30.value}" },
+      "border-color": { "value": "{haarlemmermeer.color.blue.30}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{haarlemmermeer.color.grey.0.value}" },
-      "font-family": { "value": "{haarlemmermeer.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{haarlemmermeer.color.grey.0}" },
+      "font-family": { "value": "{haarlemmermeer.typography.sans-serif.font-family}" },
       "font-size": { "value": "14px" },
       "line-height": { "value": "18px" },
       "max-inline-size": { "value": "460px" },
@@ -14,10 +14,10 @@
       "padding-inline-start": { "value": "0.3em" },
       "padding-inline-end": { "value": "0.3em" },
       "placeholder": {
-        "color": { "value": "{haarlemmermeer.color.grey.45.value}" }
+        "color": { "value": "{haarlemmermeer.color.grey.45}" }
       },
       "focus": {
-        "border-color": { "value": "{haarlemmermeer.color.blue.80.value}" }
+        "border-color": { "value": "{haarlemmermeer.color.blue.80}" }
       }
     }
   }

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,10 +4,10 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{haarlemmermeer.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{haarlemmermeer.typography.weight-scale.normal.font-weight}" }
       },
       "radio": {
-        "font-weight": { "value": "{haarlemmermeer.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{haarlemmermeer.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{haarlemmermeer.color.grey.100.value}" },
-      "border-color": { "value": "{haarlemmermeer.color.grey.85.value}" },
+      "background-color": { "value": "{haarlemmermeer.color.grey.100}" },
+      "border-color": { "value": "{haarlemmermeer.color.grey.85}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{haarlemmermeer.color.grey.0.value}" },
+      "color": { "value": "{haarlemmermeer.color.grey.0}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/heading-1.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/heading-1.tokens.json
@@ -2,7 +2,7 @@
   "utrecht": {
     "heading-1": {
       "color": {
-        "value": "{haarlemmermeer.color.grey.0.value}",
+        "value": "{haarlemmermeer.color.grey.0}",
         "comment": "Op de site hebben ze h2 2 verschillende font-size gegeven. Ik heb de kleinere h3 gemaakt en zo door."
       },
       "font-family": {},

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{haarlemmermeer.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{haarlemmermeer.typography.weight-scale.bold.font-weight}" }
     }
   }
 }

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,17 +1,17 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{haarlemmermeer.color.blue.30.value}" },
+      "color": { "value": "{haarlemmermeer.color.blue.30}" },
       "text-decoration": { "value": "underline" },
       "active": {
         "color": {}
       },
       "focus": {
-        "color": { "value": "{haarlemmermeer.color.purple.value}" },
+        "color": { "value": "{haarlemmermeer.color.purple}" },
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{haarlemmermeer.color.purple.value}" },
+        "color": { "value": "{haarlemmermeer.color.purple}" },
         "text-decoration": {}
       },
       "visited": {

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/page-footer.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/page-footer.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "page-footer": {
-      "background-color": { "value": "{haarlemmermeer.color.blue.30.value}" },
-      "color": { "value": "{haarlemmermeer.color.grey.100.value}" },
+      "background-color": { "value": "{haarlemmermeer.color.blue.30}" },
+      "color": { "value": "{haarlemmermeer.color.grey.100}" },
       "padding-block-start": { "value": "20px" },
       "padding-block-end": { "value": "20px" },
       "padding-inline-start": { "value": "20px" },

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/separator.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/separator.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "separator": {
-      "color": { "value": "{haarlemmermeer.color.grey.0.value}" },
+      "color": { "value": "{haarlemmermeer.color.grey.0}" },
       "block-size": { "value": "1px" },
       "margin-block-end": { "value": "30px" },
       "margin-block-start": { "value": "30px" }

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/table.tokens.json
@@ -14,8 +14,8 @@
       },
       "header": {
         "font-weight": { "value": "bold" },
-        "background-color": { "value": "{haarlemmermeer.color.grey.100.value}", "comment": "FIXME new" },
-        "color": { "value": "{haarlemmermeer.color.grey.0.value}" },
+        "background-color": { "value": "{haarlemmermeer.color.grey.100}", "comment": "FIXME new" },
+        "color": { "value": "{haarlemmermeer.color.grey.0}" },
         "text-transform": {},
         "border-block-end-color": {},
         "border-block-end-width": {}
@@ -40,11 +40,11 @@
         "padding-inline-end": {},
         "padding-inline-start": {},
         "alternate-odd": {
-          "background-color": { "value": "{haarlemmermeer.color.grey.95.value}" },
+          "background-color": { "value": "{haarlemmermeer.color.grey.95}" },
           "color": {}
         },
         "alternate-even": {
-          "background-color": { "value": "{haarlemmermeer.color.grey.100.value}" },
+          "background-color": { "value": "{haarlemmermeer.color.grey.100}" },
           "color": {}
         }
       }

--- a/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/unordered-list.tokens.json
+++ b/proprietary/haarlemmermeer-design-tokens/src/component/utrecht/unordered-list.tokens.json
@@ -9,7 +9,7 @@
         "margin-block-end": { "value": "1em" }
       },
       "marker": {
-        "color": { "value": "{haarlemmermeer.color.grey.0.value}" },
+        "color": { "value": "{haarlemmermeer.color.grey.0}" },
         "content": { "value": "■", "comment": "FIXME new" }
       }
     }

--- a/proprietary/hoorn-design-tokens/src/common/utrecht/feedback.tokens.json
+++ b/proprietary/hoorn-design-tokens/src/common/utrecht/feedback.tokens.json
@@ -2,9 +2,9 @@
   "utrecht": {
     "feedback": {
       "invalid": {
-        "background-color": { "value": "{hoorn.color.red.90.value}" },
-        "border-color": { "value": "{hoorn.color.red.40.value}" },
-        "color": { "value": "{hoorn.color.red.50.value}" }
+        "background-color": { "value": "{hoorn.color.red.90}" },
+        "border-color": { "value": "{hoorn.color.red.40}" },
+        "color": { "value": "{hoorn.color.red.50}" }
       }
     }
   }

--- a/proprietary/hoorn-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/hoorn-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,10 +1,10 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{hoorn.color.blue.40.value}" },
+      "background-color": { "value": "{hoorn.color.blue.40}" },
       "border-width": { "value": "0" },
       "border-radius": { "value": "0" },
-      "color": { "value": "{hoorn.color.grey.100.value}" },
+      "color": { "value": "{hoorn.color.grey.100}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "26px" },
       "padding-block-end": { "value": "6px" },
@@ -12,25 +12,25 @@
       "padding-inline-end": { "value": "30px" },
       "padding-inline-start": { "value": "30px" },
       "hover": {
-        "background-color": { "value": "{hoorn.color.blue.25.value}" },
-        "color": { "value": "{hoorn.color.grey.100.value}" }
+        "background-color": { "value": "{hoorn.color.blue.25}" },
+        "color": { "value": "{hoorn.color.grey.100}" }
       },
       "focus": {
-        "background-color": { "value": "{hoorn.color.blue.25.value}" },
-        "color": { "value": "{hoorn.color.grey.100.value}" }
+        "background-color": { "value": "{hoorn.color.blue.25}" },
+        "color": { "value": "{hoorn.color.grey.100}" }
       },
       "secondary-action": {
         "border-width": { "value": "2px" },
-        "background-color": { "value": "{hoorn.color.grey.100.value}" },
-        "color": { "value": "{hoorn.color.blue.40.value}" },
-        "border-color": { "value": "{hoorn.color.blue.40.value}" },
+        "background-color": { "value": "{hoorn.color.grey.100}" },
+        "color": { "value": "{hoorn.color.blue.40}" },
+        "border-color": { "value": "{hoorn.color.blue.40}" },
         "focus": {
-          "background-color": { "value": "{hoorn.color.blue.40.value}" },
-          "color": { "value": "{hoorn.color.grey.100.value}" }
+          "background-color": { "value": "{hoorn.color.blue.40}" },
+          "color": { "value": "{hoorn.color.grey.100}" }
         },
         "hover": {
-          "background-color": { "value": "{hoorn.color.blue.40.value}" },
-          "color": { "value": "{hoorn.color.grey.100.value}" }
+          "background-color": { "value": "{hoorn.color.blue.40}" },
+          "color": { "value": "{hoorn.color.grey.100}" }
         }
       }
     }

--- a/proprietary/hoorn-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/hoorn-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{hoorn.color.grey.100.value}" },
-      "color": { "value": "{hoorn.color.grey.20.value}" },
-      "font-family": { "value": "{hoorn.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{hoorn.color.grey.100}" },
+      "color": { "value": "{hoorn.color.grey.20}" },
+      "font-family": { "value": "{hoorn.typography.sans-serif.font-family}" },
       "font-size": { "value": "14px" },
       "line-height": { "value": "1.42857143" }
     }

--- a/proprietary/hoorn-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/hoorn-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -1,11 +1,11 @@
 {
   "utrecht": {
     "form-input": {
-      "background-color": { "value": "{hoorn.color.grey.100.value}" },
-      "color": { "value": "{hoorn.color.grey.10.value}" },
-      "border-color": { "value": "{hoorn.color.grey.30.value}" },
+      "background-color": { "value": "{hoorn.color.grey.100}" },
+      "color": { "value": "{hoorn.color.grey.10}" },
+      "border-color": { "value": "{hoorn.color.grey.30}" },
       "border-radius": { "value": "2px" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
       "font-size": { "value": "16px" },
       "padding-block-start": { "value": "5px" },
       "padding-block-end": { "value": "5px" },
@@ -13,7 +13,7 @@
       "padding-inline-end": { "value": "5px" },
       "invalid": {
         "border-width": { "value": "2px" },
-        "border-color": { "value": "{hoorn.color.red.40.value}" }
+        "border-color": { "value": "{hoorn.color.red.40}" }
       },
       "placeholder": {
         "font-style": { "value": "italic" }

--- a/proprietary/hoorn-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/hoorn-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,14 +1,14 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{hoorn.color.blue.40.value}" },
+      "color": { "value": "{hoorn.color.blue.40}" },
       "text-decoration": { "value": "underline" },
       "focus": {
-        "color": { "value": "{hoorn.color.blue.30.value}" },
+        "color": { "value": "{hoorn.color.blue.30}" },
         "text-decoration": { "value": "none" }
       },
       "hover": {
-        "color": { "value": "{hoorn.color.blue.30.value}" },
+        "color": { "value": "{hoorn.color.blue.30}" },
         "text-decoration": { "value": "none" }
       }
     }

--- a/proprietary/hoorn-design-tokens/src/component/utrecht/page-footer.tokens.json
+++ b/proprietary/hoorn-design-tokens/src/component/utrecht/page-footer.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "page-footer": {
-      "background-color": { "value": "{hoorn.color.grey.90.value}" },
-      "color": { "value": "{hoorn.color.grey.20.value}" }
+      "background-color": { "value": "{hoorn.color.grey.90}" },
+      "color": { "value": "{hoorn.color.grey.20}" }
     }
   }
 }

--- a/proprietary/hoorn-design-tokens/src/component/utrecht/page-header.tokens.json
+++ b/proprietary/hoorn-design-tokens/src/component/utrecht/page-header.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "page-header": {
-      "background-color": { "value": "{hoorn.color.grey.50.value}" },
-      "color": { "value": "{hoorn.color.grey.20.value}" }
+      "background-color": { "value": "{hoorn.color.grey.50}" },
+      "color": { "value": "{hoorn.color.grey.20}" }
     }
   }
 }

--- a/proprietary/hoorn-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/hoorn-design-tokens/src/component/utrecht/table.tokens.json
@@ -16,7 +16,7 @@
       },
       "row": {
         "border-block-end-width": { "value": "1px" },
-        "border-block-end-color": { "value": "{hoorn.color.grey.85.value}" }
+        "border-block-end-color": { "value": "{hoorn.color.grey.85}" }
       },
       "cell": {
         "padding-inline-start": { "value": "8px" },

--- a/proprietary/horstaandemaas-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/horstaandemaas-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{horstaandemaas.color.grey.100.value}" },
-      "color": { "value": "{horstaandemaas.color.grey.15.value}" },
-      "font-family": { "value": "{zwolle.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{horstaandemaas.color.grey.100}" },
+      "color": { "value": "{horstaandemaas.color.grey.15}" },
+      "font-family": { "value": "{zwolle.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "22px" }
     }

--- a/proprietary/horstaandemaas-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/horstaandemaas-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/horstaandemaas-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/horstaandemaas-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,9 +2,9 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{horstaandemaas.color.grey.0.value}" },
-      "border-color": { "value": "{horstaandemaas.color.grey.0.value}" },
-      "font-family": { "value": "{zwolle.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{horstaandemaas.color.grey.0}" },
+      "border-color": { "value": "{horstaandemaas.color.grey.0}" },
+      "font-family": { "value": "{zwolle.typography.sans-serif.font-family}" },
       "line-height": { "value": "18px" },
       "placeholder": {
         "color": {}

--- a/proprietary/horstaandemaas-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/horstaandemaas-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,7 +4,7 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight}" }
       },
       "checkbox-checked": {
         "font-weight": {
@@ -12,7 +12,7 @@
         }
       },
       "radio": {
-        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/horstaandemaas-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/horstaandemaas-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{horstaandemaas.color.grey.100.value}" },
-      "border-color": { "value": "{horstaandemaas.color.grey.0.value}" },
+      "background-color": { "value": "{horstaandemaas.color.grey.100}" },
+      "border-color": { "value": "{horstaandemaas.color.grey.0}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{horstaandemaas.color.grey.0.value}" },
+      "color": { "value": "{horstaandemaas.color.grey.0}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/horstaandemaas-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/horstaandemaas-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{zwolle.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{zwolle.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
       "color": {},

--- a/proprietary/horstaandemaas-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/horstaandemaas-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,17 +1,17 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{horstaandemaas.color.blue.40.value}" },
+      "color": { "value": "{horstaandemaas.color.blue.40}" },
       "text-decoration": { "value": "underline" },
       "active": {
         "color": {}
       },
       "focus": {
-        "color": { "value": "{horstaandemaas.color.blue.20.value}" },
+        "color": { "value": "{horstaandemaas.color.blue.20}" },
         "text-decoration": { "value": "none" }
       },
       "hover": {
-        "color": { "value": "{horstaandemaas.color.blue.20.value}" },
+        "color": { "value": "{horstaandemaas.color.blue.20}" },
         "text-decoration": { "value": "none" }
       },
       "visited": {

--- a/proprietary/horstaandemaas-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/horstaandemaas-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": {},
-      "font-size": { "value": "{zwolle.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{zwolle.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "22px" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{zwolle.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{zwolle.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/horstaandemaas-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/horstaandemaas-design-tokens/src/component/utrecht/table.tokens.json
@@ -15,7 +15,7 @@
       "header": {
         "font-weight": { "value": "bold" },
         "background-color": {},
-        "color": { "value": "{horstaandemaas.color.grey.100.value}" },
+        "color": { "value": "{horstaandemaas.color.grey.100}" },
         "text-transform": {},
         "border-block-end-color": {},
         "border-block-end-width": {}

--- a/proprietary/horstaandemaas-design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/horstaandemaas-design-tokens/src/component/utrecht/textarea.tokens.json
@@ -2,19 +2,19 @@
   "utrecht": {
     "textarea": {
       "border-bottom-width": {},
-      "border-color": { "value": "{utrecht.textbox.border-color.value}" },
-      "border-radius": { "value": "{utrecht.textbox.border-radius.value}" },
-      "border-width": { "value": "{utrecht.textbox.border-width.value}" },
-      "color": { "value": "{utrecht.textbox.color.value}" },
-      "font-family": { "value": "{utrecht.textbox.font-family.value}" },
-      "font-size": { "value": "{utrecht.textbox.font-size.value}" },
-      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size.value}" },
-      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size.value}" },
+      "border-color": { "value": "{utrecht.textbox.border-color}" },
+      "border-radius": { "value": "{utrecht.textbox.border-radius}" },
+      "border-width": { "value": "{utrecht.textbox.border-width}" },
+      "color": { "value": "{utrecht.textbox.color}" },
+      "font-family": { "value": "{utrecht.textbox.font-family}" },
+      "font-size": { "value": "{utrecht.textbox.font-size}" },
+      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size}" },
+      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size}" },
       "min-block-size": { "value": "95px" },
-      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end.value}" },
-      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start.value}" },
-      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end.value}" },
-      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start.value}" }
+      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end}" },
+      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start}" },
+      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end}" },
+      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start}" }
     }
   }
 }

--- a/proprietary/horstaandemaas-design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/horstaandemaas-design-tokens/src/component/utrecht/textbox.tokens.json
@@ -2,18 +2,18 @@
   "utrecht": {
     "textbox": {
       "border-bottom-width": { "value": "1px" },
-      "border-color": { "value": "{utrecht.form-input.border-color.value}" },
+      "border-color": { "value": "{utrecht.form-input.border-color}" },
       "border-radius": { "value": "2px" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{utrecht.form-input.color.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
-      "font-size": { "value": "{zwolle.typography.scale.md.font-size.value}" },
+      "color": { "value": "{utrecht.form-input.color}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
+      "font-size": { "value": "{zwolle.typography.scale.md.font-size}" },
       "min-inline-size": { "value": "70px" },
       "max-inline-size": { "value": "620px" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xs}" },
       "disabled": {
         "border-color": {},
         "color": {}

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,23 +1,23 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{leidschendam.color.blue.value}" },
+      "background-color": { "value": "{leidschendam.color.blue}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{leidschendam.color.white.value}" },
-      "font-family": { "value": "{leidschendam.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{leidschendam.typography.scale.md.font-size.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "color": { "value": "{leidschendam.color.white}" },
+      "font-family": { "value": "{leidschendam.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{leidschendam.typography.scale.md.font-size}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
       "secondary-action": {
-        "background-color": { "value": "{leidschendam.color.orange.value}" },
-        "color": { "value": "{leidschendam.color.black.value}" },
+        "background-color": { "value": "{leidschendam.color.orange}" },
+        "color": { "value": "{leidschendam.color.black}" },
         "border-color": {},
         "border-width": {},
         "hover": {
@@ -26,7 +26,7 @@
         }
       },
       "focus": {
-        "border-color": { "value": "{leidschendam.color.blue.value}" },
+        "border-color": { "value": "{leidschendam.color.blue}" },
         "border-width": {},
         "transform-scale": {}
       }

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{leidschendam.color.white.value}" },
-      "color": { "value": "{leidschendam.color.black.value}" },
-      "font-family": { "value": "{leidschendam.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{leidschendam.color.white}" },
+      "color": { "value": "{leidschendam.color.black}" },
+      "font-family": { "value": "{leidschendam.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "22px" }
     }

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{leidschendam.color.black.value}" },
-      "border-color": { "value": "{leidschendam.color.grey.value}" },
-      "font-family": { "value": "{leidschendam.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{leidschendam.color.black}" },
+      "border-color": { "value": "{leidschendam.color.grey}" },
+      "font-family": { "value": "{leidschendam.typography.sans-serif.font-family}" },
       "line-height": { "value": "18px" },
       "placeholder": {
-        "color": { "value": "{leidschendam.color.black.value}" }
+        "color": { "value": "{leidschendam.color.black}" }
       },
       "focus": {
         "border-color": {}

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,11 +4,11 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{leidschendam.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{leidschendam.typography.weight-scale.normal.font-weight}" }
       },
 
       "radio": {
-        "font-weight": { "value": "{leidschendam.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{leidschendam.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{leidschendam.color.white.value}" },
-      "border-color": { "value": "{leidschendam.color.black.value}" },
+      "background-color": { "value": "{leidschendam.color.white}" },
+      "border-color": { "value": "{leidschendam.color.black}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{leidschendam.color.black.value}" },
+      "color": { "value": "{leidschendam.color.black}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,10 +3,10 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{leidschendam.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{leidschendam.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
-      "color": { "value": "{leidschendam.color.black.value}" },
+      "color": { "value": "{leidschendam.color.black}" },
       "font-family": {},
       "font-size": { "value": "3.2em" },
       "font-weight": {},

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{leidschendam.color.blue.value}" },
+      "color": { "value": "{leidschendam.color.blue}" },
       "text-decoration": { "value": "underline" },
       "active": {
         "color": {}
@@ -11,7 +11,7 @@
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{leidschendam.color.blue.value}" },
+        "color": { "value": "{leidschendam.color.blue}" },
         "text-decoration": { "value": "underline" }
       },
       "visited": {

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": {},
-      "font-size": { "value": "{leidschendam.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{leidschendam.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{leidschendam.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{leidschendam.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "1.71" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{leidschendam.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{leidschendam.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/table.tokens.json
@@ -14,10 +14,10 @@
       },
       "header": {
         "font-weight": { "value": "bold" },
-        "background-color": { "value": "{leidschendam.color.blue.value}", "comment": "FIXME new" },
-        "color": { "value": "{leidschendam.color.white.value}" },
+        "background-color": { "value": "{leidschendam.color.blue}", "comment": "FIXME new" },
+        "color": { "value": "{leidschendam.color.white}" },
         "text-transform": {},
-        "border-block-end-color": { "value": "{leidschendam.color.grey.value}" },
+        "border-block-end-color": { "value": "{leidschendam.color.grey}" },
         "border-block-end-width": { "value": "0.5px" }
       },
       "heading": {

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/textarea.tokens.json
@@ -2,19 +2,19 @@
   "utrecht": {
     "textarea": {
       "border-bottom-width": {},
-      "border-color": { "value": "{utrecht.textbox.border-color.value}" },
-      "border-radius": { "value": "{utrecht.textbox.border-radius.value}" },
-      "border-width": { "value": "{utrecht.textbox.border-width.value}" },
-      "color": { "value": "{utrecht.textbox.color.value}" },
-      "font-family": { "value": "{utrecht.textbox.font-family.value}" },
-      "font-size": { "value": "{utrecht.textbox.font-size.value}" },
-      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size.value}" },
-      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size.value}" },
+      "border-color": { "value": "{utrecht.textbox.border-color}" },
+      "border-radius": { "value": "{utrecht.textbox.border-radius}" },
+      "border-width": { "value": "{utrecht.textbox.border-width}" },
+      "color": { "value": "{utrecht.textbox.color}" },
+      "font-family": { "value": "{utrecht.textbox.font-family}" },
+      "font-size": { "value": "{utrecht.textbox.font-size}" },
+      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size}" },
+      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size}" },
       "min-block-size": { "value": "95px" },
-      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end.value}" },
-      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start.value}" },
-      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end.value}" },
-      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start.value}" }
+      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end}" },
+      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start}" },
+      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end}" },
+      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start}" }
     }
   }
 }

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/textbox.tokens.json
@@ -2,18 +2,18 @@
   "utrecht": {
     "textbox": {
       "border-bottom-width": { "value": "1px" },
-      "border-color": { "value": "{utrecht.form-input.border-color.value}" },
+      "border-color": { "value": "{utrecht.form-input.border-color}" },
       "border-radius": { "value": "2px" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{utrecht.form-input.color.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
-      "font-size": { "value": "{leidschendam.typography.scale.md.font-size.value}" },
+      "color": { "value": "{utrecht.form-input.color}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
+      "font-size": { "value": "{leidschendam.typography.scale.md.font-size}" },
       "min-inline-size": { "value": "70px" },
       "max-inline-size": { "value": "620px" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xs}" },
       "disabled": {
         "border-color": {},
         "color": {}

--- a/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/unordered-list.tokens.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/src/component/utrecht/unordered-list.tokens.json
@@ -9,7 +9,7 @@
         "margin-block-end": { "value": "8px" }
       },
       "marker": {
-        "color": { "value": "{leidschendam.color.blue.value}" },
+        "color": { "value": "{leidschendam.color.blue}" },
         "content": { "value": "■", "comment": "FIXME new" }
       }
     }

--- a/proprietary/nijmegen-design-tokens/src/common/utrecht/feedback.tokens.json
+++ b/proprietary/nijmegen-design-tokens/src/common/utrecht/feedback.tokens.json
@@ -2,11 +2,11 @@
   "utrecht": {
     "feedback": {
       "invalid": {
-        "background-color": { "value": "{nijmegen.color.feedback-red.40.value}" },
-        "color": { "value": "{nijmegen.color.feedback-red.40.value}" }
+        "background-color": { "value": "{nijmegen.color.feedback-red.40}" },
+        "color": { "value": "{nijmegen.color.feedback-red.40}" }
       },
       "safe": {
-        "color": { "value": "{nijmegen.color.green.22.value}" }
+        "color": { "value": "{nijmegen.color.green.22}" }
       }
     }
   }

--- a/proprietary/nijmegen-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/nijmegen-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,10 +1,10 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{nijmegen.color.green.30.value}" },
+      "background-color": { "value": "{nijmegen.color.green.30}" },
       "border-width": { "value": "0" },
       "border-radius": { "value": ".125rem" },
-      "color": { "value": "{nijmegen.color.grey.100.value}" },
+      "color": { "value": "{nijmegen.color.grey.100}" },
       "margin-block-end": { "value": "0.5rem" },
       "font-size": { "value": "1.125rem" },
       "font-weight": { "value": "600" },
@@ -15,14 +15,14 @@
       "padding-inline-end": { "value": "2.14rem" },
       "text-transform": { "value": "uppercase" },
       "disabled": {
-        "background-color": { "value": "{nijmegen.color.grey.85b.value}" },
-        "color": { "value": "{nijmegen.color.grey.100.value}" }
+        "background-color": { "value": "{nijmegen.color.grey.85b}" },
+        "color": { "value": "{nijmegen.color.grey.100}" }
       },
       "hover": {
-        "background-color": { "value": "{nijmegen.color.green.25.value}" }
+        "background-color": { "value": "{nijmegen.color.green.25}" }
       },
       "focus": {
-        "background-color": { "value": "{nijmegen.color.green.25.value}" }
+        "background-color": { "value": "{nijmegen.color.green.25}" }
       }
     }
   }

--- a/proprietary/nijmegen-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/nijmegen-design-tokens/src/component/utrecht/document.tokens.json
@@ -3,7 +3,7 @@
     "document": {
       "background-color": { "value": "white" },
       "color": { "value": "#212121" },
-      "font-family": { "value": "{nijmegen.typography.sans-serif.font-family.value}" },
+      "font-family": { "value": "{nijmegen.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "font-weight": { "value": "300" },
       "line-height": { "value": "1.5" }

--- a/proprietary/nijmegen-design-tokens/src/component/utrecht/font-label.tokens.json
+++ b/proprietary/nijmegen-design-tokens/src/component/utrecht/font-label.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "form-label": {
-      "color": { "value": "{nijmegen.color.grey.35.value}" },
+      "color": { "value": "{nijmegen.color.grey.35}" },
       "font-weight": { "value": "600" }
     }
   }

--- a/proprietary/nijmegen-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/nijmegen-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,8 +2,8 @@
   "utrecht": {
     "form-input": {
       "background-color": { "value": "transparent" },
-      "color": { "value": "{utrecht.document.color.value}" },
-      "border-color": { "value": "{nijmegen.color.grey.35.value}" },
+      "color": { "value": "{utrecht.document.color}" },
+      "border-color": { "value": "{nijmegen.color.grey.35}" },
       "border-width": { "value": "0" },
       "font-size": { "value": "16px" },
       "font-weight": { "value": "600" },
@@ -12,13 +12,13 @@
       "padding-inline-start": { "value": "0" },
       "padding-inline-end": { "value": "0" },
       "placeholder": {
-        "color": { "value": "{nijmegen.color.grey.50.value}" }
+        "color": { "value": "{nijmegen.color.grey.50}" }
       },
       "disabled": {
-        "border-color": { "value": "{nijmegen.color.grey.85.value}" }
+        "border-color": { "value": "{nijmegen.color.grey.85}" }
       },
       "focus": {
-        "border-color": { "value": "{nijmegen.color.green.32.value}" }
+        "border-color": { "value": "{nijmegen.color.green.32}" }
       }
     }
   }

--- a/proprietary/nijmegen-design-tokens/src/component/utrecht/heading-2.tokens.json
+++ b/proprietary/nijmegen-design-tokens/src/component/utrecht/heading-2.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading-2": {
-      "color": { "value": "{nijmegen.color.red.30.value}" },
+      "color": { "value": "{nijmegen.color.red.30}" },
       "font-size": { "value": "2.25rem" },
       "margin-block-end": { "value": "0.5rem" }
     }

--- a/proprietary/nijmegen-design-tokens/src/component/utrecht/heading-3.tokens.json
+++ b/proprietary/nijmegen-design-tokens/src/component/utrecht/heading-3.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading-3": {
-      "color": { "value": "{nijmegen.color.red.30.value}" },
+      "color": { "value": "{nijmegen.color.red.30}" },
       "font-size": { "value": "1.75rem" },
       "margin-block-end": { "value": "0.5rem" }
     }

--- a/proprietary/nijmegen-design-tokens/src/component/utrecht/heading-6.tokens.json
+++ b/proprietary/nijmegen-design-tokens/src/component/utrecht/heading-6.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading-6": {
-      "color": { "value": "{nijmegen.color.grey.40.value}" },
+      "color": { "value": "{nijmegen.color.grey.40}" },
       "font-size": { "value": "1.5rem" },
       "margin-block-end": { "value": "0.5rem" }
     }

--- a/proprietary/nijmegen-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/nijmegen-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,13 +1,13 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{nijmegen.color.green.30.value}" },
+      "color": { "value": "{nijmegen.color.green.30}" },
       "text-decoration": { "value": "underline" },
       "focus": {
-        "color": { "value": "{nijmegen.color.green.20.value}" }
+        "color": { "value": "{nijmegen.color.green.20}" }
       },
       "hover": {
-        "color": { "value": "{nijmegen.color.green.20.value}" }
+        "color": { "value": "{nijmegen.color.green.20}" }
       }
     }
   }

--- a/proprietary/nijmegen-design-tokens/src/component/utrecht/page-footer.tokens.json
+++ b/proprietary/nijmegen-design-tokens/src/component/utrecht/page-footer.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "page-footer": {
-      "background-color": { "value": "{nijmegen.color.grey.20.value}" },
-      "color": { "value": "{nijmegen.color.grey.100.value}" },
+      "background-color": { "value": "{nijmegen.color.grey.20}" },
+      "color": { "value": "{nijmegen.color.grey.100}" },
       "padding-block-start": { "value": "60px" }
     }
   }

--- a/proprietary/noordoostpolder-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/noordoostpolder-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,12 +1,12 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{noordoostpolder.color.purple.50.value}" },
+      "background-color": { "value": "{noordoostpolder.color.purple.50}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
       "block-size": { "value": "50px" },
-      "color": { "value": "{noordoostpolder.color.grey.100.value}" },
-      "font-family": { "value": "{noordoostpolder.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{noordoostpolder.color.grey.100}" },
+      "font-family": { "value": "{noordoostpolder.typography.sans-serif.font-family}" },
       "font-size": { "value": "25px" },
       "margin-block-end": {},
       "margin-block-start": {},
@@ -27,10 +27,10 @@
         }
       },
       "hover": {
-        "background-color": { "value": "{noordoostpolder.color.purple.50.value}" }
+        "background-color": { "value": "{noordoostpolder.color.purple.50}" }
       },
       "focus": {
-        "background-color": { "value": "{noordoostpolder.color.purple.50.value}" },
+        "background-color": { "value": "{noordoostpolder.color.purple.50}" },
         "border-color": {},
         "border-width": {},
         "transform-scale": {}

--- a/proprietary/noordoostpolder-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/noordoostpolder-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{noordoostpolder.color.grey.100.value}" },
-      "color": { "value": "{noordoostpolder.color.grey.30.value}" },
-      "font-family": { "value": "{noordoostpolder.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{noordoostpolder.color.grey.100}" },
+      "color": { "value": "{noordoostpolder.color.grey.30}" },
+      "font-family": { "value": "{noordoostpolder.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "22px" }
     }

--- a/proprietary/noordoostpolder-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/noordoostpolder-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -3,10 +3,10 @@
     "form-input": {
       "block-size": { "value": "40px" },
       "border-radius": { "value": "5px" },
-      "color": { "value": "{noordoostpolder.color.grey.0.value}" },
-      "border-color": { "value": "{noordoostpolder.color.grey.70.value}" },
+      "color": { "value": "{noordoostpolder.color.grey.0}" },
+      "border-color": { "value": "{noordoostpolder.color.grey.70}" },
       "border-width": { "value": "1px" },
-      "font-family": { "value": "{noordoostpolder.typography.sans-serif.font-family.value}" },
+      "font-family": { "value": "{noordoostpolder.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "40px" },
       "padding-inline-start": { "value": "15px" },
@@ -17,7 +17,7 @@
         "color": {}
       },
       "focus": {
-        "border-color": { "value": "{noordoostpolder.color.grey.30.value}" }
+        "border-color": { "value": "{noordoostpolder.color.grey.30}" }
       }
     }
   }

--- a/proprietary/noordoostpolder-design-tokens/src/component/utrecht/heading-1.tokens.json
+++ b/proprietary/noordoostpolder-design-tokens/src/component/utrecht/heading-1.tokens.json
@@ -2,7 +2,7 @@
   "utrecht": {
     "heading-1": {
       "color": {
-        "value": "{noordoostpolder.color.grey.25.value}"
+        "value": "{noordoostpolder.color.grey.25}"
       },
       "font-size": {
         "value": "38px"

--- a/proprietary/noordoostpolder-design-tokens/src/component/utrecht/heading-2.tokens.json
+++ b/proprietary/noordoostpolder-design-tokens/src/component/utrecht/heading-2.tokens.json
@@ -2,7 +2,7 @@
   "utrecht": {
     "heading-2": {
       "color": {
-        "value": "{noordoostpolder.color.pink.50.value}"
+        "value": "{noordoostpolder.color.pink.50}"
       },
       "font-size": {
         "value": "25px"

--- a/proprietary/noordoostpolder-design-tokens/src/component/utrecht/heading-3.tokens.json
+++ b/proprietary/noordoostpolder-design-tokens/src/component/utrecht/heading-3.tokens.json
@@ -2,7 +2,7 @@
   "utrecht": {
     "heading-3": {
       "color": {
-        "value": "{noordoostpolder.color.grey.30.value}"
+        "value": "{noordoostpolder.color.grey.30}"
       },
       "font-size": {
         "value": "25px"

--- a/proprietary/noordoostpolder-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/noordoostpolder-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,17 +1,17 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{noordoostpolder.color.pink.50.value}" },
+      "color": { "value": "{noordoostpolder.color.pink.50}" },
       "text-decoration": { "value": "underline" },
       "active": {
         "color": {}
       },
       "focus": {
-        "color": { "value": "{noordoostpolder.color.pink.45.value}" },
+        "color": { "value": "{noordoostpolder.color.pink.45}" },
         "text-decoration": { "value": "none" }
       },
       "hover": {
-        "color": { "value": "{noordoostpolder.color.pink.45.value}" },
+        "color": { "value": "{noordoostpolder.color.pink.45}" },
         "text-decoration": { "value": "none" }
       },
       "visited": {

--- a/proprietary/noordoostpolder-design-tokens/src/component/utrecht/page-footer.tokens.json
+++ b/proprietary/noordoostpolder-design-tokens/src/component/utrecht/page-footer.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "page-footer": {
-      "background-color": { "value": "{noordoostpolder.color.green.30.value}" },
+      "background-color": { "value": "{noordoostpolder.color.green.30}" },
       "content": {
         "padding-block-start": { "value": "30px" },
         "padding-block-end": { "value": "50px" },

--- a/proprietary/noordoostpolder-design-tokens/src/component/utrecht/separator.tokens.json
+++ b/proprietary/noordoostpolder-design-tokens/src/component/utrecht/separator.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "separator": {
-      "color": { "value": "{utrecht.document.color.value}" },
+      "color": { "value": "{utrecht.document.color}" },
       "block-size": { "value": "1px" },
       "margin-block-end": { "value": "2em" },
       "margin-block-start": { "value": "2em" }

--- a/proprietary/noordoostpolder-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/noordoostpolder-design-tokens/src/component/utrecht/table.tokens.json
@@ -15,8 +15,8 @@
       "header": {
         "font-size": { "value": "18px" },
         "font-weight": { "value": "bold" },
-        "background-color": { "value": "{noordoostpolder.color.green.30.value}" },
-        "color": { "value": "{noordoostpolder.color.grey.100.value}" },
+        "background-color": { "value": "{noordoostpolder.color.green.30}" },
+        "color": { "value": "{noordoostpolder.color.grey.100}" },
         "text-transform": {},
         "border-block-end-color": {},
         "border-block-end-width": {}
@@ -35,7 +35,7 @@
         "border-color": {}
       },
       "row": {
-        "border-block-end-color": { "value": "{noordoostpolder.color.grey.85.value}" },
+        "border-block-end-color": { "value": "{noordoostpolder.color.grey.85}" },
         "border-block-end-width": { "value": "2px" },
         "padding-inline-end": {},
         "padding-inline-start": {},

--- a/proprietary/riddeliemers-design-tokens/src/components/utrecht/form-input.tokens.json
+++ b/proprietary/riddeliemers-design-tokens/src/components/utrecht/form-input.tokens.json
@@ -9,7 +9,7 @@
       "padding-inline-end": { "value": "15px" },
       "padding-inline-start": { "value": "15px" },
       "invalid": {
-        "border-color": { "value": "{utrecht.feedback.invalid.color.value}" }
+        "border-color": { "value": "{utrecht.feedback.invalid.color}" }
       }
     }
   }

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/badge-counter.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/badge-counter.tokens.json
@@ -2,13 +2,13 @@
   "utrecht": {
     "badge-counter": {
       "background-color": {
-        "value": "{rotterdam.color.green.30.value}"
+        "value": "{rotterdam.color.green.30}"
       },
       "border-radius": {
         "value": "3ex"
       },
       "color": {
-        "value": "{rotterdam.color.white.value}"
+        "value": "{rotterdam.color.white}"
       },
       "font-weight": {},
       "padding-block": {

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/badge.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/badge.tokens.json
@@ -2,22 +2,22 @@
   "utrecht": {
     "badge": {
       "background-color": {
-        "value": "{rotterdam.color.green.30.value}"
+        "value": "{rotterdam.color.green.30}"
       },
       "border-radius": {
         "value": "0"
       },
       "color": {
-        "value": "{rotterdam.color.white.value}"
+        "value": "{rotterdam.color.white}"
       },
       "font-weight": {
-        "value": "{rotterdam.typography.weight-scale.semi-bold.font-weight.value}"
+        "value": "{rotterdam.typography.weight-scale.semi-bold.font-weight}"
       },
       "padding-block": {
         "value": "6px"
       },
       "padding-inline": {
-        "value": "{utrecht.space.inline.md.value}"
+        "value": "{utrecht.space.inline.md}"
       }
     }
   }

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,23 +1,23 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{rotterdam.color.green.30.value}" },
+      "background-color": { "value": "{rotterdam.color.green.30}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{rotterdam.color.white.value}" },
-      "font-family": { "value": "{rotterdam.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{rotterdam.typography.scale.md.font-size.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "color": { "value": "{rotterdam.color.white}" },
+      "font-family": { "value": "{rotterdam.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{rotterdam.typography.scale.md.font-size}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
       "secondary-action": {
-        "background-color": { "value": "{rotterdam.color.green.30.value}" },
-        "color": { "value": "{rotterdam.color.white.value}" },
+        "background-color": { "value": "{rotterdam.color.green.30}" },
+        "color": { "value": "{rotterdam.color.white}" },
         "border-color": {},
         "border-width": {},
         "hover": {
@@ -26,7 +26,7 @@
         }
       },
       "focus": {
-        "border-color": { "value": "{rotterdam.color.grey.0.value}" },
+        "border-color": { "value": "{rotterdam.color.grey.0}" },
         "border-width": {},
         "transform-scale": {}
       }

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{rotterdam.color.white.value}" },
-      "color": { "value": "{rotterdam.color.grey.20.value}" },
-      "font-family": { "value": "{rotterdam.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{rotterdam.color.white}" },
+      "color": { "value": "{rotterdam.color.grey.20}" },
+      "font-family": { "value": "{rotterdam.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "22px" }
     }

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{rotterdam.color.grey.20.value}" },
-      "border-color": { "value": "{rotterdam.color.grey.20.value}" },
-      "font-family": { "value": "{rotterdam.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{rotterdam.color.grey.20}" },
+      "border-color": { "value": "{rotterdam.color.grey.20}" },
+      "font-family": { "value": "{rotterdam.typography.sans-serif.font-family}" },
       "line-height": { "value": "18px" },
       "placeholder": {
-        "color": { "value": "{rotterdam.color.grey.95.value}" }
+        "color": { "value": "{rotterdam.color.grey.95}" }
       },
       "focus": {
         "border-color": {}

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,17 +4,17 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{rotterdam.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{rotterdam.typography.weight-scale.normal.font-weight}" }
       },
       "checkbox-checked": {
         "font-weight": {
-          "value": "{rotterdam.typography.weight-scale.bold.font-weight.value}",
+          "value": "{rotterdam.typography.weight-scale.bold.font-weight}",
           "comment": "FIXME: new"
         }
       },
       "radio": {
-        "font-weight": { "value": "{rotterdam.typography.weight-scale.normal.font-weight.value}" },
-        "border-color": { "value": "{rotterdam.color.green.30.value}", "comment": "fix me new" }
+        "font-weight": { "value": "{rotterdam.typography.weight-scale.normal.font-weight}" },
+        "border-color": { "value": "{rotterdam.color.green.30}", "comment": "fix me new" }
       }
     }
   }

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{rotterdam.color.white.value}" },
+      "background-color": { "value": "{rotterdam.color.white}" },
       "border-color": {},
       "border-width": { "value": "1px" },
-      "color": { "value": "{rotterdam.color.grey.20.value}" },
+      "color": { "value": "{rotterdam.color.grey.20}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{rotterdam.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{rotterdam.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
       "color": {},

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{rotterdam.color.white.value}" },
+      "color": { "value": "{rotterdam.color.white}" },
       "text-decoration": { "value": "underline" },
       "active": {
         "color": {}
@@ -11,7 +11,7 @@
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{rotterdam.color.white.value}" },
+        "color": { "value": "{rotterdam.color.white}" },
         "text-decoration": {}
       },
       "visited": {

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": {},
-      "font-size": { "value": "{rotterdam.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{rotterdam.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{rotterdam.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{rotterdam.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "22px" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{rotterdam.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{rotterdam.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/table.tokens.json
@@ -14,10 +14,10 @@
       },
       "header": {
         "font-weight": { "value": "bold" },
-        "background-color": { "value": "{rotterdam.color.green.30.value}" },
-        "color": { "value": "{rotterdam.color.white.value}" },
+        "background-color": { "value": "{rotterdam.color.green.30}" },
+        "color": { "value": "{rotterdam.color.white}" },
         "text-transform": {},
-        "border-block-end-color": { "value": "{rotterdam.color.grey.95.value}" },
+        "border-block-end-color": { "value": "{rotterdam.color.grey.95}" },
         "border-block-end-width": { "value": "0.5px" }
       },
       "heading": {

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/textarea.tokens.json
@@ -2,20 +2,20 @@
   "utrecht": {
     "textarea": {
       "border-bottom-width": {},
-      "border-color": { "value": "{utrecht.textbox.border-color.value}" },
-      "border-radius": { "value": "{utrecht.textbox.border-radius.value}" },
-      "border-width": { "value": "{utrecht.textbox.border-width.value}" },
-      "background-color": { "value": "{rotterdam.color.white.value}", "comment": "fix me new" },
-      "color": { "value": "{utrecht.textbox.color.value}" },
-      "font-family": { "value": "{utrecht.textbox.font-family.value}" },
-      "font-size": { "value": "{utrecht.textbox.font-size.value}" },
-      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size.value}" },
-      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size.value}" },
+      "border-color": { "value": "{utrecht.textbox.border-color}" },
+      "border-radius": { "value": "{utrecht.textbox.border-radius}" },
+      "border-width": { "value": "{utrecht.textbox.border-width}" },
+      "background-color": { "value": "{rotterdam.color.white}", "comment": "fix me new" },
+      "color": { "value": "{utrecht.textbox.color}" },
+      "font-family": { "value": "{utrecht.textbox.font-family}" },
+      "font-size": { "value": "{utrecht.textbox.font-size}" },
+      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size}" },
+      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size}" },
       "min-block-size": { "value": "95px" },
-      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end.value}" },
-      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start.value}" },
-      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end.value}" },
-      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start.value}" }
+      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end}" },
+      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start}" },
+      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end}" },
+      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start}" }
     }
   }
 }

--- a/proprietary/rotterdam-design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/rotterdam-design-tokens/src/component/utrecht/textbox.tokens.json
@@ -2,19 +2,19 @@
   "utrecht": {
     "textbox": {
       "border-bottom-width": { "value": "1px" },
-      "border-color": { "value": "{utrecht.form-input.border-color.value}" },
+      "border-color": { "value": "{utrecht.form-input.border-color}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "1px" },
-      "background-color": { "value": "{rotterdam.color.white.value}" },
-      "color": { "value": "{utrecht.form-input.color.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
+      "background-color": { "value": "{rotterdam.color.white}" },
+      "color": { "value": "{utrecht.form-input.color}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
       "font-size": { "value": "16px" },
       "min-inline-size": { "value": "70px" },
       "max-inline-size": { "value": "620px" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xs}" },
       "disabled": {
         "border-color": {},
         "color": {}

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,28 +1,28 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{stedebroec.color.green.40.value}" },
+      "background-color": { "value": "{stedebroec.color.green.40}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{stedebroec.color.white.value}" },
-      "font-family": { "value": "{stedebroec.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{stedebroec.typography.scale.md.font-size.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "color": { "value": "{stedebroec.color.white}" },
+      "font-family": { "value": "{stedebroec.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{stedebroec.typography.scale.md.font-size}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
       "hover": {
-        "background-color": { "value": "{stedebroec.color.green.25.value}" },
+        "background-color": { "value": "{stedebroec.color.green.25}" },
         "color": {},
         "border-color": {}
       },
       "secondary-action": {
-        "background-color": { "value": "{stedebroec.color.green.40.value}" },
-        "color": { "value": "{stedebroec.color.white.value}" },
+        "background-color": { "value": "{stedebroec.color.green.40}" },
+        "color": { "value": "{stedebroec.color.white}" },
         "border-color": {},
         "border-width": {},
         "hover": {
@@ -31,7 +31,7 @@
         }
       },
       "focus": {
-        "border-color": { "value": "{stedebroec.color.grey.91.value}" },
+        "border-color": { "value": "{stedebroec.color.grey.91}" },
         "border-width": {},
         "transform-scale": {}
       }

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{stedebroec.color.grey.98.value}" },
-      "color": { "value": "{stedebroec.color.black.value}" },
-      "font-family": { "value": "{stedebroec.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{stedebroec.color.grey.98}" },
+      "color": { "value": "{stedebroec.color.black}" },
+      "font-family": { "value": "{stedebroec.typography.sans-serif.font-family}" },
       "font-size": { "value": "1em" },
       "line-height": { "value": "1.75" }
     }

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{stedebroec.color.grey.91.value}" },
-      "border-color": { "value": "{stedebroec.color.grey.91.value}" },
-      "font-family": { "value": "{stedebroec.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{stedebroec.color.grey.91}" },
+      "border-color": { "value": "{stedebroec.color.grey.91}" },
+      "font-family": { "value": "{stedebroec.typography.sans-serif.font-family}" },
       "line-height": { "value": "28px" },
       "placeholder": {
-        "color": { "value": "{stedebroec.color.grey.91.value}" }
+        "color": { "value": "{stedebroec.color.grey.91}" }
       },
       "focus": {
         "border-color": {}

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,16 +4,16 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{stedebroec.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{stedebroec.typography.weight-scale.normal.font-weight}" }
       },
       "checkbox-checked": {
         "font-weight": {
-          "value": "{stedebroec.typography.weight-scale.bold.font-weight.value}",
+          "value": "{stedebroec.typography.weight-scale.bold.font-weight}",
           "comment": "FIXME: new"
         }
       },
       "radio": {
-        "font-weight": { "value": "{stedebroec.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{stedebroec.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{stedebroec.color.white.value}" },
-      "border-color": { "value": "{stedebroec.color.grey.91.value}" },
+      "background-color": { "value": "{stedebroec.color.white}" },
+      "border-color": { "value": "{stedebroec.color.grey.91}" },
       "border-width": { "value": "0.5px" },
-      "color": { "value": "{stedebroec.color.grey.91.value}" },
+      "color": { "value": "{stedebroec.color.grey.91}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,10 +3,10 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{stedebroec.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{stedebroec.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
-      "color": { "value": "{stedebroec.color.green.25.value}" },
+      "color": { "value": "{stedebroec.color.green.25}" },
       "font-family": {},
       "font-size": { "value": "2.1em" },
       "font-weight": {},

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{stedebroec.color.green.25.value}" },
+      "color": { "value": "{stedebroec.color.green.25}" },
       "text-decoration": { "value": "underline" },
       "active": {
         "color": {}
@@ -11,7 +11,7 @@
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{stedebroec.color.black.value}" },
+        "color": { "value": "{stedebroec.color.black}" },
         "text-decoration": { "value": "underline" }
       },
       "visited": {

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": {},
-      "font-size": { "value": "{stedebroec.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{stedebroec.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{stedebroec.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{stedebroec.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "1.75" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{stedebroec.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{stedebroec.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/table.tokens.json
@@ -14,8 +14,8 @@
       },
       "header": {
         "font-weight": { "value": "bold" },
-        "background-color": { "value": "{stedebroec.color.green.40.value}", "comment": "FIXME new" },
-        "color": { "value": "{stedebroec.color.white.value}" },
+        "background-color": { "value": "{stedebroec.color.green.40}", "comment": "FIXME new" },
+        "color": { "value": "{stedebroec.color.white}" },
         "text-transform": {},
         "border-block-end-color": {},
         "border-block-end-width": {}

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/textarea.tokens.json
@@ -2,19 +2,19 @@
   "utrecht": {
     "textarea": {
       "border-bottom-width": {},
-      "border-color": { "value": "{utrecht.textbox.border-color.value}" },
-      "border-radius": { "value": "{utrecht.textbox.border-radius.value}" },
-      "border-width": { "value": "{utrecht.textbox.border-width.value}" },
-      "color": { "value": "{utrecht.textbox.color.value}" },
-      "font-family": { "value": "{utrecht.textbox.font-family.value}" },
-      "font-size": { "value": "{utrecht.textbox.font-size.value}" },
-      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size.value}" },
-      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size.value}" },
+      "border-color": { "value": "{utrecht.textbox.border-color}" },
+      "border-radius": { "value": "{utrecht.textbox.border-radius}" },
+      "border-width": { "value": "{utrecht.textbox.border-width}" },
+      "color": { "value": "{utrecht.textbox.color}" },
+      "font-family": { "value": "{utrecht.textbox.font-family}" },
+      "font-size": { "value": "{utrecht.textbox.font-size}" },
+      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size}" },
+      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size}" },
       "min-block-size": { "value": "95px" },
-      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end.value}" },
-      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start.value}" },
-      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end.value}" },
-      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start.value}" }
+      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end}" },
+      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start}" },
+      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end}" },
+      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start}" }
     }
   }
 }

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/textbox.tokens.json
@@ -2,18 +2,18 @@
   "utrecht": {
     "textbox": {
       "border-bottom-width": { "value": "1px" },
-      "border-color": { "value": "{utrecht.form-input.border-color.value}" },
+      "border-color": { "value": "{utrecht.form-input.border-color}" },
       "border-radius": { "value": "2px" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{utrecht.form-input.color.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
-      "font-size": { "value": "{stedebroec.typography.scale.md.font-size.value}" },
+      "color": { "value": "{utrecht.form-input.color}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
+      "font-size": { "value": "{stedebroec.typography.scale.md.font-size}" },
       "min-inline-size": { "value": "70px" },
       "max-inline-size": { "value": "620px" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xs}" },
       "disabled": {
         "border-color": {},
         "color": {}

--- a/proprietary/stedebroec-design-tokens/src/component/utrecht/unordered-list.tokens.json
+++ b/proprietary/stedebroec-design-tokens/src/component/utrecht/unordered-list.tokens.json
@@ -9,7 +9,7 @@
         "margin-block-end": { "value": "8px" }
       },
       "marker": {
-        "color": { "value": "{stedebroec.color.black.value}" },
+        "color": { "value": "{stedebroec.color.black}" },
         "content": { "value": "■", "comment": "FIXME new" }
       }
     }

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/badge-counter.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/badge-counter.tokens.json
@@ -2,13 +2,13 @@
   "utrecht": {
     "badge-counter": {
       "background-color": {
-        "value": "{tilburg.color.green.20.value}"
+        "value": "{tilburg.color.green.20}"
       },
       "border-radius": {
         "value": "3ex"
       },
       "color": {
-        "value": "{tilburg.color.grey.100.value}"
+        "value": "{tilburg.color.grey.100}"
       },
       "font-weight": {},
       "padding-block": {

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/badge.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/badge.tokens.json
@@ -2,22 +2,22 @@
   "utrecht": {
     "badge": {
       "background-color": {
-        "value": "{tilburg.color.green.20.value}"
+        "value": "{tilburg.color.green.20}"
       },
       "border-radius": {
         "value": "0"
       },
       "color": {
-        "value": "{tilburg.color.grey.100.value}"
+        "value": "{tilburg.color.grey.100}"
       },
       "font-weight": {
-        "value": "{tilburg.typography.weight-scale.semi-bold.font-weight.value}"
+        "value": "{tilburg.typography.weight-scale.semi-bold.font-weight}"
       },
       "padding-block": {
         "value": "6px"
       },
       "padding-inline": {
-        "value": "{utrecht.space.inline.md.value}"
+        "value": "{utrecht.space.inline.md}"
       }
     }
   }

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,28 +1,28 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{tilburg.color.grey.40.value}" },
+      "background-color": { "value": "{tilburg.color.grey.40}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{tilburg.color.grey.100.value}" },
-      "font-family": { "value": "{tilburg.typography.heading.font-family.value}" },
-      "font-size": { "value": "{tilburg.typography.scale.md.font-size.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "color": { "value": "{tilburg.color.grey.100}" },
+      "font-family": { "value": "{tilburg.typography.heading.font-family}" },
+      "font-size": { "value": "{tilburg.typography.scale.md.font-size}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
       "text-transform": { "value": "uppercase" },
       "primary-action": {
-        "background-color": { "value": "{tilburg.color.orange.50.value}" },
-        "color": { "value": "{tilburg.color.grey.100.value}" }
+        "background-color": { "value": "{tilburg.color.orange.50}" },
+        "color": { "value": "{tilburg.color.grey.100}" }
       },
       "secondary-action": {
-        "background-color": { "value": "{tilburg.color.blue.20b.value}" },
-        "color": { "value": "{tilburg.color.grey.100.value}" },
+        "background-color": { "value": "{tilburg.color.blue.20b}" },
+        "color": { "value": "{tilburg.color.grey.100}" },
         "border-color": {},
         "border-width": {},
         "hover": {
@@ -31,14 +31,14 @@
         }
       },
       "focus": {
-        "background-color": { "value": "{tilburg.color.green.20.value}" },
-        "color": { "value": "{tilburg.color.grey.100.value}" },
+        "background-color": { "value": "{tilburg.color.green.20}" },
+        "color": { "value": "{tilburg.color.grey.100}" },
         "border-width": {},
         "transform-scale": {}
       },
       "disabled": {
-        "background-color": { "value": "{tilburg.color.grey.80.value}" },
-        "color": { "value": "{tilburg.color.grey.100.value}" }
+        "background-color": { "value": "{tilburg.color.grey.80}" },
+        "color": { "value": "{tilburg.color.grey.100}" }
       }
     }
   }

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{tilburg.color.grey.100.value}" },
-      "color": { "value": "{tilburg.color.grey.0.value}" },
-      "font-family": { "value": "{tilburg.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{tilburg.color.grey.100}" },
+      "color": { "value": "{tilburg.color.grey.0}" },
+      "font-family": { "value": "{tilburg.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "22px" }
     }

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/form-fieldset.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/form-fieldset.tokens.json
@@ -2,8 +2,8 @@
   "utrecht": {
     "form-fieldset": {
       "legend": {
-        "color": { "value": "{tilburg.color.blue.30b.value}" },
-        "font-family": { "value": "{tilburg.typography.heading.font-family.value}" },
+        "color": { "value": "{tilburg.color.blue.30b}" },
+        "font-family": { "value": "{tilburg.typography.heading.font-family}" },
         "font-size": { "value": "24.48px" },
         "font-weight": { "value": "400" },
         "line-height": { "value": "1.2em" },

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,7 +2,7 @@
   "utrecht": {
     "form-input": {
       "invalid": {
-        "border-color": { "value": "{tilburg.color.warning.40.value}" },
+        "border-color": { "value": "{tilburg.color.warning.40}" },
         "border-width": { "value": "2px" }
       }
     }

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{tilburg.color.grey.20.value}" },
-      "border-color": { "value": "{tilburg.color.grey.40.value}" },
+      "background-color": { "value": "{tilburg.color.grey.20}" },
+      "border-color": { "value": "{tilburg.color.grey.40}" },
       "border-width": { "value": "0.1px" },
-      "color": { "value": "{tilburg.color.grey.80.value}" },
+      "color": { "value": "{tilburg.color.grey.80}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{tilburg.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{tilburg.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
       "color": {},

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,13 +1,13 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{tilburg.color.pink.40.value}" },
+      "color": { "value": "{tilburg.color.pink.40}" },
       "text-decoration": { "value": "underline" },
       "focus": {
-        "color": { "value": "{tilburg.color.blue.40.value}" }
+        "color": { "value": "{tilburg.color.blue.40}" }
       },
       "hover": {
-        "color": { "value": "{tilburg.color.blue.40.value}" }
+        "color": { "value": "{tilburg.color.blue.40}" }
       }
     }
   }

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -3,12 +3,12 @@
     "paragraph": {
       "font-family": {},
       "font-size": { "value": "14.4px" },
-      "font-weight": { "value": "{tilburg.typography.weight-scale.normal.font-weight.value}" },
+      "font-weight": { "value": "{tilburg.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "22px" },
       "margin-block-start": {},
       "margin-block-end": { "value": "24.5px" },
       "lead": {
-        "color": { "value": "{tilburg.color.blue.40.value}" },
+        "color": { "value": "{tilburg.color.blue.40}" },
         "font-size": { "value": "1.7em" },
         "font-weight": { "value": "400" },
         "line-height": { "value": "34px" },

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/separator.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/separator.tokens.json
@@ -2,7 +2,7 @@
   "utrecht": {
     "separator": {
       "block-size": { "value": "10px" },
-      "color": { "value": "{tilburg.color.grey.0.value}" },
+      "color": { "value": "{tilburg.color.grey.0}" },
       "margin-block-end": { "value": "40px" },
       "margin-block-start": { "value": "40px" }
     }

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/table.tokens.json
@@ -14,10 +14,10 @@
       },
       "header": {
         "font-weight": { "value": "bold" },
-        "background-color": { "value": "{tilburg.color.grey.20.value}" },
+        "background-color": { "value": "{tilburg.color.grey.20}" },
         "color": {},
         "text-transform": {},
-        "border-block-end-color": { "value": "{tilburg.color.grey.80.value}" },
+        "border-block-end-color": { "value": "{tilburg.color.grey.80}" },
         "border-block-end-width": { "value": "0.5px" }
       },
       "heading": {
@@ -31,11 +31,11 @@
         "padding-block-start": { "value": "15px" },
         "padding-inline-end": { "value": "6px" },
         "padding-inline-start": { "value": "6px" },
-        "border-color": { "value": "{tilburg.color.grey.0.value}", "comment": "FIXME new" },
+        "border-color": { "value": "{tilburg.color.grey.0}", "comment": "FIXME new" },
         "border-width": { "value": "0.5px", "comment": "FIXME new" }
       },
       "row": {
-        "border-block-end-color": { "value": "{tilburg.color.grey.80.value}" },
+        "border-block-end-color": { "value": "{tilburg.color.grey.80}" },
         "border-block-end-width": {},
         "padding-inline-end": {},
         "padding-inline-start": {},

--- a/proprietary/tilburg-design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/tilburg-design-tokens/src/component/utrecht/textbox.tokens.json
@@ -2,18 +2,18 @@
   "utrecht": {
     "textbox": {
       "border-bottom-width": { "value": "0.5px" },
-      "border-color": { "value": "{tilburg.color.grey.80.value}" },
+      "border-color": { "value": "{tilburg.color.grey.80}" },
       "border-radius": { "value": "3px" },
       "border-width": { "value": "1px" },
       "color": {},
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
-      "font-size": { "value": "{tilburg.typography.scale.md.font-size.value}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
+      "font-size": { "value": "{tilburg.typography.scale.md.font-size}" },
       "min-inline-size": { "value": "70px" },
       "max-inline-size": { "value": "620px" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xs}" },
       "disabled": {
         "border-color": {},
         "color": {}

--- a/proprietary/venray-design-tokens/src/component/utrecht/badge-counter.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/badge-counter.tokens.json
@@ -2,13 +2,13 @@
   "utrecht": {
     "badge-counter": {
       "background-color": {
-        "value": "{zwolle.color.blue.40.value}"
+        "value": "{zwolle.color.blue.40}"
       },
       "border-radius": {
         "value": "3ex"
       },
       "color": {
-        "value": "{zwolle.color.white.value}"
+        "value": "{zwolle.color.white}"
       },
       "font-weight": {},
       "padding-block": {

--- a/proprietary/venray-design-tokens/src/component/utrecht/badge.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/badge.tokens.json
@@ -2,13 +2,13 @@
   "utrecht": {
     "badge": {
       "background-color": {
-        "value": "{zwolle.color.blue.40.value}"
+        "value": "{zwolle.color.blue.40}"
       },
       "border-radius": {
         "value": "0"
       },
       "color": {
-        "value": "{zwolle.color.white.value}"
+        "value": "{zwolle.color.white}"
       },
       "font-weight": {
         "value": "700"
@@ -17,7 +17,7 @@
         "value": "6px"
       },
       "padding-inline": {
-        "value": "{utrecht.space.inline.md.value}"
+        "value": "{utrecht.space.inline.md}"
       }
     }
   }

--- a/proprietary/venray-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,23 +1,23 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{zwolle.color.blue.50.value}" },
+      "background-color": { "value": "{zwolle.color.blue.50}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{zwolle.color.white.value}" },
-      "font-family": { "value": "{zwolle.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{zwolle.typography.scale.md.font-size.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "color": { "value": "{zwolle.color.white}" },
+      "font-family": { "value": "{zwolle.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{zwolle.typography.scale.md.font-size}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
       "secondary-action": {
-        "background-color": { "value": "{zwolle.color.blue.50.value}" },
-        "color": { "value": "{zwolle.color.white.value}" },
+        "background-color": { "value": "{zwolle.color.blue.50}" },
+        "color": { "value": "{zwolle.color.white}" },
         "border-color": {},
         "border-width": {},
         "hover": {
@@ -26,7 +26,7 @@
         }
       },
       "focus": {
-        "border-color": { "value": "{zwolle.color.black.value}" },
+        "border-color": { "value": "{zwolle.color.black}" },
         "border-width": {},
         "transform-scale": {}
       }

--- a/proprietary/venray-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{zwolle.color.white.value}" },
-      "color": { "value": "{zwolle.color.black.value}" },
-      "font-family": { "value": "{zwolle.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{zwolle.color.white}" },
+      "color": { "value": "{zwolle.color.black}" },
+      "font-family": { "value": "{zwolle.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "22px" }
     }

--- a/proprietary/venray-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/venray-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{zwolle.color.black.value}" },
-      "border-color": { "value": "{zwolle.color.black.value}" },
-      "font-family": { "value": "{zwolle.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{zwolle.color.black}" },
+      "border-color": { "value": "{zwolle.color.black}" },
+      "font-family": { "value": "{zwolle.typography.sans-serif.font-family}" },
       "line-height": { "value": "18px" },
       "placeholder": {
-        "color": { "value": "{zwolle.color.blue.50.value}" }
+        "color": { "value": "{zwolle.color.blue.50}" }
       },
       "focus": {
         "border-color": {}

--- a/proprietary/venray-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,7 +4,7 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight}" }
       },
       "checkbox-checked": {
         "font-weight": {
@@ -12,7 +12,7 @@
         }
       },
       "radio": {
-        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/venray-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{zwolle.color.white.value}" },
-      "border-color": { "value": "{zwolle.color.black.value}" },
+      "background-color": { "value": "{zwolle.color.white}" },
+      "border-color": { "value": "{zwolle.color.black}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{zwolle.color.black.value}" },
+      "color": { "value": "{zwolle.color.black}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/venray-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{zwolle.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{zwolle.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
       "color": {},

--- a/proprietary/venray-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,17 +1,17 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{venray.color.green.40.value}" },
+      "color": { "value": "{venray.color.green.40}" },
       "text-decoration": { "value": "underline" },
       "active": {
         "color": {}
       },
       "focus": {
-        "color": { "value": "{venray.color.green.30.value}" },
+        "color": { "value": "{venray.color.green.30}" },
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{venray.color.green.30.value}" },
+        "color": { "value": "{venray.color.green.30}" },
         "text-decoration": {}
       },
       "visited": {

--- a/proprietary/venray-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": {},
-      "font-size": { "value": "{zwolle.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{zwolle.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "22px" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{zwolle.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{zwolle.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/venray-design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/textarea.tokens.json
@@ -2,19 +2,19 @@
   "utrecht": {
     "textarea": {
       "border-bottom-width": {},
-      "border-color": { "value": "{utrecht.textbox.border-color.value}" },
-      "border-radius": { "value": "{utrecht.textbox.border-radius.value}" },
-      "border-width": { "value": "{utrecht.textbox.border-width.value}" },
-      "color": { "value": "{utrecht.textbox.color.value}" },
-      "font-family": { "value": "{utrecht.textbox.font-family.value}" },
-      "font-size": { "value": "{utrecht.textbox.font-size.value}" },
-      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size.value}" },
-      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size.value}" },
+      "border-color": { "value": "{utrecht.textbox.border-color}" },
+      "border-radius": { "value": "{utrecht.textbox.border-radius}" },
+      "border-width": { "value": "{utrecht.textbox.border-width}" },
+      "color": { "value": "{utrecht.textbox.color}" },
+      "font-family": { "value": "{utrecht.textbox.font-family}" },
+      "font-size": { "value": "{utrecht.textbox.font-size}" },
+      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size}" },
+      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size}" },
       "min-block-size": { "value": "95px" },
-      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end.value}" },
-      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start.value}" },
-      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end.value}" },
-      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start.value}" }
+      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end}" },
+      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start}" },
+      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end}" },
+      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start}" }
     }
   }
 }

--- a/proprietary/venray-design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/textbox.tokens.json
@@ -2,18 +2,18 @@
   "utrecht": {
     "textbox": {
       "border-bottom-width": { "value": "1px" },
-      "border-color": { "value": "{utrecht.form-input.border-color.value}" },
+      "border-color": { "value": "{utrecht.form-input.border-color}" },
       "border-radius": { "value": "2px" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{utrecht.form-input.color.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
-      "font-size": { "value": "{zwolle.typography.scale.md.font-size.value}" },
+      "color": { "value": "{utrecht.form-input.color}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
+      "font-size": { "value": "{zwolle.typography.scale.md.font-size}" },
       "min-inline-size": { "value": "70px" },
       "max-inline-size": { "value": "620px" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xs}" },
       "disabled": {
         "border-color": {},
         "color": {}

--- a/proprietary/venray-design-tokens/src/component/utrecht/unordered-list.tokens.json
+++ b/proprietary/venray-design-tokens/src/component/utrecht/unordered-list.tokens.json
@@ -9,7 +9,7 @@
         "margin-block-end": { "value": "8px" }
       },
       "marker": {
-        "color": { "value": "{venray.color.red.40.value}" },
+        "color": { "value": "{venray.color.red.40}" },
         "content": {}
       }
     }

--- a/proprietary/vught-design-tokens/src/component/utrecht/badge-counter.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/badge-counter.tokens.json
@@ -2,13 +2,13 @@
   "utrecht": {
     "badge-counter": {
       "background-color": {
-        "value": "{zwolle.color.blue.40.value}"
+        "value": "{zwolle.color.blue.40}"
       },
       "border-radius": {
         "value": "3ex"
       },
       "color": {
-        "value": "{zwolle.color.white.value}"
+        "value": "{zwolle.color.white}"
       },
       "font-weight": {},
       "padding-block": {

--- a/proprietary/vught-design-tokens/src/component/utrecht/badge.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/badge.tokens.json
@@ -2,13 +2,13 @@
   "utrecht": {
     "badge": {
       "background-color": {
-        "value": "{zwolle.color.blue.40.value}"
+        "value": "{zwolle.color.blue.40}"
       },
       "border-radius": {
         "value": "0"
       },
       "color": {
-        "value": "{zwolle.color.white.value}"
+        "value": "{zwolle.color.white}"
       },
       "font-weight": {
         "value": "700"
@@ -17,7 +17,7 @@
         "value": "6px"
       },
       "padding-inline": {
-        "value": "{utrecht.space.inline.md.value}"
+        "value": "{utrecht.space.inline.md}"
       }
     }
   }

--- a/proprietary/vught-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,23 +1,23 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{zwolle.color.blue.50.value}" },
+      "background-color": { "value": "{zwolle.color.blue.50}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{zwolle.color.white.value}" },
-      "font-family": { "value": "{zwolle.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{zwolle.typography.scale.md.font-size.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "color": { "value": "{zwolle.color.white}" },
+      "font-family": { "value": "{zwolle.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{zwolle.typography.scale.md.font-size}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
       "secondary-action": {
-        "background-color": { "value": "{zwolle.color.blue.50.value}" },
-        "color": { "value": "{zwolle.color.white.value}" },
+        "background-color": { "value": "{zwolle.color.blue.50}" },
+        "color": { "value": "{zwolle.color.white}" },
         "border-color": {},
         "border-width": {},
         "hover": {
@@ -26,7 +26,7 @@
         }
       },
       "focus": {
-        "border-color": { "value": "{zwolle.color.black.value}" },
+        "border-color": { "value": "{zwolle.color.black}" },
         "border-width": {},
         "transform-scale": {}
       }

--- a/proprietary/vught-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{zwolle.color.white.value}" },
-      "color": { "value": "{zwolle.color.black.value}" },
-      "font-family": { "value": "{zwolle.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{zwolle.color.white}" },
+      "color": { "value": "{zwolle.color.black}" },
+      "font-family": { "value": "{zwolle.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "22px" }
     }

--- a/proprietary/vught-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/vught-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{zwolle.color.black.value}" },
-      "border-color": { "value": "{zwolle.color.black.value}" },
-      "font-family": { "value": "{zwolle.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{zwolle.color.black}" },
+      "border-color": { "value": "{zwolle.color.black}" },
+      "font-family": { "value": "{zwolle.typography.sans-serif.font-family}" },
       "line-height": { "value": "18px" },
       "placeholder": {
-        "color": { "value": "{zwolle.color.blue.50.value}" }
+        "color": { "value": "{zwolle.color.blue.50}" }
       },
       "focus": {
         "border-color": {}

--- a/proprietary/vught-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,7 +4,7 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight}" }
       },
       "checkbox-checked": {
         "font-weight": {
@@ -12,7 +12,7 @@
         }
       },
       "radio": {
-        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/vught-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{zwolle.color.white.value}" },
-      "border-color": { "value": "{zwolle.color.black.value}" },
+      "background-color": { "value": "{zwolle.color.white}" },
+      "border-color": { "value": "{zwolle.color.black}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{zwolle.color.black.value}" },
+      "color": { "value": "{zwolle.color.black}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/vught-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{zwolle.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{zwolle.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
       "color": {},

--- a/proprietary/vught-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,17 +1,17 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{vught.color.blue.30.value}" },
+      "color": { "value": "{vught.color.blue.30}" },
       "text-decoration": { "value": "underline" },
       "active": {
         "color": {}
       },
       "focus": {
-        "color": { "value": "{vught.color.blue.15.value}" },
+        "color": { "value": "{vught.color.blue.15}" },
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{vught.color.blue.15.value}" },
+        "color": { "value": "{vught.color.blue.15}" },
         "text-decoration": {}
       },
       "visited": {

--- a/proprietary/vught-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": {},
-      "font-size": { "value": "{zwolle.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{zwolle.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "22px" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{zwolle.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{zwolle.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/vught-design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/textarea.tokens.json
@@ -2,19 +2,19 @@
   "utrecht": {
     "textarea": {
       "border-bottom-width": {},
-      "border-color": { "value": "{utrecht.textbox.border-color.value}" },
-      "border-radius": { "value": "{utrecht.textbox.border-radius.value}" },
-      "border-width": { "value": "{utrecht.textbox.border-width.value}" },
-      "color": { "value": "{utrecht.textbox.color.value}" },
-      "font-family": { "value": "{utrecht.textbox.font-family.value}" },
-      "font-size": { "value": "{utrecht.textbox.font-size.value}" },
-      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size.value}" },
-      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size.value}" },
+      "border-color": { "value": "{utrecht.textbox.border-color}" },
+      "border-radius": { "value": "{utrecht.textbox.border-radius}" },
+      "border-width": { "value": "{utrecht.textbox.border-width}" },
+      "color": { "value": "{utrecht.textbox.color}" },
+      "font-family": { "value": "{utrecht.textbox.font-family}" },
+      "font-size": { "value": "{utrecht.textbox.font-size}" },
+      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size}" },
+      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size}" },
       "min-block-size": { "value": "95px" },
-      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end.value}" },
-      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start.value}" },
-      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end.value}" },
-      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start.value}" }
+      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end}" },
+      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start}" },
+      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end}" },
+      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start}" }
     }
   }
 }

--- a/proprietary/vught-design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/textbox.tokens.json
@@ -2,18 +2,18 @@
   "utrecht": {
     "textbox": {
       "border-bottom-width": { "value": "1px" },
-      "border-color": { "value": "{utrecht.form-input.border-color.value}" },
+      "border-color": { "value": "{utrecht.form-input.border-color}" },
       "border-radius": { "value": "2px" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{utrecht.form-input.color.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
-      "font-size": { "value": "{zwolle.typography.scale.md.font-size.value}" },
+      "color": { "value": "{utrecht.form-input.color}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
+      "font-size": { "value": "{zwolle.typography.scale.md.font-size}" },
       "min-inline-size": { "value": "70px" },
       "max-inline-size": { "value": "620px" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xs}" },
       "disabled": {
         "border-color": {},
         "color": {}

--- a/proprietary/vught-design-tokens/src/component/utrecht/unordered-list.tokens.json
+++ b/proprietary/vught-design-tokens/src/component/utrecht/unordered-list.tokens.json
@@ -9,7 +9,7 @@
         "margin-block-end": { "value": "8px" }
       },
       "marker": {
-        "color": { "value": "{vught.color.green2.30.value}" },
+        "color": { "value": "{vught.color.green2.30}" },
         "content": { "value": "■", "comment": "FIXME new" }
       }
     }

--- a/proprietary/westervoort-design-tokens/src/component/utrecht/blockquote.tokens.json
+++ b/proprietary/westervoort-design-tokens/src/component/utrecht/blockquote.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "blockquote": {
-      "border-color": { "value": "{westervoort.color.green.45.value}" },
+      "border-color": { "value": "{westervoort.color.green.45}" },
       "border-inline-start-width": { "value": "3px" }
     }
   }

--- a/proprietary/westervoort-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/westervoort-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,17 +1,17 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{westervoort.color.blue.20.value}" },
-      "color": { "value": "{westervoort.color.white.value}" },
-      "font-family": { "value": "{westervoort.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{westervoort.color.blue.20}" },
+      "color": { "value": "{westervoort.color.white}" },
+      "font-family": { "value": "{westervoort.typography.sans-serif.font-family}" },
       "hover": {
-        "background-color": { "value": "{westervoort.color.black.value}" },
-        "color": { "value": "{westervoort.color.white.value}" },
+        "background-color": { "value": "{westervoort.color.black}" },
+        "color": { "value": "{westervoort.color.white}" },
         "text-decoration": { "value": "underline", "comment": "fix me new" }
       },
       "focus": {
-        "background-color": { "value": "{westervoort.color.black.value}" },
-        "color": { "value": "{westervoort.color.white.value}" },
+        "background-color": { "value": "{westervoort.color.black}" },
+        "color": { "value": "{westervoort.color.white}" },
         "text-decoration": { "value": "underline", "comment": "fix me new" }
       }
     }

--- a/proprietary/westervoort-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/westervoort-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{westervoort.color.white.value}" },
-      "color": { "value": "{westervoort.color.black.value}" },
-      "font-family": { "value": "{westervoort.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{westervoort.color.white}" },
+      "color": { "value": "{westervoort.color.black}" },
+      "font-family": { "value": "{westervoort.typography.sans-serif.font-family}" },
       "font-size": { "value": "18px" },
       "line-height": {}
     }

--- a/proprietary/westervoort-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/westervoort-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -1,11 +1,11 @@
 {
   "utrecht": {
     "form-input": {
-      "color": { "value": "{westervoort.color.black.value}" },
-      "border-color": { "value": "{westervoort.color.blue.50.value}" },
-      "font-family": { "value": "{westervoort.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{westervoort.color.black}" },
+      "border-color": { "value": "{westervoort.color.blue.50}" },
+      "font-family": { "value": "{westervoort.typography.sans-serif.font-family}" },
       "focus": {
-        "border-color": { "value": "{westervoort.color.blue.20.value}" }
+        "border-color": { "value": "{westervoort.color.blue.20}" }
       }
     }
   }

--- a/proprietary/westervoort-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/westervoort-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,16 +4,16 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{westervoort.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{westervoort.typography.weight-scale.normal.font-weight}" }
       },
       "checkbox-checked": {
         "font-weight": {
-          "value": "{westervoort.typography.weight-scale.bold.font-weight.value}",
+          "value": "{westervoort.typography.weight-scale.bold.font-weight}",
           "comment": "FIXME: new"
         }
       },
       "radio": {
-        "font-weight": { "value": "{westervoort.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{westervoort.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/westervoort-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/westervoort-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{westervoort.color.white.value}" },
-      "border-color": { "value": "{westervoort.color.black.value}" },
-      "color": { "value": "{westervoort.color.grey.71.value}" }
+      "background-color": { "value": "{westervoort.color.white}" },
+      "border-color": { "value": "{westervoort.color.black}" },
+      "color": { "value": "{westervoort.color.grey.71}" }
     }
   }
 }

--- a/proprietary/westervoort-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/westervoort-design-tokens/src/component/utrecht/heading.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading": {
-      "color": { "value": "{westervoort.color.blue.20.value}" }
+      "color": { "value": "{westervoort.color.blue.20}" }
     }
   }
 }

--- a/proprietary/westervoort-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/westervoort-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,12 +1,12 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{westervoort.color.blue.30.value}" },
+      "color": { "value": "{westervoort.color.blue.30}" },
       "focus": {
-        "color": { "value": "{westervoort.color.black.value}" }
+        "color": { "value": "{westervoort.color.black}" }
       },
       "hover": {
-        "color": { "value": "{westervoort.color.black.value}" }
+        "color": { "value": "{westervoort.color.black}" }
       }
     }
   }

--- a/proprietary/westervoort-design-tokens/src/component/utrecht/page-footer.tokens.json
+++ b/proprietary/westervoort-design-tokens/src/component/utrecht/page-footer.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "page-footer": {
-      "background-color": { "value": "{westervoort.color.green.20.value}" },
-      "color": { "value": "{westervoort.color.grey.100.value}" }
+      "background-color": { "value": "{westervoort.color.green.20}" },
+      "color": { "value": "{westervoort.color.grey.100}" }
     }
   }
 }

--- a/proprietary/westervoort-design-tokens/src/component/utrecht/page-header.tokens.json
+++ b/proprietary/westervoort-design-tokens/src/component/utrecht/page-header.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "page-header": {
-      "background-color": { "value": "{westervoort.color.blue.50.value}" },
-      "color": { "value": "{westervoort.color.white.value}" }
+      "background-color": { "value": "{westervoort.color.blue.50}" },
+      "color": { "value": "{westervoort.color.white}" }
     }
   }
 }

--- a/proprietary/westervoort-design-tokens/src/component/utrecht/separator.tokens.json
+++ b/proprietary/westervoort-design-tokens/src/component/utrecht/separator.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "separator": {
-      "color": { "value": "{westervoort.color.green.45.value}" }
+      "color": { "value": "{westervoort.color.green.45}" }
     }
   }
 }

--- a/proprietary/westervoort-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/westervoort-design-tokens/src/component/utrecht/table.tokens.json
@@ -14,8 +14,8 @@
       },
       "header": {
         "font-weight": { "value": "bold" },
-        "background-color": { "value": "{westervoort.color.white.value}", "comment": "FIXME new" },
-        "color": { "value": "{westervoort.color.black.value}" },
+        "background-color": { "value": "{westervoort.color.white}", "comment": "FIXME new" },
+        "color": { "value": "{westervoort.color.black}" },
         "text-transform": {},
         "border-block-end-color": {},
         "border-block-end-width": {}

--- a/proprietary/zevenaar-design-tokens/src/component/utrecht/blockquote.tokens.json
+++ b/proprietary/zevenaar-design-tokens/src/component/utrecht/blockquote.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "blockquote": {
-      "border-color": { "value": "{zevenaar.color.yellow.88.value}" },
+      "border-color": { "value": "{zevenaar.color.yellow.88}" },
       "border-inline-start-width": { "value": "8px" }
     }
   }

--- a/proprietary/zevenaar-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/zevenaar-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,14 +1,14 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{zevenaar.color.grey.25.value}" },
-      "border-color": { "value": "{zevenaar.color.grey.25.value}" },
+      "background-color": { "value": "{zevenaar.color.grey.25}" },
+      "border-color": { "value": "{zevenaar.color.grey.25}" },
       "border-width": { "value": "2px" },
-      "color": { "value": "{zevenaar.color.white.value}" },
-      "font-family": { "value": "{zevenaar.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{zevenaar.color.white}" },
+      "font-family": { "value": "{zevenaar.typography.sans-serif.font-family}" },
       "focus": {
-        "background-color": { "value": "{zevenaar.color.white.value}" },
-        "color": { "value": "{zevenaar.color.grey.25.value}" }
+        "background-color": { "value": "{zevenaar.color.white}" },
+        "color": { "value": "{zevenaar.color.grey.25}" }
       }
     }
   }

--- a/proprietary/zevenaar-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/zevenaar-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{zevenaar.color.white.value}" },
-      "color": { "value": "{zevenaar.color.black.value}" },
-      "font-family": { "value": "{zevenaar.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{zevenaar.color.white}" },
+      "color": { "value": "{zevenaar.color.black}" },
+      "font-family": { "value": "{zevenaar.typography.sans-serif.font-family}" },
       "font-size": { "value": "18px" },
       "line-height": {}
     }

--- a/proprietary/zevenaar-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/zevenaar-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -1,11 +1,11 @@
 {
   "utrecht": {
     "form-input": {
-      "color": { "value": "{zevenaar.color.black.value}" },
-      "border-color": { "value": "{zevenaar.color.black.value}" },
-      "font-family": { "value": "{zevenaar.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{zevenaar.color.black}" },
+      "border-color": { "value": "{zevenaar.color.black}" },
+      "font-family": { "value": "{zevenaar.typography.sans-serif.font-family}" },
       "focus": {
-        "border-color": { "value": "{zevenaar.color.green.20.value}" }
+        "border-color": { "value": "{zevenaar.color.green.20}" }
       }
     }
   }

--- a/proprietary/zevenaar-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/zevenaar-design-tokens/src/component/utrecht/heading.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "heading": {
-      "color": { "value": "{zevenaar.color.grey.25.value}" }
+      "color": { "value": "{zevenaar.color.grey.25}" }
     }
   }
 }

--- a/proprietary/zevenaar-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/zevenaar-design-tokens/src/component/utrecht/link.tokens.json
@@ -1,12 +1,12 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{zevenaar.color.green.20.value}" },
+      "color": { "value": "{zevenaar.color.green.20}" },
       "focus": {
-        "color": { "value": "{zevenaar.color.grey.0.value}" }
+        "color": { "value": "{zevenaar.color.grey.0}" }
       },
       "hover": {
-        "color": { "value": "{zevenaar.color.grey.0.value}" }
+        "color": { "value": "{zevenaar.color.grey.0}" }
       }
     }
   }

--- a/proprietary/zevenaar-design-tokens/src/component/utrecht/page-footer.tokens.json
+++ b/proprietary/zevenaar-design-tokens/src/component/utrecht/page-footer.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "page-footer": {
-      "background-color": { "value": "{zevenaar.color.grey.25.value}" },
-      "color": { "value": "{zevenaar.color.grey.100.value}" }
+      "background-color": { "value": "{zevenaar.color.grey.25}" },
+      "color": { "value": "{zevenaar.color.grey.100}" }
     }
   }
 }

--- a/proprietary/zevenaar-design-tokens/src/component/utrecht/separator.tokens.json
+++ b/proprietary/zevenaar-design-tokens/src/component/utrecht/separator.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "separator": {
-      "color": { "value": "{zevenaar.color.green.40.value}" }
+      "color": { "value": "{zevenaar.color.green.40}" }
     }
   }
 }

--- a/proprietary/zevenaar-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/zevenaar-design-tokens/src/component/utrecht/table.tokens.json
@@ -3,8 +3,8 @@
     "table": {
       "header": {
         "font-weight": { "value": "bold" },
-        "background-color": { "value": "{zevenaar.color.yellow.88.value}", "comment": "FIXME new" },
-        "color": { "value": "{zevenaar.color.black.value}" },
+        "background-color": { "value": "{zevenaar.color.yellow.88}", "comment": "FIXME new" },
+        "color": { "value": "{zevenaar.color.black}" },
         "text-transform": {},
         "border-block-end-color": {},
         "border-block-end-width": {}
@@ -13,7 +13,7 @@
         "border-color": { "value": "hsl(0deg 0% 71%)", "comment": "FIXME new" }
       },
       "row": {
-        "border-block-end-color": { "value": "{zevenaar.color.yellow.70.value}" },
+        "border-block-end-color": { "value": "{zevenaar.color.yellow.70}" },
         "border-block-end-width": { "value": "0.5px" },
         "padding-inline-end": {},
         "padding-inline-start": {},

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/badge-counter.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/badge-counter.tokens.json
@@ -2,13 +2,13 @@
   "utrecht": {
     "badge-counter": {
       "background-color": {
-        "value": "{zwolle.color.blue.40.value}"
+        "value": "{zwolle.color.blue.40}"
       },
       "border-radius": {
         "value": "3ex"
       },
       "color": {
-        "value": "{zwolle.color.white.value}"
+        "value": "{zwolle.color.white}"
       },
       "font-weight": {},
       "padding-block": {

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/badge.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/badge.tokens.json
@@ -2,13 +2,13 @@
   "utrecht": {
     "badge": {
       "background-color": {
-        "value": "{zwolle.color.blue.40.value}"
+        "value": "{zwolle.color.blue.40}"
       },
       "border-radius": {
         "value": "0"
       },
       "color": {
-        "value": "{zwolle.color.white.value}"
+        "value": "{zwolle.color.white}"
       },
       "font-weight": {
         "value": "700"
@@ -17,7 +17,7 @@
         "value": "6px"
       },
       "padding-inline": {
-        "value": "{utrecht.space.inline.md.value}"
+        "value": "{utrecht.space.inline.md}"
       }
     }
   }

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/button.tokens.json
@@ -1,23 +1,23 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{zwolle.color.blue.50.value}" },
+      "background-color": { "value": "{zwolle.color.blue.50}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{zwolle.color.white.value}" },
-      "font-family": { "value": "{zwolle.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{zwolle.typography.scale.md.font-size.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "color": { "value": "{zwolle.color.white}" },
+      "font-family": { "value": "{zwolle.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{zwolle.typography.scale.md.font-size}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.lg.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.lg.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.lg}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.lg}" },
       "secondary-action": {
-        "background-color": { "value": "{zwolle.color.blue.50.value}" },
-        "color": { "value": "{zwolle.color.white.value}" },
+        "background-color": { "value": "{zwolle.color.blue.50}" },
+        "color": { "value": "{zwolle.color.white}" },
         "border-color": {},
         "border-width": {},
         "hover": {
@@ -26,7 +26,7 @@
         }
       },
       "focus": {
-        "border-color": { "value": "{zwolle.color.black.value}" },
+        "border-color": { "value": "{zwolle.color.black}" },
         "border-width": {},
         "transform-scale": {}
       }

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,9 +1,9 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{zwolle.color.white.value}" },
-      "color": { "value": "{zwolle.color.black.value}" },
-      "font-family": { "value": "{zwolle.typography.sans-serif.font-family.value}" },
+      "background-color": { "value": "{zwolle.color.white}" },
+      "color": { "value": "{zwolle.color.black}" },
+      "font-family": { "value": "{zwolle.typography.sans-serif.font-family}" },
       "font-size": { "value": "16px" },
       "line-height": { "value": "22px" }
     }

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "form-input": {
       "block-size": { "value": "44px" },
-      "color": { "value": "{zwolle.color.black.value}" },
-      "border-color": { "value": "{zwolle.color.black.value}" },
-      "font-family": { "value": "{zwolle.typography.sans-serif.font-family.value}" },
+      "color": { "value": "{zwolle.color.black}" },
+      "border-color": { "value": "{zwolle.color.black}" },
+      "font-family": { "value": "{zwolle.typography.sans-serif.font-family}" },
       "line-height": { "value": "18px" },
       "placeholder": {
-        "color": { "value": "{zwolle.color.blue.50.value}" }
+        "color": { "value": "{zwolle.color.blue.50}" }
       },
       "focus": {
         "border-color": {}

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -4,16 +4,16 @@
       "font-size": {},
       "font-weight": {},
       "checkbox": {
-        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight}" }
       },
       "checkbox-checked": {
         "font-weight": {
-          "value": "{zwolle.typography.weight-scale.bold.font-weight.value}",
+          "value": "{zwolle.typography.weight-scale.bold.font-weight}",
           "comment": "FIXME: new"
         }
       },
       "radio": {
-        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-select": {
-      "background-color": { "value": "{zwolle.color.white.value}" },
-      "border-color": { "value": "{zwolle.color.black.value}" },
+      "background-color": { "value": "{zwolle.color.white}" },
+      "border-color": { "value": "{zwolle.color.black}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{zwolle.color.black.value}" },
+      "color": { "value": "{zwolle.color.black}" },
       "font-size": { "value": "1rem" },
       "max-inline-size": { "value": "100%" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.block.sm.value}" }
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.block.sm}" },
+      "padding-inline-start": { "value": "{utrecht.space.block.sm}" }
     }
   }
 }

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{zwolle.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{zwolle.typography.weight-scale.bold.font-weight}" }
     },
     "heading-1": {
       "color": {},

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "paragraph": {
       "font-family": {},
-      "font-size": { "value": "{zwolle.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight.value}" },
+      "font-size": { "value": "{zwolle.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{zwolle.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "22px" },
       "margin-block-start": {},
       "margin-block-end": {},
       "lead": {
         "font-size": {},
-        "font-weight": { "value": "{zwolle.typography.weight-scale.semi-bold.font-weight.value}" },
+        "font-weight": { "value": "{zwolle.typography.weight-scale.semi-bold.font-weight}" },
         "line-height": {}
       }
     }

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/table.tokens.json
@@ -14,10 +14,10 @@
       },
       "header": {
         "font-weight": { "value": "bold" },
-        "background-color": { "value": "{zwolle.color.blue.50.value}", "comment": "FIXME new" },
-        "color": { "value": "{zwolle.color.white.value}" },
+        "background-color": { "value": "{zwolle.color.blue.50}", "comment": "FIXME new" },
+        "color": { "value": "{zwolle.color.white}" },
         "text-transform": {},
-        "border-block-end-color": { "value": "{zwolle.color.grey.value}" },
+        "border-block-end-color": { "value": "{zwolle.color.grey}" },
         "border-block-end-width": { "value": "0.5px" }
       },
       "heading": {

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/textarea.tokens.json
@@ -2,19 +2,19 @@
   "utrecht": {
     "textarea": {
       "border-bottom-width": {},
-      "border-color": { "value": "{utrecht.textbox.border-color.value}" },
-      "border-radius": { "value": "{utrecht.textbox.border-radius.value}" },
-      "border-width": { "value": "{utrecht.textbox.border-width.value}" },
-      "color": { "value": "{utrecht.textbox.color.value}" },
-      "font-family": { "value": "{utrecht.textbox.font-family.value}" },
-      "font-size": { "value": "{utrecht.textbox.font-size.value}" },
-      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size.value}" },
-      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size.value}" },
+      "border-color": { "value": "{utrecht.textbox.border-color}" },
+      "border-radius": { "value": "{utrecht.textbox.border-radius}" },
+      "border-width": { "value": "{utrecht.textbox.border-width}" },
+      "color": { "value": "{utrecht.textbox.color}" },
+      "font-family": { "value": "{utrecht.textbox.font-family}" },
+      "font-size": { "value": "{utrecht.textbox.font-size}" },
+      "min-inline-size": { "value": "{utrecht.textbox.min-inline-size}" },
+      "max-inline-size": { "value": "{utrecht.textbox.max-inline-size}" },
       "min-block-size": { "value": "95px" },
-      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end.value}" },
-      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start.value}" },
-      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end.value}" },
-      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start.value}" }
+      "padding-block-end": { "value": "{utrecht.textbox.padding-block-end}" },
+      "padding-block-start": { "value": "{utrecht.textbox.padding-block-start}" },
+      "padding-inline-end": { "value": "{utrecht.textbox.padding-inline-end}" },
+      "padding-inline-start": { "value": "{utrecht.textbox.padding-inline-start}" }
     }
   }
 }

--- a/proprietary/zwolle-design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/zwolle-design-tokens/src/component/utrecht/textbox.tokens.json
@@ -2,18 +2,18 @@
   "utrecht": {
     "textbox": {
       "border-bottom-width": { "value": "1px" },
-      "border-color": { "value": "{utrecht.form-input.border-color.value}" },
+      "border-color": { "value": "{utrecht.form-input.border-color}" },
       "border-radius": { "value": "2px" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{utrecht.form-input.color.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
-      "font-size": { "value": "{zwolle.typography.scale.md.font-size.value}" },
+      "color": { "value": "{utrecht.form-input.color}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
+      "font-size": { "value": "{zwolle.typography.scale.md.font-size}" },
       "min-inline-size": { "value": "70px" },
       "max-inline-size": { "value": "620px" },
-      "padding-block-end": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xs}" },
       "disabled": {
         "border-color": {},
         "color": {}


### PR DESCRIPTION
Supported since style-dictionary@3.1.0, and in line with the [draft Design Tokens JSON specification](https://design-tokens.github.io/community-group/format/).

https://github.com/amzn/style-dictionary/pull/746