### PR TITLE
ci: add github-actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
 version: 2
 
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "main"
     versioning-strategy: "increase-if-necessary"
     ignore:
       # Storybook 6.4 causes issues with the code samples in our stories.


### PR DESCRIPTION
Let's use Dependabot to also manage GitHub-actions packages.

- [x] Add GitHub-actions
- [x] Remove configuration of the main branch as it's the default