### PR TITLE
fix: use correct lightness values as design token name for Buren

### DIFF
--- a/proprietary/buren-design-tokens/src/brand/buren/color.tokens.json
+++ b/proprietary/buren-design-tokens/src/brand/buren/color.tokens.json
@@ -2,26 +2,28 @@
   "buren": {
     "color": {
       "rood": {
-        "30": { "value": "#f2757f", "comment": "Used for focus outline" },
+        "40": { "value": "#b1111c", "comment": "Button focus achtergrond" },
         "50": { "value": "#d41422", "comment": "Standaard rood" },
-        "60": { "value": "#b1111c", "comment": "Button focus achtergrond" }
+        "70": { "value": "#f2757f", "comment": "Used for focus outline" }
       },
-      "Geel": {
+      "geel": {
         "50": { "value": "#fbbe04", "comment": "Standaard geel" }
       },
       "grijs": {
-        "0": { "value": "#fff", "comment": "Puur wit" },
-        "10": { "value": "#f2f2f2", "comment": "Licht grijs" },
-        "20": { "value": "#e9ecef", "comment": "Licht grijs" },
-        "30": { "value": "#ced4da", "comment": "Licht grijs" },
-        "40": { "value": "#949494", "comment": "Mid grijs" },
-        "60": { "value": "#757575", "comment": "Donker grijs" },
-        "80": { "value": "#555", "comment": "Donker grijs" },
-        "100": { "value": "#333", "comment": "Puur wit" }
+        "20": { "value": "#333333", "comment": "Donker grijs (mine)" },
+        "30": { "value": "#555555", "comment": "Donker grijs" },
+        "50": { "value": "#757575", "comment": "Donker grijs (boulder)" },
+        "60": { "value": "#949494", "comment": "Mid grijs (graphic)" },
+        "80": { "value": "#ced4da", "comment": "Licht grijs" },
+        "90": { "value": "#e9ecef", "comment": "Licht grijs" },
+        "95": { "value": "#f2f2f2", "comment": "Licht grijs (concrete)" },
+        "100": { "value": "#ffffff", "comment": "Puur wit" }
       },
-      "feedback": {
-        "succes": { "value": "#0d8228" },
-        "danger": { "value": "#d41422" }
+      "feedback-success": {
+        "30": { "value": "#0d8228" }
+      },
+      "feedback-danger": {
+        "50": { "value": "{buren.color.rood.50}" }
       }
     }
   }

--- a/proprietary/buren-design-tokens/src/common/utrecht/focus.tokens.json
+++ b/proprietary/buren-design-tokens/src/common/utrecht/focus.tokens.json
@@ -4,7 +4,7 @@
       "background-color": {},
       "border-color": {},
       "color": {},
-      "outline-color": { "value": "{buren.color.rood.30}" }
+      "outline-color": { "value": "{buren.color.rood.70}" }
     }
   }
 }

--- a/proprietary/buren-design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/buren-design-tokens/src/component/utrecht/button.tokens.json
@@ -5,7 +5,7 @@
       "border-color": { "value": "{buren.color.rood.50}", "comment": "fix me, i don not exist" },
       "border-width": { "value": "0" },
       "border-radius": { "value": "2px", "comment": "fix me, i don not exist" },
-      "color": { "value": "{buren.color.grijs.0}" },
+      "color": { "value": "{buren.color.grijs.100}" },
       "focus-transform-scale": {},
       "font-size": {},
       "font-weight": {},
@@ -23,7 +23,7 @@
       "padding-inline-end": { "value": "17.6px" },
       "text-transform": {},
       "active": {
-        "background-color": { "value": "{buren.color.rood.60}" },
+        "background-color": { "value": "{buren.color.rood.40}" },
         "color": {}
       },
       "disabled": {
@@ -31,11 +31,11 @@
         "hover-background-color": {}
       },
       "focus": {
-        "background-color": { "value": "{buren.color.rood.60}" },
+        "background-color": { "value": "{buren.color.rood.40}" },
         "color": {}
       },
       "hover": {
-        "background-color": { "value": "{buren.color.grijs.0}" },
+        "background-color": { "value": "{buren.color.grijs.100}" },
         "color": { "value": "{buren.color.rood.50}" }
       }
     }

--- a/proprietary/buren-design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/buren-design-tokens/src/component/utrecht/document.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{buren.color.grijs.0}" },
-      "color": { "value": "{buren.color.grijs.100}" },
+      "background-color": { "value": "{buren.color.grijs.100}" },
+      "color": { "value": "{buren.color.grijs.20}" },
       "font-family": { "value": "{buren.typography.sans-serif.font-family}" },
       "font-size": { "value": "{buren.typography.scale.md.font-size}" },
       "font-weight": { "value": "{buren.typography.weight-scale.normal}" },

--- a/proprietary/buren-design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/buren-design-tokens/src/component/utrecht/form-input.tokens.json
@@ -2,10 +2,10 @@
   "utrecht": {
     "form-input": {
       "background-color": {},
-      "border-color": { "value": "{buren.color.grijs.30}" },
+      "border-color": { "value": "{buren.color.grijs.80}" },
       "border-radius": { "value": "4px" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{buren.color.grijs.100}" },
+      "color": { "value": "{buren.color.grijs.20}" },
       "font-family": { "value": "{buren.typography.sans-serif.font-family}" },
       "font-size": { "value": "{buren.typography.scale.md.font-size}" },
       "font-style": {},
@@ -21,10 +21,10 @@
       "padding-inline-end": { "value": "12px" },
       "padding-inline-start": { "value": "12px" },
       "placeholder": {
-        "color": { "value": "{buren.color.grijs.60}" }
+        "color": { "value": "{buren.color.grijs.50}" }
       },
       "disabled": {
-        "background-color": { "value": "{buren.color.grijs.20}" },
+        "background-color": { "value": "{buren.color.grijs.90}" },
         "border-color": {},
         "color": {}
       },
@@ -35,11 +35,11 @@
       },
       "invalid": {
         "background-color": {},
-        "border-color": { "value": "{buren.color.feedback.danger}" },
+        "border-color": { "value": "{buren.color.feedback-danger.50}" },
         "border-width": {}
       },
       "read-only": {
-        "background-color": { "value": "{buren.color.grijs.20}" },
+        "background-color": { "value": "{buren.color.grijs.90}" },
         "border-color": {},
         "color": {}
       }

--- a/proprietary/buren-design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/buren-design-tokens/src/component/utrecht/form-label.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "form-label": {
-      "color": { "value": "{buren.color.grijs.100}" },
+      "color": { "value": "{buren.color.grijs.20}" },
       "font-weight": { "value": "{buren.typography.weight-scale.bold.font-weight}" },
       "font-size": { "value": "{buren.typography.scale.lg.font-size}" },
       "checkbox": {

--- a/proprietary/buren-design-tokens/src/component/utrecht/form-select.tokens.json
+++ b/proprietary/buren-design-tokens/src/component/utrecht/form-select.tokens.json
@@ -3,7 +3,7 @@
     "select": {
       "background-color": {},
       "border-bottom-width": {},
-      "border-color": { "value": "{buren.color.grijs.30}" },
+      "border-color": { "value": "{buren.color.grijs.80}" },
       "border-radius": { "value": "4px" },
       "border-width": { "value": "1px" },
       "color": {},
@@ -26,7 +26,7 @@
       },
       "invalid": {
         "background-color": {},
-        "border-color": { "value": "{buren.color.feedback.danger}" },
+        "border-color": { "value": "{buren.color.feedback-danger.50}" },
         "border-width": {}
       }
     }

--- a/proprietary/buren-design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/buren-design-tokens/src/component/utrecht/link.tokens.json
@@ -11,7 +11,7 @@
         "text-decoration": {}
       },
       "hover": {
-        "color": { "value": "{buren.color.grijs.100}" },
+        "color": { "value": "{buren.color.grijs.20}" },
         "text-decoration": {}
       },
       "visited": {

--- a/proprietary/buren-design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/buren-design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "paragraph": {
-      "color": { "value": "{buren.color.grijs.100}" },
+      "color": { "value": "{buren.color.grijs.20}" },
       "font-family": {},
       "font-size": { "value": "{buren.typography.scale.md.font-size}" },
       "font-weight": {},

--- a/proprietary/buren-design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/buren-design-tokens/src/component/utrecht/textarea.tokens.json
@@ -3,10 +3,10 @@
     "textarea": {
       "background-color": {},
       "border-bottom-width": {},
-      "border-color": { "value": "{buren.color.grijs.30}" },
+      "border-color": { "value": "{buren.color.grijs.80}" },
       "border-radius": { "value": "4px" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{buren.color.grijs.100}" },
+      "color": { "value": "{buren.color.grijs.20}" },
       "font-family": { "value": "{buren.typography.sans-serif.font-family}" },
       "font-size": { "value": "{buren.typography.scale.md.font-size}" },
       "max-inline-size": {},
@@ -16,10 +16,10 @@
       "padding-inline-end": {},
       "padding-inline-start": {},
       "placeholder": {
-        "color": { "value": "{buren.color.grijs.60}" }
+        "color": { "value": "{buren.color.grijs.50}" }
       },
       "disabled": {
-        "background-color": { "value": "{buren.color.grijs.20}" },
+        "background-color": { "value": "{buren.color.grijs.90}" },
         "border-color": {},
         "color": {}
       },
@@ -30,11 +30,11 @@
       },
       "invalid": {
         "background-color": {},
-        "border-color": { "value": "{buren.color.feedback.danger}" },
+        "border-color": { "value": "{buren.color.feedback-danger.50}" },
         "border-width": {}
       },
       "read-only": {
-        "background-color": { "value": "{buren.color.grijs.20}" },
+        "background-color": { "value": "{buren.color.grijs.90}" },
         "border-color": {},
         "color": {}
       }


### PR DESCRIPTION
The tokens in all other themes use the lightness as key, and in this package the tokens were in reverse lightness. So where before a color `hsl(h, s, 70%)` would have `"30": { ... }` as key, now it has `"70": { ... }` as key.