### PR TITLE
ci: add code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+* @nl-design-system/sysadmin
+/packages/ @nl-design-system/kernteam
+/proprietary/ @nl-design-system/kernteam
+/proprietary/amsterdam-design-tokens/ @nl-design-system/amsterdam
+/proprietary/buren-design-tokens/ @nl-design-system/buren
+/proprietary/haarlem-design-tokens/ @nl-design-system/haarlem


### PR DESCRIPTION
Add [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax) file to enable requiring code owners to review for specific parts of the themes repo. 

I've also enabled `require code owner review before merging`