### PR TITLE
ci: acutally release npm package, no dry run

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: "Continuous Deployment: publish to GitHub repository"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
           GIT_AUTHOR_NAME: "NL Design System"
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "prepare": "husky install",
     "prettier": "prettier --write .",
     "publish": "lerna publish from-package --no-verify-access --yes",
-    "release": "lerna version prerelease --conventional-prerelease --no-changelog --no-private --dry-run --yes",
+    "release": "lerna version prerelease --conventional-prerelease --no-changelog --no-private --yes",
     "start": "node_modules/http-server/bin/http-server dist/",
     "storybook": "npm-run-all --parallel watch:**",
     "test": "npm-run-all test-workspaces test-build:**",


### PR DESCRIPTION
Somehow `--dry-run` was included during testing and merged.