### PR TITLE
ci: temporarily disable publiccode.yml checking

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           npm run lint --if-present
 
-      - name: "Continuous Integration: public code validator"
-        uses: nl-design-system/publiccode-parser-action@latest
+      # - name: "Continuous Integration: public code validator"
+      #   uses: nl-design-system/publiccode-parser-action@latest
 
       - name: "Continuous Integration: build"
         run: |


### PR DESCRIPTION
apparently the validator does not support `nl` extensions, and none of the valid files pass the check