### PR TITLE
ci: change default review team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
-* @nl-design-system/kernteam-sysadmin
-/packages/ @nl-design-system/kernteam
-/proprietary/ @nl-design-system/kernteam
+* @nl-design-system/kernteam-maintainer
 /proprietary/amsterdam-design-tokens/ @nl-design-system/gemeente-amsterdam
 /proprietary/bodegraven-reeuwijk-design-tokens/ @nl-design-system/gemeente-bodegraven-reeuwijk
 /proprietary/borne-design-tokens/ @nl-design-system/gemeente-borne


### PR DESCRIPTION
A step in the right direction to remove the root `kernteam-sysadmin`.