### PR TITLE
build: update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
 version: 2
 
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-    target-branch: "main"
+      interval: "monthly"
     versioning-strategy: "increase-if-necessary"
     ignore:
       # Storybook 6.4 causes issues with the code samples in our stories.
@@ -54,13 +57,11 @@ updates:
   - package-ecosystem: "npm"
     directory: "/documentation/"
     schedule:
-      interval: "weekly"
-    target-branch: "main"
+      interval: "monthly"
     versioning-strategy: "increase-if-necessary"
 
   - package-ecosystem: "npm"
     directory: "/components/"
     schedule:
-      interval: "weekly"
-    target-branch: "main"
+      interval: "monthly"
     versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
- 'github-actions' ecosystem was missing and we're expecting quite a few action updates due to node16 being end-of-life
- remove 'target-branch' because 'main' is our default branch already
- change the interval to 'monthly'