### PR TITLE
Link list token update

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3357,6 +3357,44 @@
       }
     }
   },
+  "components/link-list": {
+    "utrecht": {
+      "link-list": {
+        "margin-block-start": {
+          "value": "0px",
+          "type": "spacing"
+        },
+        "row-gap": {
+          "value": "{voorbeeld.space.row.snail}",
+          "type": "spacing"
+        },
+        "margin-block-end": {
+          "value": "0px",
+          "type": "spacing"
+        },
+        "item": {
+          "column-gap": {
+            "value": "{voorbeeld.space.block.beetle}",
+            "type": "spacing"
+          },
+          "text-decoration": {
+            "value": "None",
+            "type": "textDecoration"
+          }
+        },
+        "icon": {
+          "size": {
+            "value": "{utrecht.icon.functional.size}",
+            "type": "sizing"
+          },
+          "inset-block-start": {
+            "value": "0px",
+            "type": "spacing"
+          }
+        }
+      }
+    }
+  },
   "components/modal-dialog": {
     "todo": {
       "modal-dialog": {
@@ -5227,6 +5265,7 @@
       "components/heading",
       "components/icon-only-button",
       "components/link",
+      "components/link-list",
       "components/modal-dialog",
       "components/ordered-list",
       "components/pagination",


### PR DESCRIPTION
Link list tokens meer in lijn met huidige tokens. Waarin is er verschil en waarom?

- `utrecht.link-list.row-gap` in plaats van `utrecht.link-list.item.margin-block-start` omdat we hiervoor met gap kunnen werken.
- `utrecht.link-list.item.text-decoration` is nieuw zodat links in een lijst geen underline hoeven te bevatten.