### PR TITLE
chore: nest breadcrumb navigation

### DIFF
--- a/packages/storybook/config/main.ts
+++ b/packages/storybook/config/main.ts
@@ -2,13 +2,13 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: [
-    {
-      titlePrefix: 'Components',
-      directory: '../../voorbeeld-design-tokens/documentation',
-      files: '*.stories.tsx',
-    },
+    // {
+    //   titlePrefix: 'Components',
+    //   directory: '../../voorbeeld-design-tokens/documentation',
+    //   files: '*.stories.{ts,tsx}',
+    // },
     '../../voorbeeld-design-tokens/documentation/{readme,color,design-tokens,typography}.mdx',
-    '../../voorbeeld-design-tokens/documentation/*.stories.ts',
+    '../../voorbeeld-design-tokens/documentation/**/*.stories.{ts,tsx}',
     '../../../proprietary/*/documentation/{readme,color,design-tokens,typography}.mdx',
     '../../../proprietary/*/documentation/*.stories.ts',
   ],

--- a/packages/voorbeeld-design-tokens/documentation/breadcrumb-navigation/utrecht.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/breadcrumb-navigation/utrecht.stories.tsx
@@ -12,7 +12,8 @@ const items = [
 ];
 
 const meta = {
-  id: 'breadcrumb',
+  id: 'utrecht-breadcrumb-nav',
+  title: 'Components/Breadcrumb Navigation/Utrecht',
   component: BreadcrumbNav,
   parameters: { actions: { disable: true } },
   args: { label: 'kruimelpad' },
@@ -31,5 +32,5 @@ const meta = {
 type Story = StoryObj<typeof meta>;
 
 export default meta;
-export const GemeenteVoorbeeld: Story = { parameters: { theme: 'voorbeeld-theme' } };
-export const Utrecht: Story = { parameters: { theme: 'utrecht-theme' } };
+export const VoorbeeldTheme: Story = { parameters: { theme: 'voorbeeld-theme' } };
+export const UtrechtTheme: Story = { parameters: { theme: 'utrecht-theme' } };


### PR DESCRIPTION
- Breadcrumb.stories.tsx -> breadcrumb-navigation/utrecht.stories.tsx
- add title to meta so the sidebar nests breadcrumb navigation properly and is ready for adding for example the RVO breadcrumb