### PR TITLE
Switch tokens

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4694,6 +4694,28 @@
             "type": "borderWidth"
           }
         },
+        "icon": {
+          "color": {
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
+          },
+          "focus": {
+            "color": {
+              "value": "{utrecht.focus.color}",
+              "type": "color"
+            }
+          },
+          "disabled": {
+            "color": {
+              "value": "{voorbeeld.color.gray.600}",
+              "type": "color"
+            }
+          },
+          "size": {
+            "value": "{utrecht.icon.functional.size}",
+            "type": "sizing"
+          }
+        },
         "border-color": {
           "value": "transparent",
           "type": "color"
@@ -4719,7 +4741,7 @@
           },
           "focus": {
             "background-color": {
-              "value": "{utrecht.button.focus.color}",
+              "value": "{utrecht.focus.color}",
               "type": "color"
             }
           },

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4611,6 +4611,142 @@
       }
     }
   },
+  "components/switch": {
+    "todo": {
+      "switch": {
+        "track": {
+          "background-color": {
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
+          },
+          "active": {
+            "background-color": {
+              "value": "{voorbeeld.color.gray.700}",
+              "type": "color"
+            }
+          },
+          "hover": {
+            "background-color": {
+              "value": "{voorbeeld.color.gray.600}",
+              "type": "color"
+            }
+          },
+          "focus": {
+            "background-color": {
+              "value": "{utrecht.focus.background-color}",
+              "type": "color"
+            }
+          },
+          "disabled": {
+            "background-color": {
+              "value": "{voorbeeld.color.gray.300}",
+              "type": "color"
+            }
+          },
+          "checked": {
+            "background-color": {
+              "value": "{voorbeeld.color.green.500}",
+              "type": "color"
+            },
+            "hover": {
+              "background-color": {
+                "value": "{voorbeeld.color.green.600}",
+                "type": "color"
+              }
+            },
+            "active": {
+              "background-color": {
+                "value": "{voorbeeld.color.green.700}",
+                "type": "color"
+              }
+            },
+            "focus": {
+              "background-color": {
+                "value": "{utrecht.focus.background-color}",
+                "type": "color"
+              }
+            },
+            "disabled": {
+              "background-color": {
+                "value": "{voorbeeld.color.gray.300}",
+                "type": "color"
+              }
+            }
+          },
+          "border-radius": {
+            "value": "{voorbeeld.border-radius.round}",
+            "type": "borderRadius"
+          },
+          "padding-block": {
+            "value": "{voorbeeld.space.inline.ant}",
+            "type": "spacing"
+          },
+          "padding-inline": {
+            "value": "{voorbeeld.space.inline.ant}",
+            "type": "spacing"
+          },
+          "inline-size": {
+            "value": "5rem",
+            "type": "sizing"
+          },
+          "border-width": {
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
+          }
+        },
+        "border-color": {
+          "value": "transparent",
+          "type": "color"
+        },
+        "thumb": {
+          "disabled": {
+            "background-color": {
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
+            },
+            "box-shadow": {
+              "value": "None",
+              "type": "boxShadow"
+            }
+          },
+          "background-color": {
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "transparent",
+            "type": "color"
+          },
+          "focus": {
+            "background-color": {
+              "value": "{utrecht.button.focus.color}",
+              "type": "color"
+            }
+          },
+          "min-inline-size": {
+            "value": "{voorbeeld.size.sm}",
+            "type": "sizing"
+          },
+          "min-block-size": {
+            "value": "{voorbeeld.size.sm}",
+            "type": "sizing"
+          },
+          "box-shadow": {
+            "value": "{voorbeeld.box-shadow.sm}",
+            "type": "boxShadow"
+          },
+          "border-radius": {
+            "value": "{voorbeeld.border-radius.round}",
+            "type": "borderRadius"
+          },
+          "border-width": {
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
+          }
+        }
+      }
+    }
+  },
   "components/table": {
     "utrecht": {
       "table": {
@@ -5292,6 +5428,7 @@
       "components/skip-link",
       "components/status-badge",
       "components/summary-list",
+      "components/switch",
       "components/table",
       "components/task-list",
       "components/textarea",


### PR DESCRIPTION
Tokens voor de Switch component toegevoegd tijdens Estafettemodeldag 2. Begonnen vanuit [Utrecht form toggle](https://nl-design-system.github.io/utrecht/storybook/?path=/story/css_css-form-toggle--design-tokens) maar gedurende ontwikkeling tokens aangepast ([vragen genoteerd](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O?node-id=11982-21531#853314235)), vandaar nu als todo beschikbaar.
