### PR TITLE
Common tokens prefix uitsplitsen

### DIFF
--- a/.changeset/20240815--jeff
+++ b/.changeset/20240815--jeff
@@ -1,0 +1,43 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Overview of tokens that had the utrecht prefix and now have the voorbeeld prefix:
+
+Typography
+.document.strong.font-weight
+
+Colors
+.root.background-color
+.document.subtle.color
+.document.inverse.color
+.document.inverse.background-color
+.container.border-color
+.line.border-color
+.interaction.* (all)
+.form-control.accent-color
+.form-control.active.* (all)
+.form-control.hover.* (all)
+.form-control.disabled.accent-color
+.feedback.informative.* (all)
+.feedback.negative.* (all)
+.feedback.positive.* (all)
+
+Size
+icon.functional.size
+icon.toptask.size
+
+Border
+.container.border-width
+.line.border-width
+.form-control.active.border-width
+.form-control.focus.border-width
+.form-control.hover.border-width
+
+Focus
+.focus.color
+`.form-control.focus.border-width`
+`.form-control.hover.border-width`
+
+Focus
+`.focus.color`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -926,22 +926,6 @@
           "value": "{voorbeeld.color.gray.900}",
           "type": "color"
         },
-        "inverse": {
-          "background-color": {
-            "value": "{voorbeeld.color.gray.950}",
-            "type": "color"
-          },
-          "color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
-          }
-        },
-        "subtle": {
-          "color": {
-            "value": "{voorbeeld.color.gray.600}",
-            "type": "color"
-          }
-        },
         "font-family": {
           "value": "{voorbeeld.typography.font-family.secondary}",
           "type": "fontFamilies"
@@ -954,22 +938,12 @@
           "value": "{voorbeeld.typography.font-weight.normal}",
           "type": "fontWeights"
         },
-        "strong": {
-          "font-weight": {
-            "value": "{voorbeeld.typography.font-weight.bold}",
-            "type": "fontWeights"
-          }
-        },
         "line-height": {
           "value": "{voorbeeld.typography.line-height.md}",
           "type": "lineHeights"
         }
       },
       "heading": {
-        "color": {
-          "value": "{voorbeeld.color.gray.900}",
-          "type": "color"
-        },
         "font-family": {
           "value": "{voorbeeld.typography.font-family.primary}",
           "type": "fontFamilies"
@@ -980,41 +954,15 @@
         }
       },
       "container": {
-        "border-color": {
-          "value": "{voorbeeld.color.gray.200}",
-          "type": "color"
-        },
         "border-width": {
           "value": "{voorbeeld.border-width.sm}",
           "type": "borderWidth"
         }
       },
       "line": {
-        "border-color": {
-          "value": "{voorbeeld.color.gray.200}",
-          "type": "color"
-        },
         "border-width": {
           "value": "{voorbeeld.border-width.sm}",
           "type": "borderWidth"
-        }
-      },
-      "interaction": {
-        "color": {
-          "value": "{voorbeeld.color.violet.700}",
-          "type": "color"
-        },
-        "active": {
-          "color": {
-            "value": "{voorbeeld.color.violet.900}",
-            "type": "color"
-          }
-        },
-        "hover": {
-          "color": {
-            "value": "{voorbeeld.color.violet.800}",
-            "type": "color"
-          }
         }
       },
       "focus": {
@@ -1050,10 +998,6 @@
         }
       },
       "form-control": {
-        "accent-color": {
-          "value": "{utrecht.interaction.color}",
-          "type": "color"
-        },
         "background-color": {
           "value": "{voorbeeld.color.white}",
           "type": "color"
@@ -1071,40 +1015,12 @@
           "type": "color"
         },
         "active": {
-          "accent-color": {
-            "value": "{utrecht.interaction.active.color}",
-            "type": "color"
-          },
-          "background-color": {
-            "value": "{voorbeeld.color.gray.100}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
-          },
           "border-width": {
             "value": "{voorbeeld.border-width.md}",
             "type": "borderWidth"
-          },
-          "color": {
-            "value": "{voorbeeld.color.gray.950}",
-            "type": "color"
           }
         },
         "disabled": {
-          "accent-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
-          },
-          "background-color": {
-            "value": "{voorbeeld.color.gray.50}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
-          },
           "color": {
             "value": "{voorbeeld.color.gray.500}",
             "type": "color"
@@ -1129,42 +1045,18 @@
           }
         },
         "hover": {
-          "accent-color": {
-            "value": "{utrecht.interaction.hover.color}",
-            "type": "color"
-          },
-          "background-color": {
-            "value": "{voorbeeld.color.gray.50}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
-          },
           "border-width": {
             "value": "{voorbeeld.border-width.md}",
             "type": "borderWidth"
-          },
-          "color": {
-            "value": "{voorbeeld.color.gray.950}",
-            "type": "color"
           }
         },
         "invalid": {
-          "background-color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{utrecht.feedback.negative.border-color}",
-            "type": "color"
-          },
           "border-width": {
             "value": "{voorbeeld.border-width.md}",
             "type": "borderWidth"
           },
           "color": {
-            "value": "{utrecht.feedback.negative.color}",
+            "value": "{voorbeeld.feedback.negative.color}",
             "type": "color"
           }
         },
@@ -1193,6 +1085,150 @@
         "min-size": {
           "value": "{voorbeeld.size.md}",
           "type": "sizing"
+        }
+      },
+      "feedback": {
+        "warning": {
+          "background-color": {
+            "value": "{voorbeeld.color.yellow.100}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{voorbeeld.color.yellow.600}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{voorbeeld.color.yellow.600}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "voorbeeld": {
+      "document": {
+        "inverse": {
+          "background-color": {
+            "value": "{voorbeeld.color.gray.950}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
+          }
+        },
+        "subtle": {
+          "color": {
+            "value": "{voorbeeld.color.gray.600}",
+            "type": "color"
+          }
+        },
+        "strong": {
+          "font-weight": {
+            "value": "{voorbeeld.typography.font-weight.bold}",
+            "type": "fontWeights"
+          }
+        }
+      },
+      "heading": {
+        "color": {
+          "value": "{voorbeeld.color.gray.900}",
+          "type": "color"
+        }
+      },
+      "container": {
+        "border-color": {
+          "value": "{voorbeeld.color.gray.200}",
+          "type": "color"
+        }
+      },
+      "line": {
+        "border-color": {
+          "value": "{voorbeeld.color.gray.200}",
+          "type": "color"
+        }
+      },
+      "interaction": {
+        "color": {
+          "value": "{voorbeeld.color.violet.700}",
+          "type": "color"
+        },
+        "active": {
+          "color": {
+            "value": "{voorbeeld.color.violet.900}",
+            "type": "color"
+          }
+        },
+        "hover": {
+          "color": {
+            "value": "{voorbeeld.color.violet.800}",
+            "type": "color"
+          }
+        }
+      },
+      "form-control": {
+        "accent-color": {
+          "value": "{voorbeeld.interaction.color}",
+          "type": "color"
+        },
+        "active": {
+          "accent-color": {
+            "value": "{voorbeeld.interaction.active.color}",
+            "type": "color"
+          },
+          "background-color": {
+            "value": "{voorbeeld.color.gray.100}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{voorbeeld.color.gray.950}",
+            "type": "color"
+          }
+        },
+        "disabled": {
+          "accent-color": {
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
+          },
+          "background-color": {
+            "value": "{voorbeeld.color.gray.50}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
+          }
+        },
+        "hover": {
+          "accent-color": {
+            "value": "{voorbeeld.interaction.hover.color}",
+            "type": "color"
+          },
+          "background-color": {
+            "value": "{voorbeeld.color.gray.50}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{voorbeeld.color.gray.950}",
+            "type": "color"
+          }
+        },
+        "invalid": {
+          "background-color": {
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{voorbeeld.feedback.negative.border-color}",
+            "type": "color"
+          }
         }
       },
       "icon": {
@@ -1251,24 +1287,8 @@
             "value": "{voorbeeld.color.green.600}",
             "type": "color"
           }
-        },
-        "warning": {
-          "background-color": {
-            "value": "{voorbeeld.color.yellow.100}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{voorbeeld.color.yellow.600}",
-            "type": "color"
-          },
-          "color": {
-            "value": "{voorbeeld.color.yellow.600}",
-            "type": "color"
-          }
         }
-      }
-    },
-    "voorbeeld": {
+      },
       "space": {
         "relation": {
           "kind": {
@@ -1338,7 +1358,7 @@
             "value": "auto"
           },
           "border-color": {
-            "value": "{utrecht.line.border-color}",
+            "value": "{voorbeeld.line.border-color}",
             "type": "color"
           }
         },
@@ -1388,7 +1408,7 @@
             },
             "size": {
               "type": "sizing",
-              "value": "{utrecht.icon.functional.size}"
+              "value": "{voorbeeld.icon.functional.size}"
             }
           },
           "padding-block-end": {
@@ -1418,7 +1438,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}"
             }
           },
           "expanded": {
@@ -1432,7 +1452,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.color}"
+              "value": "{voorbeeld.interaction.color}"
             }
           },
           "background-color": {
@@ -1445,7 +1465,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{utrecht.interaction.color}"
+            "value": "{voorbeeld.interaction.color}"
           },
           "focus": {
             "background-color": {
@@ -1472,7 +1492,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}"
             }
           },
           "border-width": {
@@ -1488,7 +1508,7 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{utrecht.document.strong.font-weight}",
+            "value": "{voorbeeld.document.strong.font-weight}",
             "type": "fontWeights"
           }
         }
@@ -1549,11 +1569,11 @@
           "type": "spacing"
         },
         "background-color": {
-          "value": "{utrecht.feedback.informative.background-color}",
+          "value": "{voorbeeld.feedback.informative.background-color}",
           "type": "color"
         },
         "border-color": {
-          "value": "{utrecht.feedback.informative.border-color}",
+          "value": "{voorbeeld.feedback.informative.border-color}",
           "type": "color"
         },
         "color": {
@@ -1562,11 +1582,11 @@
         },
         "info": {
           "background-color": {
-            "value": "{utrecht.feedback.informative.background-color}",
+            "value": "{voorbeeld.feedback.informative.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.feedback.informative.border-color}",
+            "value": "{voorbeeld.feedback.informative.border-color}",
             "type": "color"
           },
           "color": {
@@ -1576,11 +1596,11 @@
         },
         "error": {
           "background-color": {
-            "value": "{utrecht.feedback.negative.background-color}",
+            "value": "{voorbeeld.feedback.negative.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.feedback.negative.border-color}",
+            "value": "{voorbeeld.feedback.negative.border-color}",
             "type": "color"
           },
           "color": {
@@ -1590,11 +1610,11 @@
         },
         "ok": {
           "background-color": {
-            "value": "{utrecht.feedback.positive.background-color}",
+            "value": "{voorbeeld.feedback.positive.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.feedback.positive.border-color}",
+            "value": "{voorbeeld.feedback.positive.border-color}",
             "type": "color"
           },
           "color": {
@@ -1623,19 +1643,19 @@
           },
           "info": {
             "color": {
-              "value": "{utrecht.feedback.informative.color}",
+              "value": "{voorbeeld.feedback.informative.color}",
               "type": "color"
             }
           },
           "error": {
             "color": {
-              "value": "{utrecht.feedback.negative.color}",
+              "value": "{voorbeeld.feedback.negative.color}",
               "type": "color"
             }
           },
           "ok": {
             "color": {
-              "value": "{utrecht.feedback.positive.color}",
+              "value": "{voorbeeld.feedback.positive.color}",
               "type": "color"
             }
           },
@@ -1647,7 +1667,7 @@
           },
           "size": {
             "type": "sizing",
-            "value": "{utrecht.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}"
           }
         },
         "message": {
@@ -1667,7 +1687,7 @@
     "todo": {
       "avatar": {
         "background-color": {
-          "value": "{utrecht.interaction.color}",
+          "value": "{voorbeeld.interaction.color}",
           "type": "color"
         },
         "border-radius": {
@@ -1680,7 +1700,7 @@
         },
         "icon": {
           "icon-size": {
-            "value": "{utrecht.icon.functional.size}",
+            "value": "{voorbeeld.icon.functional.size}",
             "type": "sizing"
           }
         },
@@ -1698,7 +1718,7 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{utrecht.document.strong.font-weight}",
+            "value": "{voorbeeld.document.strong.font-weight}",
             "type": "fontWeights"
           },
           "line-height": {
@@ -1720,7 +1740,7 @@
         },
         "hover": {
           "background-color": {
-            "value": "{utrecht.interaction.hover.color}",
+            "value": "{voorbeeld.interaction.hover.color}",
             "type": "color"
           },
           "border-color": {
@@ -1794,7 +1814,7 @@
             "type": "spacing"
           },
           "color": {
-            "value": "{utrecht.document.subtle.color}",
+            "value": "{voorbeeld.document.subtle.color}",
             "type": "color"
           }
         },
@@ -1858,7 +1878,7 @@
           "icon": {
             "size": {
               "type": "sizing",
-              "value": "{utrecht.icon.functional.size}"
+              "value": "{voorbeeld.icon.functional.size}"
             },
             "margin-inline": {
               "value": "{voorbeeld.space.text.beetle}",
@@ -1883,12 +1903,12 @@
           },
           "color": {
             "type": "color",
-            "value": "{utrecht.interaction.color}"
+            "value": "{voorbeeld.interaction.color}"
           },
           "active": {
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}"
             },
             "text-decoration": {
               "value": "None",
@@ -1912,7 +1932,7 @@
           "hover": {
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}"
             },
             "text-decoration": {
               "value": "None",
@@ -1922,7 +1942,7 @@
           "current": {
             "color": {
               "type": "color",
-              "value": "{utrecht.document.subtle.color}"
+              "value": "{voorbeeld.document.subtle.color}"
             }
           },
           "text-decoration": {
@@ -1936,7 +1956,7 @@
             "value": "{voorbeeld.size.2xs}"
           },
           "color": {
-            "value": "{utrecht.document.subtle.color}",
+            "value": "{voorbeeld.document.subtle.color}",
             "type": "color"
           }
         },
@@ -1981,7 +2001,7 @@
         "icon": {
           "size": {
             "type": "sizing",
-            "value": "{utrecht.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}"
           }
         },
         "font-family": {
@@ -1993,7 +2013,7 @@
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{utrecht.document.strong.font-weight}",
+          "value": "{voorbeeld.document.strong.font-weight}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -2050,11 +2070,11 @@
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.interaction.hover.color}",
+            "value": "{voorbeeld.interaction.hover.color}",
             "type": "color"
           },
           "color": {
-            "value": "{utrecht.interaction.hover.color}",
+            "value": "{voorbeeld.interaction.hover.color}",
             "type": "color"
           }
         },
@@ -2064,11 +2084,11 @@
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.interaction.active.color}",
+            "value": "{voorbeeld.interaction.active.color}",
             "type": "color"
           },
           "color": {
-            "value": "{utrecht.interaction.active.color}",
+            "value": "{voorbeeld.interaction.active.color}",
             "type": "color"
           }
         },
@@ -2088,7 +2108,7 @@
           "hover": {
             "background-color": {
               "type": "color",
-              "value": "{utrecht.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}"
             },
             "border-color": {
               "value": "transparent",
@@ -2101,7 +2121,7 @@
           },
           "background-color": {
             "type": "color",
-            "value": "{utrecht.interaction.color}"
+            "value": "{voorbeeld.interaction.color}"
           },
           "border-color": {
             "value": "transparent",
@@ -2140,13 +2160,13 @@
             }
           },
           "font-weight": {
-            "value": "{utrecht.document.strong.font-weight}",
+            "value": "{voorbeeld.document.strong.font-weight}",
             "type": "fontWeights"
           },
           "active": {
             "background-color": {
               "type": "color",
-              "value": "{utrecht.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}"
             },
             "border-color": {
               "value": "transparent",
@@ -2174,11 +2194,11 @@
             },
             "border-color": {
               "type": "color",
-              "value": "{utrecht.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}"
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}"
             }
           },
           "background-color": {
@@ -2187,11 +2207,11 @@
           },
           "border-color": {
             "type": "color",
-            "value": "{utrecht.interaction.color}"
+            "value": "{voorbeeld.interaction.color}"
           },
           "color": {
             "type": "color",
-            "value": "{utrecht.interaction.color}"
+            "value": "{voorbeeld.interaction.color}"
           },
           "disabled": {
             "background-color": {
@@ -2222,7 +2242,7 @@
             }
           },
           "font-weight": {
-            "value": "{utrecht.document.strong.font-weight}",
+            "value": "{voorbeeld.document.strong.font-weight}",
             "type": "fontWeights"
           },
           "active": {
@@ -2232,11 +2252,11 @@
             },
             "border-color": {
               "type": "color",
-              "value": "{utrecht.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}"
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}"
             }
           },
           "font-size": {
@@ -2254,7 +2274,7 @@
             "type": "fontSizes"
           },
           "font-weight": {
-            "value": "{utrecht.document.strong.font-weight}",
+            "value": "{voorbeeld.document.strong.font-weight}",
             "type": "fontWeights"
           },
           "hover": {
@@ -2268,7 +2288,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}"
             }
           },
           "background-color": {
@@ -2281,7 +2301,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{utrecht.interaction.color}"
+            "value": "{voorbeeld.interaction.color}"
           },
           "disabled": {
             "background-color": {
@@ -2322,7 +2342,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}"
             }
           },
           "line-height": {
@@ -2381,7 +2401,7 @@
         "icon": {
           "size": {
             "type": "sizing",
-            "value": "{utrecht.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}"
           }
         },
         "background-color": {
@@ -2394,11 +2414,11 @@
         },
         "invalid": {
           "background-color": {
-            "value": "{utrecht.form-control.invalid.background-color}",
+            "value": "{voorbeeld.form-control.invalid.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.invalid.border-color}",
+            "value": "{voorbeeld.form-control.invalid.border-color}",
             "type": "color"
           },
           "border-width": {
@@ -2422,17 +2442,17 @@
         },
         "disabled": {
           "background-color": {
-            "value": "{utrecht.form-control.disabled.background-color}",
+            "value": "{voorbeeld.form-control.disabled.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.disabled.border-color}",
+            "value": "{voorbeeld.form-control.disabled.border-color}",
             "type": "color"
           }
         },
         "checked": {
           "background-color": {
-            "value": "{utrecht.form-control.accent-color}",
+            "value": "{voorbeeld.form-control.accent-color}",
             "type": "color"
           },
           "border-color": {
@@ -2449,7 +2469,7 @@
           },
           "disabled": {
             "background-color": {
-              "value": "{utrecht.form-control.disabled.accent-color}",
+              "value": "{voorbeeld.form-control.disabled.accent-color}",
               "type": "color"
             },
             "border-color": {
@@ -2485,7 +2505,7 @@
               "type": "borderWidth"
             },
             "background-color": {
-              "value": "{utrecht.form-control.hover.accent-color}",
+              "value": "{voorbeeld.form-control.hover.accent-color}",
               "type": "color"
             },
             "border-color": {
@@ -2503,7 +2523,7 @@
               "type": "borderWidth"
             },
             "background-color": {
-              "value": "{utrecht.form-control.active.accent-color}",
+              "value": "{voorbeeld.form-control.active.accent-color}",
               "type": "color"
             },
             "border-color": {
@@ -2518,7 +2538,7 @@
         },
         "indeterminate": {
           "background-color": {
-            "value": "{utrecht.form-control.accent-color}",
+            "value": "{voorbeeld.form-control.accent-color}",
             "type": "color"
           },
           "border-color": {
@@ -2535,7 +2555,7 @@
           },
           "disabled": {
             "background-color": {
-              "value": "{utrecht.form-control.disabled.accent-color}",
+              "value": "{voorbeeld.form-control.disabled.accent-color}",
               "type": "color"
             },
             "border-color": {
@@ -2549,7 +2569,7 @@
           },
           "active": {
             "background-color": {
-              "value": "{utrecht.form-control.active.accent-color}",
+              "value": "{voorbeeld.form-control.active.accent-color}",
               "type": "color"
             },
             "border-color": {
@@ -2567,7 +2587,7 @@
           },
           "hover": {
             "background-color": {
-              "value": "{utrecht.form-control.hover.accent-color}",
+              "value": "{voorbeeld.form-control.hover.accent-color}",
               "type": "color"
             },
             "border-color": {
@@ -2612,11 +2632,11 @@
             "type": "borderWidth"
           },
           "background-color": {
-            "value": "{utrecht.form-control.hover.background-color}",
+            "value": "{voorbeeld.form-control.hover.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.hover.border-color}",
+            "value": "{voorbeeld.form-control.hover.border-color}",
             "type": "color"
           }
         },
@@ -2626,11 +2646,11 @@
             "type": "borderWidth"
           },
           "background-color": {
-            "value": "{utrecht.form-control.active.background-color}",
+            "value": "{voorbeeld.form-control.active.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.active.border-color}",
+            "value": "{voorbeeld.form-control.active.border-color}",
             "type": "color"
           }
         }
@@ -2675,7 +2695,7 @@
           "value": "{voorbeeld.size.xs}"
         },
         "font-weight": {
-          "value": "{utrecht.document.strong.font-weight}",
+          "value": "{voorbeeld.document.strong.font-weight}",
           "type": "fontWeights"
         },
         "border-width": {
@@ -2748,7 +2768,7 @@
             "type": "spacing"
           },
           "border-color": {
-            "value": "{utrecht.line.border-color}",
+            "value": "{voorbeeld.line.border-color}",
             "type": "color"
           },
           "background-color": {
@@ -2782,7 +2802,7 @@
             "type": "spacing"
           },
           "border-color": {
-            "value": "{utrecht.line.border-color}",
+            "value": "{voorbeeld.line.border-color}",
             "type": "color"
           },
           "background-color": {
@@ -2813,7 +2833,7 @@
           "type": "color"
         },
         "border-color": {
-          "value": "{utrecht.container.border-color}",
+          "value": "{voorbeeld.container.border-color}",
           "type": "color"
         },
         "color": {
@@ -2839,7 +2859,7 @@
               "type": "fontSizes"
             },
             "font-weight": {
-              "value": "{utrecht.document.strong.font-weight}",
+              "value": "{voorbeeld.document.strong.font-weight}",
               "type": "fontWeights"
             },
             "line-height": {
@@ -2856,7 +2876,7 @@
       "form-field": {
         "invalid": {
           "border-inline-start-color": {
-            "value": "{utrecht.feedback.negative.border-color}",
+            "value": "{voorbeeld.feedback.negative.border-color}",
             "type": "color"
           },
           "border-inline-start-width": {
@@ -2886,7 +2906,7 @@
       "form-field-description": {
         "color": {
           "type": "color",
-          "value": "{utrecht.document.subtle.color}"
+          "value": "{voorbeeld.document.subtle.color}"
         },
         "font-family": {
           "value": "{utrecht.document.font-family}",
@@ -2909,7 +2929,7 @@
         "icon": {
           "size": {
             "type": "sizing",
-            "value": "{utrecht.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}"
           },
           "margin-inline-end": {
             "value": "{voorbeeld.space.text.mouse}",
@@ -2918,7 +2938,7 @@
         },
         "color": {
           "type": "color",
-          "value": "{utrecht.feedback.negative.color}"
+          "value": "{voorbeeld.feedback.negative.color}"
         },
         "font-family": {
           "value": "{utrecht.document.font-family}",
@@ -2951,7 +2971,7 @@
           "type": "fontSizes"
         },
         "font-weight": {
-          "value": "{utrecht.document.strong.font-weight}",
+          "value": "{voorbeeld.document.strong.font-weight}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -3008,7 +3028,7 @@
       "heading-1": {
         "color": {
           "type": "color",
-          "value": "{utrecht.heading.color}"
+          "value": "{voorbeeld.heading.color}"
         },
         "font-family": {
           "value": "{utrecht.heading.font-family}",
@@ -3038,7 +3058,7 @@
       "heading-2": {
         "color": {
           "type": "color",
-          "value": "{utrecht.heading.color}"
+          "value": "{voorbeeld.heading.color}"
         },
         "font-family": {
           "value": "{utrecht.heading.font-family}",
@@ -3068,7 +3088,7 @@
       "heading-3": {
         "color": {
           "type": "color",
-          "value": "{utrecht.heading.color}"
+          "value": "{voorbeeld.heading.color}"
         },
         "font-family": {
           "value": "{utrecht.heading.font-family}",
@@ -3098,7 +3118,7 @@
       "heading-4": {
         "color": {
           "type": "color",
-          "value": "{utrecht.heading.color}"
+          "value": "{voorbeeld.heading.color}"
         },
         "font-family": {
           "value": "{utrecht.heading.font-family}",
@@ -3128,7 +3148,7 @@
       "heading-5": {
         "color": {
           "type": "color",
-          "value": "{utrecht.heading.color}"
+          "value": "{voorbeeld.heading.color}"
         },
         "font-family": {
           "value": "{utrecht.heading.font-family}",
@@ -3158,7 +3178,7 @@
       "heading-6": {
         "color": {
           "type": "color",
-          "value": "{utrecht.heading.color}"
+          "value": "{voorbeeld.heading.color}"
         },
         "font-family": {
           "value": "{utrecht.heading.font-family}",
@@ -3214,16 +3234,16 @@
       "link": {
         "color": {
           "type": "color",
-          "value": "{utrecht.interaction.color}"
+          "value": "{voorbeeld.interaction.color}"
         },
         "text-decoration-color": {
           "type": "color",
-          "value": "{utrecht.interaction.color}"
+          "value": "{voorbeeld.interaction.color}"
         },
         "active": {
           "color": {
             "type": "color",
-            "value": "{utrecht.interaction.active.color}"
+            "value": "{voorbeeld.interaction.active.color}"
           },
           "text-decoration": {
             "value": "None",
@@ -3251,7 +3271,7 @@
         "hover": {
           "color": {
             "type": "color",
-            "value": "{utrecht.interaction.hover.color}"
+            "value": "{voorbeeld.interaction.hover.color}"
           },
           "text-decoration": {
             "value": "None",
@@ -3265,7 +3285,7 @@
         "visited": {
           "color": {
             "type": "color",
-            "value": "{utrecht.interaction.color}"
+            "value": "{voorbeeld.interaction.color}"
           }
         },
         "text-decoration": {
@@ -3275,7 +3295,7 @@
         "icon": {
           "size": {
             "type": "sizing",
-            "value": "{utrecht.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}"
           }
         },
         "column-gap": {
@@ -3335,7 +3355,7 @@
               "type": "fontFamilies"
             },
             "font-weight": {
-              "value": "{utrecht.document.strong.font-weight}",
+              "value": "{voorbeeld.document.strong.font-weight}",
               "type": "fontWeights"
             },
             "font-size": {
@@ -3348,7 +3368,7 @@
             }
           },
           "border-color": {
-            "value": "{utrecht.line.border-color}",
+            "value": "{voorbeeld.line.border-color}",
             "type": "color"
           },
           "column-gap": {
@@ -3478,7 +3498,7 @@
             },
             "size": {
               "type": "sizing",
-              "value": "{utrecht.icon.functional.size}"
+              "value": "{voorbeeld.icon.functional.size}"
             }
           },
           "padding-block-end": {
@@ -3507,7 +3527,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{utrecht.interaction.color}"
+            "value": "{voorbeeld.interaction.color}"
           },
           "active": {
             "background-color": {
@@ -3520,7 +3540,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}"
             },
             "text-decoration": {
               "value": "underline",
@@ -3552,7 +3572,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}"
             },
             "text-decoration": {
               "value": "underline",
@@ -3605,7 +3625,7 @@
           },
           "current": {
             "font-weight": {
-              "value": "{utrecht.document.strong.font-weight}",
+              "value": "{voorbeeld.document.strong.font-weight}",
               "type": "fontWeights"
             },
             "text-decoration": {
@@ -3674,7 +3694,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}"
             }
           },
           "text-decoration": {
@@ -3696,7 +3716,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}"
             }
           },
           "background-color": {
@@ -3709,7 +3729,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{utrecht.interaction.color}"
+            "value": "{voorbeeld.interaction.color}"
           },
           "min-block-size": {
             "type": "sizing",
@@ -3750,7 +3770,7 @@
             "type": "spacing"
           },
           "color": {
-            "value": "{utrecht.document.subtle.color}",
+            "value": "{voorbeeld.document.subtle.color}",
             "type": "color"
           },
           "font-weight": {
@@ -3850,11 +3870,11 @@
             "type": "borderWidth"
           },
           "background-color": {
-            "value": "{utrecht.form-control.active.background-color}",
+            "value": "{voorbeeld.form-control.active.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.active.border-color}",
+            "value": "{voorbeeld.form-control.active.border-color}",
             "type": "color"
           }
         },
@@ -3878,11 +3898,11 @@
         },
         "invalid": {
           "background-color": {
-            "value": "{utrecht.form-control.invalid.background-color}",
+            "value": "{voorbeeld.form-control.invalid.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.invalid.border-color}",
+            "value": "{voorbeeld.form-control.invalid.border-color}",
             "type": "color"
           },
           "border-width": {
@@ -3906,17 +3926,17 @@
         },
         "disabled": {
           "background-color": {
-            "value": "{utrecht.form-control.disabled.background-color}",
+            "value": "{voorbeeld.form-control.disabled.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.disabled.border-color}",
+            "value": "{voorbeeld.form-control.disabled.border-color}",
             "type": "color"
           }
         },
         "checked": {
           "background-color": {
-            "value": "{utrecht.form-control.accent-color}",
+            "value": "{voorbeeld.form-control.accent-color}",
             "type": "color"
           },
           "border-color": {
@@ -3929,7 +3949,7 @@
           },
           "hover": {
             "background-color": {
-              "value": "{utrecht.form-control.hover.accent-color}",
+              "value": "{voorbeeld.form-control.hover.accent-color}",
               "type": "color"
             },
             "border-color": {
@@ -3947,7 +3967,7 @@
           },
           "active": {
             "background-color": {
-              "value": "{utrecht.form-control.active.accent-color}",
+              "value": "{voorbeeld.form-control.active.accent-color}",
               "type": "color"
             },
             "border-color": {
@@ -3983,7 +4003,7 @@
           },
           "disabled": {
             "background-color": {
-              "value": "{utrecht.form-control.disabled.accent-color}",
+              "value": "{voorbeeld.form-control.disabled.accent-color}",
               "type": "color"
             },
             "border-color": {
@@ -4002,11 +4022,11 @@
         },
         "hover": {
           "background-color": {
-            "value": "{utrecht.form-control.hover.background-color}",
+            "value": "{voorbeeld.form-control.hover.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.hover.border-color}",
+            "value": "{voorbeeld.form-control.hover.border-color}",
             "type": "color"
           },
           "border-width": {
@@ -4049,7 +4069,7 @@
         "icon": {
           "size": {
             "type": "sizing",
-            "value": "{utrecht.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}"
           }
         },
         "background-color": {
@@ -4066,11 +4086,11 @@
         },
         "invalid": {
           "background-color": {
-            "value": "{utrecht.form-control.invalid.background-color}",
+            "value": "{voorbeeld.form-control.invalid.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.invalid.border-color}",
+            "value": "{voorbeeld.form-control.invalid.border-color}",
             "type": "color"
           },
           "color": {
@@ -4102,11 +4122,11 @@
         },
         "disabled": {
           "background-color": {
-            "value": "{utrecht.form-control.disabled.background-color}",
+            "value": "{voorbeeld.form-control.disabled.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.disabled.border-color}",
+            "value": "{voorbeeld.form-control.disabled.border-color}",
             "type": "color"
           },
           "color": {
@@ -4116,15 +4136,15 @@
         },
         "hover": {
           "background-color": {
-            "value": "{utrecht.form-control.hover.background-color}",
+            "value": "{voorbeeld.form-control.hover.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.hover.border-color}",
+            "value": "{voorbeeld.form-control.hover.border-color}",
             "type": "color"
           },
           "color": {
-            "value": "{utrecht.form-control.hover.color}",
+            "value": "{voorbeeld.form-control.hover.color}",
             "type": "color"
           },
           "border-width": {
@@ -4187,7 +4207,7 @@
     "utrecht": {
       "separator": {
         "color": {
-          "value": "{utrecht.line.border-color}",
+          "value": "{voorbeeld.line.border-color}",
           "type": "color"
         },
         "block-size": {
@@ -4216,7 +4236,7 @@
           "icon": {
             "size": {
               "type": "sizing",
-              "value": "{utrecht.icon.functional.size}"
+              "value": "{voorbeeld.icon.functional.size}"
             },
             "margin-inline": {
               "value": "{voorbeeld.space.text.mouse}",
@@ -4237,7 +4257,7 @@
           },
           "current": {
             "font-weight": {
-              "value": "{utrecht.document.strong.font-weight}",
+              "value": "{voorbeeld.document.strong.font-weight}",
               "type": "fontWeights"
             },
             "color": {
@@ -4247,12 +4267,12 @@
           },
           "color": {
             "type": "color",
-            "value": "{utrecht.interaction.color}"
+            "value": "{voorbeeld.interaction.color}"
           },
           "active": {
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}"
             },
             "text-decoration": {
               "value": "underline",
@@ -4276,7 +4296,7 @@
           "hover": {
             "color": {
               "type": "color",
-              "value": "{utrecht.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}"
             },
             "text-decoration": {
               "value": "underline",
@@ -4303,7 +4323,7 @@
     "utrecht": {
       "skip-link": {
         "font-weight": {
-          "value": "{utrecht.document.strong.font-weight}",
+          "value": "{voorbeeld.document.strong.font-weight}",
           "type": "fontWeights"
         },
         "font-family": {
@@ -4362,7 +4382,7 @@
         },
         "background-color": {
           "type": "color",
-          "value": "{utrecht.document.inverse.background-color}"
+          "value": "{voorbeeld.document.inverse.background-color}"
         },
         "border-color": {
           "value": "transparent",
@@ -4370,7 +4390,7 @@
         },
         "color": {
           "type": "color",
-          "value": "{utrecht.document.inverse.color}"
+          "value": "{voorbeeld.document.inverse.color}"
         },
         "border-width": {
           "type": "borderWidth",
@@ -4399,7 +4419,7 @@
           "type": "lineHeights"
         },
         "font-weight": {
-          "value": "{utrecht.document.strong.font-weight}",
+          "value": "{voorbeeld.document.strong.font-weight}",
           "type": "fontWeights"
         },
         "border-width": {
@@ -4433,7 +4453,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{utrecht.feedback.informative.color}"
+            "value": "{voorbeeld.feedback.informative.color}"
           }
         },
         "positive": {
@@ -4447,13 +4467,13 @@
           },
           "color": {
             "type": "color",
-            "value": "{utrecht.feedback.positive.color}"
+            "value": "{voorbeeld.feedback.positive.color}"
           }
         },
         "negative": {
           "background-color": {
             "type": "color",
-            "value": "{utrecht.feedback.negative.background-color}"
+            "value": "{voorbeeld.feedback.negative.background-color}"
           },
           "border-color": {
             "type": "color",
@@ -4461,7 +4481,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{utrecht.feedback.negative.color}"
+            "value": "{voorbeeld.feedback.negative.color}"
           }
         },
         "warning": {
@@ -4542,7 +4562,7 @@
         },
         "item-key": {
           "font-weight": {
-            "value": "{utrecht.document.strong.font-weight}",
+            "value": "{voorbeeld.document.strong.font-weight}",
             "type": "fontWeights"
           },
           "row": {
@@ -4586,7 +4606,7 @@
             "value": "{voorbeeld.border-width.sm}"
           },
           "border-color": {
-            "value": "{utrecht.line.border-color}",
+            "value": "{voorbeeld.line.border-color}",
             "type": "color"
           },
           "color": {
@@ -4742,7 +4762,7 @@
             }
           },
           "size": {
-            "value": "{utrecht.icon.functional.size}",
+            "value": "{voorbeeld.icon.functional.size}",
             "type": "sizing"
           }
         },
@@ -4816,7 +4836,7 @@
             "type": "fontFamilies"
           },
           "font-weight": {
-            "value": "{utrecht.document.strong.font-weight}",
+            "value": "{voorbeeld.document.strong.font-weight}",
             "type": "fontWeights"
           },
           "font-size": {
@@ -4834,7 +4854,7 @@
             "type": "spacing"
           },
           "color": {
-            "value": "{utrecht.heading.color}",
+            "value": "{voorbeeld.heading.color}",
             "type": "color"
           },
           "font-family": {
@@ -4896,7 +4916,7 @@
             "type": "borderWidth"
           },
           "border-block-end-color": {
-            "value": "{utrecht.line.border-color}",
+            "value": "{voorbeeld.line.border-color}",
             "type": "color"
           },
           "background-color": {
@@ -4910,7 +4930,7 @@
             "type": "borderWidth"
           },
           "border-block-end-color": {
-            "value": "{utrecht.line.border-color}",
+            "value": "{voorbeeld.line.border-color}",
             "type": "color"
           },
           "background-color": {
@@ -4924,7 +4944,7 @@
             "type": "borderWidth"
           },
           "border-block-end-color": {
-            "value": "{utrecht.line.border-color}",
+            "value": "{voorbeeld.line.border-color}",
             "type": "color"
           },
           "background-color": {
@@ -4934,7 +4954,7 @@
         },
         "footer-cell": {
           "font-weight": {
-            "value": "{utrecht.document.strong.font-weight}",
+            "value": "{voorbeeld.document.strong.font-weight}",
             "type": "fontWeights"
           },
           "font-size": {
@@ -5092,11 +5112,11 @@
         },
         "invalid": {
           "background-color": {
-            "value": "{utrecht.form-control.invalid.background-color}",
+            "value": "{voorbeeld.form-control.invalid.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.invalid.border-color}",
+            "value": "{voorbeeld.form-control.invalid.border-color}",
             "type": "color"
           },
           "color": {
@@ -5134,11 +5154,11 @@
         },
         "disabled": {
           "background-color": {
-            "value": "{utrecht.form-control.disabled.background-color}",
+            "value": "{voorbeeld.form-control.disabled.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.disabled.border-color}",
+            "value": "{voorbeeld.form-control.disabled.border-color}",
             "type": "color"
           },
           "color": {
@@ -5162,15 +5182,15 @@
         },
         "hover": {
           "background-color": {
-            "value": "{utrecht.form-control.hover.background-color}",
+            "value": "{voorbeeld.form-control.hover.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.hover.border-color}",
+            "value": "{voorbeeld.form-control.hover.border-color}",
             "type": "color"
           },
           "color": {
-            "value": "{utrecht.form-control.hover.color}",
+            "value": "{voorbeeld.form-control.hover.color}",
             "type": "color"
           },
           "border-width": {
@@ -5266,11 +5286,11 @@
         },
         "invalid": {
           "background-color": {
-            "value": "{utrecht.form-control.invalid.background-color}",
+            "value": "{voorbeeld.form-control.invalid.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.invalid.border-color}",
+            "value": "{voorbeeld.form-control.invalid.border-color}",
             "type": "color"
           },
           "color": {
@@ -5316,11 +5336,11 @@
         },
         "disabled": {
           "background-color": {
-            "value": "{utrecht.form-control.disabled.background-color}",
+            "value": "{voorbeeld.form-control.disabled.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.disabled.border-color}",
+            "value": "{voorbeeld.form-control.disabled.border-color}",
             "type": "color"
           },
           "color": {
@@ -5348,15 +5368,15 @@
             "type": "borderWidth"
           },
           "background-color": {
-            "value": "{utrecht.form-control.hover.background-color}",
+            "value": "{voorbeeld.form-control.hover.background-color}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.form-control.hover.border-color}",
+            "value": "{voorbeeld.form-control.hover.border-color}",
             "type": "color"
           },
           "color": {
-            "value": "{utrecht.form-control.hover.color}",
+            "value": "{voorbeeld.form-control.hover.color}",
             "type": "color"
           }
         }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4,517 +4,517 @@
       "typography": {
         "font-size": {
           "sm": {
-            "value": "14px",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "14px"
           },
           "md": {
-            "value": "16px",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "16px"
           },
           "lg": {
-            "value": "20px",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "20px"
           },
           "xl": {
-            "value": "24px",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "24px"
           },
           "2xl": {
-            "value": "32px",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "32px"
           },
           "3xl": {
-            "value": "40px",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "40px"
           },
           "4xl": {
-            "value": "48px",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "48px"
           }
         },
         "line-height": {
           "xs": {
-            "value": "100%",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "100%"
           },
           "sm": {
-            "value": "125%",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "125%"
           },
           "md": {
-            "value": "150%",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "150%"
           },
           "lg": {
-            "value": "200%",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "200%"
           }
         },
         "font-weight": {
           "normal": {
-            "value": "Regular",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "Regular"
           },
           "bold": {
-            "value": "Bold",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "Bold"
           }
         },
         "font-family": {
           "primary": {
-            "value": "Source Serif Pro, Tahoma, Verdana, sans-serif",
-            "type": "fontFamilies"
+            "$type": "fontFamilies",
+            "$value": "Source Serif Pro, Tahoma, Verdana, sans-serif"
           },
           "secondary": {
-            "value": "Fira Sans, Tahoma, Verdana, sans-serif",
-            "type": "fontFamilies"
+            "$type": "fontFamilies",
+            "$value": "Fira Sans, Tahoma, Verdana, sans-serif"
           }
         }
       },
       "color": {
         "white": {
-          "value": "#ffffff",
-          "type": "color"
+          "$type": "color",
+          "$value": "#ffffff"
         },
         "black": {
-          "value": "#000000",
-          "type": "color"
+          "$type": "color",
+          "$value": "#000000"
         },
         "violet": {
           "50": {
-            "value": "#FAF8FF",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FAF8FF"
           },
           "100": {
-            "value": "#F5F2FF",
-            "type": "color"
+            "$type": "color",
+            "$value": "#F5F2FF"
           },
           "200": {
-            "value": "#EBE3FF",
-            "type": "color"
+            "$type": "color",
+            "$value": "#EBE3FF"
           },
           "300": {
-            "value": "#DBCDFF",
-            "type": "color"
+            "$type": "color",
+            "$value": "#DBCDFF"
           },
           "400": {
-            "value": "#AF91FF",
-            "type": "color"
+            "$type": "color",
+            "$value": "#AF91FF"
           },
           "500": {
-            "value": "#966EFF",
-            "type": "color"
+            "$type": "color",
+            "$value": "#966EFF"
           },
           "600": {
-            "value": "#7744FF",
-            "type": "color"
+            "$type": "color",
+            "$value": "#7744FF"
           },
           "700": {
-            "value": "#5315F6",
-            "type": "color"
+            "$type": "color",
+            "$value": "#5315F6"
           },
           "800": {
-            "value": "#3F10BC",
-            "type": "color"
+            "$type": "color",
+            "$value": "#3F10BC"
           },
           "900": {
-            "value": "#290B7A",
-            "type": "color"
+            "$type": "color",
+            "$value": "#290B7A"
           },
           "950": {
-            "value": "#1A074C",
-            "type": "color"
+            "$type": "color",
+            "$value": "#1A074C"
           }
         },
         "gray": {
           "50": {
-            "value": "#F9F9FA",
-            "type": "color"
+            "$type": "color",
+            "$value": "#F9F9FA"
           },
           "100": {
-            "value": "#F2F4F6",
-            "type": "color"
+            "$type": "color",
+            "$value": "#F2F4F6"
           },
           "200": {
-            "value": "#E4E7EC",
-            "type": "color"
+            "$type": "color",
+            "$value": "#E4E7EC"
           },
           "300": {
-            "value": "#CFD5DD",
-            "type": "color"
+            "$type": "color",
+            "$value": "#CFD5DD"
           },
           "400": {
-            "value": "#98A4B6",
-            "type": "color"
+            "$type": "color",
+            "$value": "#98A4B6"
           },
           "500": {
-            "value": "#7A8AA0",
-            "type": "color"
+            "$type": "color",
+            "$value": "#7A8AA0"
           },
           "600": {
-            "value": "#5B6E8A",
-            "type": "color"
+            "$type": "color",
+            "$value": "#5B6E8A"
           },
           "700": {
-            "value": "#3F5676",
-            "type": "color"
+            "$type": "color",
+            "$value": "#3F5676"
           },
           "800": {
-            "value": "#274065",
-            "type": "color"
+            "$type": "color",
+            "$value": "#274065"
           },
           "900": {
-            "value": "#0A2750",
-            "type": "color"
+            "$type": "color",
+            "$value": "#0A2750"
           },
           "950": {
-            "value": "#001737",
-            "type": "color"
+            "$type": "color",
+            "$value": "#001737"
           }
         },
         "pink": {
           "50": {
-            "value": "#FDF8FA",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FDF8FA"
           },
           "100": {
-            "value": "#FCF1F6",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FCF1F6"
           },
           "200": {
-            "value": "#F8E1EB",
-            "type": "color"
+            "$type": "color",
+            "$value": "#F8E1EB"
           },
           "300": {
-            "value": "#F2C9DC",
-            "type": "color"
+            "$type": "color",
+            "$value": "#F2C9DC"
           },
           "400": {
-            "value": "#E287B0",
-            "type": "color"
+            "$type": "color",
+            "$value": "#E287B0"
           },
           "500": {
-            "value": "#D85E95",
-            "type": "color"
+            "$type": "color",
+            "$value": "#D85E95"
           },
           "600": {
-            "value": "#CA2771",
-            "type": "color"
+            "$type": "color",
+            "$value": "#CA2771"
           },
           "700": {
-            "value": "#A60E52",
-            "type": "color"
+            "$type": "color",
+            "$value": "#A60E52"
           },
           "800": {
-            "value": "#7F0B3F",
-            "type": "color"
+            "$type": "color",
+            "$value": "#7F0B3F"
           },
           "900": {
-            "value": "#520729",
-            "type": "color"
+            "$type": "color",
+            "$value": "#520729"
           },
           "950": {
-            "value": "#33041A",
-            "type": "color"
+            "$type": "color",
+            "$value": "#33041A"
           }
         },
         "red": {
           "50": {
-            "value": "#FFF8F8",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FFF8F8"
           },
           "100": {
-            "value": "#FEF0F1",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FEF0F1"
           },
           "200": {
-            "value": "#FEE0E1",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FEE0E1"
           },
           "300": {
-            "value": "#FDC7CA",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FDC7CA"
           },
           "400": {
-            "value": "#F97D83",
-            "type": "color"
+            "$type": "color",
+            "$value": "#F97D83"
           },
           "500": {
-            "value": "#F7464E",
-            "type": "color"
+            "$type": "color",
+            "$value": "#F7464E"
           },
           "600": {
-            "value": "#D2262E",
-            "type": "color"
+            "$type": "color",
+            "$value": "#D2262E"
           },
           "700": {
-            "value": "#A41E24",
-            "type": "color"
+            "$type": "color",
+            "$value": "#A41E24"
           },
           "800": {
-            "value": "#7E171C",
-            "type": "color"
+            "$type": "color",
+            "$value": "#7E171C"
           },
           "900": {
-            "value": "#500F12",
-            "type": "color"
+            "$type": "color",
+            "$value": "#500F12"
           },
           "950": {
-            "value": "#31090B",
-            "type": "color"
+            "$type": "color",
+            "$value": "#31090B"
           }
         },
         "orange": {
           "50": {
-            "value": "#FFF8F3",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FFF8F3"
           },
           "100": {
-            "value": "#FFF1E7",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FFF1E7"
           },
           "200": {
-            "value": "#FFE1CB",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FFE1CB"
           },
           "300": {
-            "value": "#FFC9A3",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FFC9A3"
           },
           "400": {
-            "value": "#FF7A2A",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FF7A2A"
           },
           "500": {
-            "value": "#DD6525",
-            "type": "color"
+            "$type": "color",
+            "$value": "#DD6525"
           },
           "600": {
-            "value": "#B2501F",
-            "type": "color"
+            "$type": "color",
+            "$value": "#B2501F"
           },
           "700": {
-            "value": "#8B3E18",
-            "type": "color"
+            "$type": "color",
+            "$value": "#8B3E18"
           },
           "800": {
-            "value": "#6A2E13",
-            "type": "color"
+            "$type": "color",
+            "$value": "#6A2E13"
           },
           "900": {
-            "value": "#431D0D",
-            "type": "color"
+            "$type": "color",
+            "$value": "#431D0D"
           },
           "950": {
-            "value": "#271208",
-            "type": "color"
+            "$type": "color",
+            "$value": "#271208"
           }
         },
         "yellow": {
           "50": {
-            "value": "#FFFADF",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FFFADF"
           },
           "100": {
-            "value": "#FFF5BE",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FFF5BE"
           },
           "200": {
-            "value": "#FFE76B",
-            "type": "color"
+            "$type": "color",
+            "$value": "#FFE76B"
           },
           "300": {
-            "value": "#F9D100",
-            "type": "color"
+            "$type": "color",
+            "$value": "#F9D100"
           },
           "400": {
-            "value": "#C0A100",
-            "type": "color"
+            "$type": "color",
+            "$value": "#C0A100"
           },
           "500": {
-            "value": "#A08700",
-            "type": "color"
+            "$type": "color",
+            "$value": "#A08700"
           },
           "600": {
-            "value": "#806C00",
-            "type": "color"
+            "$type": "color",
+            "$value": "#806C00"
           },
           "700": {
-            "value": "#645400",
-            "type": "color"
+            "$type": "color",
+            "$value": "#645400"
           },
           "800": {
-            "value": "#4B3F00",
-            "type": "color"
+            "$type": "color",
+            "$value": "#4B3F00"
           },
           "900": {
-            "value": "#2F2800",
-            "type": "color"
+            "$type": "color",
+            "$value": "#2F2800"
           },
           "950": {
-            "value": "#1C1800",
-            "type": "color"
+            "$type": "color",
+            "$value": "#1C1800"
           }
         },
         "green": {
           "50": {
-            "value": "#F2FCF4",
-            "type": "color"
+            "$type": "color",
+            "$value": "#F2FCF4"
           },
           "100": {
-            "value": "#E4F9EA",
-            "type": "color"
+            "$type": "color",
+            "$value": "#E4F9EA"
           },
           "200": {
-            "value": "#C5F1D1",
-            "type": "color"
+            "$type": "color",
+            "$value": "#C5F1D1"
           },
           "300": {
-            "value": "#94E6AB",
-            "type": "color"
+            "$type": "color",
+            "$value": "#94E6AB"
           },
           "400": {
-            "value": "#20BC4B",
-            "type": "color"
+            "$type": "color",
+            "$value": "#20BC4B"
           },
           "500": {
-            "value": "#1B9D3F",
-            "type": "color"
+            "$type": "color",
+            "$value": "#1B9D3F"
           },
           "600": {
-            "value": "#167E33",
-            "type": "color"
+            "$type": "color",
+            "$value": "#167E33"
           },
           "700": {
-            "value": "#116227",
-            "type": "color"
+            "$type": "color",
+            "$value": "#116227"
           },
           "800": {
-            "value": "#0D4A1E",
-            "type": "color"
+            "$type": "color",
+            "$value": "#0D4A1E"
           },
           "900": {
-            "value": "#082F13",
-            "type": "color"
+            "$type": "color",
+            "$value": "#082F13"
           },
           "950": {
-            "value": "#051C0B",
-            "type": "color"
+            "$type": "color",
+            "$value": "#051C0B"
           }
         },
         "sea-green": {
           "50": {
-            "value": "#F2FBFA",
-            "type": "color"
+            "$type": "color",
+            "$value": "#F2FBFA"
           },
           "100": {
-            "value": "#E5F7F5",
-            "type": "color"
+            "$type": "color",
+            "$value": "#E5F7F5"
           },
           "200": {
-            "value": "#C6EFE9",
-            "type": "color"
+            "$type": "color",
+            "$value": "#C6EFE9"
           },
           "300": {
-            "value": "#99E2D8",
-            "type": "color"
+            "$type": "color",
+            "$value": "#99E2D8"
           },
           "400": {
-            "value": "#05B7A0",
-            "type": "color"
+            "$type": "color",
+            "$value": "#05B7A0"
           },
           "500": {
-            "value": "#009A85",
-            "type": "color"
+            "$type": "color",
+            "$value": "#009A85"
           },
           "600": {
-            "value": "#007B6B",
-            "type": "color"
+            "$type": "color",
+            "$value": "#007B6B"
           },
           "700": {
-            "value": "#006053",
-            "type": "color"
+            "$type": "color",
+            "$value": "#006053"
           },
           "800": {
-            "value": "#00493F",
-            "type": "color"
+            "$type": "color",
+            "$value": "#00493F"
           },
           "900": {
-            "value": "#002E28",
-            "type": "color"
+            "$type": "color",
+            "$value": "#002E28"
           },
           "950": {
-            "value": "#001C18",
-            "type": "color"
+            "$type": "color",
+            "$value": "#001C18"
           }
         },
         "blue": {
           "50": {
-            "value": "#F4FAFE",
-            "type": "color"
+            "$type": "color",
+            "$value": "#F4FAFE"
           },
           "100": {
-            "value": "#E9F5FD",
-            "type": "color"
+            "$type": "color",
+            "$value": "#E9F5FD"
           },
           "200": {
-            "value": "#D0EBFB",
-            "type": "color"
+            "$type": "color",
+            "$value": "#D0EBFB"
           },
           "300": {
-            "value": "#ABDBF8",
-            "type": "color"
+            "$type": "color",
+            "$value": "#ABDBF8"
           },
           "400": {
-            "value": "#3EACEF",
-            "type": "color"
+            "$type": "color",
+            "$value": "#3EACEF"
           },
           "500": {
-            "value": "#008DE4",
-            "type": "color"
+            "$type": "color",
+            "$value": "#008DE4"
           },
           "600": {
-            "value": "#0071B7",
-            "type": "color"
+            "$type": "color",
+            "$value": "#0071B7"
           },
           "700": {
-            "value": "#00588F",
-            "type": "color"
+            "$type": "color",
+            "$value": "#00588F"
           },
           "800": {
-            "value": "#00436C",
-            "type": "color"
+            "$type": "color",
+            "$value": "#00436C"
           },
           "900": {
-            "value": "#002A44",
-            "type": "color"
+            "$type": "color",
+            "$value": "#002A44"
           },
           "950": {
-            "value": "#001A29",
-            "type": "color"
+            "$type": "color",
+            "$value": "#001A29"
           }
         },
         "light": {
           "alpha": {
             "50": {
-              "value": "#ffffff0d",
-              "type": "color"
+              "$type": "color",
+              "$value": "#ffffff0d"
             },
             "100": {
-              "value": "#ffffff1a",
-              "type": "color"
+              "$type": "color",
+              "$value": "#ffffff1a"
             }
           }
         },
         "dark": {
           "alpha": {
             "50": {
-              "value": "#0000000d",
-              "type": "color"
+              "$type": "color",
+              "$value": "#0000000d"
             },
             "100": {
-              "value": "#0000001a",
-              "type": "color"
+              "$type": "color",
+              "$value": "#0000001a"
             }
           }
         }
@@ -522,794 +522,792 @@
       "space": {
         "inline": {
           "flea": {
-            "value": "2px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "2px"
           },
           "ant": {
-            "value": "4px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "4px"
           },
           "beetle": {
-            "value": "8px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "8px"
           },
           "snail": {
-            "value": "12px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "12px"
           },
           "mouse": {
-            "value": "16px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "16px"
           },
           "rat": {
-            "value": "20px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "20px"
           },
           "rabbit": {
-            "value": "24px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "24px"
           },
           "cat": {
-            "value": "28px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "28px"
           },
           "dog": {
-            "value": "32px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "32px"
           },
           "pig": {
-            "value": "48px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "48px"
           }
         },
         "block": {
           "flea": {
-            "value": "2px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "2px"
           },
           "ant": {
-            "value": "4px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "4px"
           },
           "beetle": {
-            "value": "8px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "8px"
           },
           "snail": {
-            "value": "12px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "12px"
           },
           "mouse": {
-            "value": "16px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "16px"
           },
           "rat": {
-            "value": "20px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "20px"
           },
           "rabbit": {
-            "value": "24px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "24px"
           },
           "cat": {
-            "value": "32px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "32px"
           },
           "dog": {
-            "value": "48px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "48px"
           },
           "pig": {
-            "value": "64px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "64px"
           }
         },
         "text": {
           "flea": {
-            "value": "1px",
-            "type": "spacing",
-            "description": "0.125ch"
+            "$type": "spacing",
+            "$value": "1px",
+            "$description": "0.125ch"
           },
           "ant": {
-            "value": "2px",
-            "type": "spacing",
-            "description": "0.25ch"
+            "$type": "spacing",
+            "$value": "2px",
+            "$description": "0.25ch"
           },
           "beetle": {
-            "value": "4px",
-            "type": "spacing",
-            "description": "0.5ch"
+            "$type": "spacing",
+            "$value": "4px",
+            "$description": "0.5ch"
           },
           "snail": {
-            "value": "6px",
-            "type": "spacing",
-            "description": "0.75ch"
+            "$type": "spacing",
+            "$value": "6px",
+            "$description": "0.75ch"
           },
           "mouse": {
-            "value": "8px",
-            "type": "spacing",
-            "description": "1ch"
+            "$type": "spacing",
+            "$value": "8px",
+            "$description": "1ch"
           },
           "rat": {
-            "value": "12px",
-            "type": "spacing",
-            "description": "1.5ch"
+            "$type": "spacing",
+            "$value": "12px",
+            "$description": "1.5ch"
           },
           "rabbit": {
-            "value": "14px",
-            "type": "spacing",
-            "description": "1.75ch"
+            "$type": "spacing",
+            "$value": "14px",
+            "$description": "1.75ch"
           },
           "cat": {
-            "value": "16px",
-            "type": "spacing",
-            "description": "2ch"
+            "$type": "spacing",
+            "$value": "16px",
+            "$description": "2ch"
           },
           "dog": {
-            "value": "24px",
-            "type": "spacing",
-            "description": "3ch"
+            "$type": "spacing",
+            "$value": "24px",
+            "$description": "3ch"
           }
         },
         "column": {
           "flea": {
-            "value": "1px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "1px"
           },
           "ant": {
-            "value": "2px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "2px"
           },
           "beetle": {
-            "value": "4px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "4px"
           },
           "snail": {
-            "value": "8px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "8px"
           },
           "mouse": {
-            "value": "12px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "12px"
           },
           "rat": {
-            "value": "16px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "16px"
           },
           "rabbit": {
-            "value": "20px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "20px"
           },
           "cat": {
-            "value": "24px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "24px"
           },
           "dog": {
-            "value": "28px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "28px"
           },
           "pig": {
-            "value": "32px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "32px"
           },
           "tiger": {
-            "value": "48px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "48px"
           },
           "horse": {
-            "value": "64px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "64px"
           },
           "elephant": {
-            "value": "96px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "96px"
           },
           "giraffe": {
-            "value": "160px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "160px"
           }
         },
         "row": {
           "flea": {
-            "value": "1px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "1px"
           },
           "ant": {
-            "value": "2px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "2px"
           },
           "beetle": {
-            "value": "4px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "4px"
           },
           "snail": {
-            "value": "8px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "8px"
           },
           "mouse": {
-            "value": "12px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "12px"
           },
           "rat": {
-            "value": "16px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "16px"
           },
           "rabbit": {
-            "value": "20px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "20px"
           },
           "cat": {
-            "value": "24px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "24px"
           },
           "dog": {
-            "value": "28px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "28px"
           },
           "pig": {
-            "value": "32px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "32px"
           },
           "tiger": {
-            "value": "48px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "48px"
           },
           "horse": {
-            "value": "64px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "64px"
           },
           "elephant": {
-            "value": "96px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "96px"
           },
           "giraffe": {
-            "value": "160px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "160px"
           }
         }
       },
       "border-radius": {
         "sm": {
-          "value": "4px",
-          "type": "borderRadius"
+          "$type": "borderRadius",
+          "$value": "4px"
         },
         "md": {
-          "value": "8px",
-          "type": "borderRadius"
+          "$type": "borderRadius",
+          "$value": "8px"
         },
         "lg": {
-          "value": "16px",
-          "type": "borderRadius"
+          "$type": "borderRadius",
+          "$value": "16px"
         },
         "round": {
-          "value": "999px",
-          "type": "borderRadius"
+          "$type": "borderRadius",
+          "$value": "999px"
         }
       },
       "border-width": {
         "sm": {
-          "value": "1px",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "1px"
         },
         "md": {
-          "value": "2px",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "2px"
         },
         "lg": {
-          "value": "4px",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "4px"
         }
       },
       "size": {
         "5xs": {
-          "value": "2px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "2px"
         },
         "4xs": {
-          "value": "4px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "4px"
         },
         "3xs": {
-          "value": "8px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "8px"
         },
         "2xs": {
-          "value": "16px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "16px"
         },
         "xs": {
-          "value": "24px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "24px"
         },
         "sm": {
-          "value": "32px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "32px"
         },
         "md": {
-          "value": "48px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "48px"
         },
         "lg": {
-          "value": "64px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "64px"
         },
         "xl": {
-          "value": "96px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "96px"
         },
         "2xl": {
-          "value": "160px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "160px"
         },
         "icon": {
           "sm": {
-            "value": "16px",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "16px"
           },
           "md": {
-            "value": "24px",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "24px"
           },
           "lg": {
-            "value": "24px",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "24px"
           },
           "xl": {
-            "value": "24px",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "24px"
           },
           "2xl": {
-            "value": "32px",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "32px"
           },
           "3xl": {
-            "value": "40px",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "40px"
           },
           "4xl": {
-            "value": "48px",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "48px"
           }
         }
       },
       "box-shadow": {
         "sm": {
-          "value": {
+          "$type": "boxShadow",
+          "$value": {
             "x": "0",
             "y": "2",
             "blur": "6",
             "spread": "0",
             "color": "{voorbeeld.color.dark.alpha.100}",
             "type": "dropShadow"
-          },
-          "type": "boxShadow"
+          }
         },
         "md": {
-          "value": {
+          "$type": "boxShadow",
+          "$value": {
             "x": "0",
             "y": "8",
             "blur": "16",
             "spread": "0",
             "color": "{voorbeeld.color.dark.alpha.100}",
             "type": "dropShadow"
-          },
-          "type": "boxShadow"
+          }
         },
         "lg": {
-          "value": {
+          "$type": "boxShadow",
+          "$value": {
             "x": "0",
             "y": "16",
             "blur": "48",
             "spread": "0",
             "color": "{voorbeeld.color.dark.alpha.100}",
             "type": "dropShadow"
-          },
-          "type": "boxShadow"
+          }
         }
       }
     }
   },
   "common": {
     "utrecht": {
-      "root": {
-        "background-color": {
-          "value": "{voorbeeld.color.gray.50}",
-          "type": "color"
-        }
-      },
       "document": {
         "background-color": {
-          "value": "{voorbeeld.color.white}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.white}"
         },
         "color": {
-          "value": "{voorbeeld.color.gray.900}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.900}"
         },
         "font-family": {
-          "value": "{voorbeeld.typography.font-family.secondary}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{voorbeeld.typography.font-family.secondary}"
         },
         "font-size": {
-          "value": "{voorbeeld.typography.font-size.md}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.md}"
         },
         "font-weight": {
-          "value": "{voorbeeld.typography.font-weight.normal}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.typography.font-weight.normal}"
         },
         "line-height": {
-          "value": "{voorbeeld.typography.line-height.md}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{voorbeeld.typography.line-height.md}"
         }
       },
       "heading": {
         "font-family": {
-          "value": "{voorbeeld.typography.font-family.primary}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{voorbeeld.typography.font-family.primary}"
         },
         "font-weight": {
-          "value": "{voorbeeld.typography.font-weight.bold}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.typography.font-weight.bold}"
         }
       },
       "focus": {
         "background-color": {
-          "value": "{voorbeeld.color.yellow.200}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.yellow.200}"
         },
         "outline-color": {
-          "value": "{voorbeeld.color.violet.700}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.violet.700}"
         },
         "inverse": {
           "outline-color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
           }
         },
         "outline-offset": {
-          "value": "0",
-          "type": "other"
+          "$type": "other",
+          "$value": "0"
         },
         "outline-style": {
-          "value": "dotted",
-          "type": "other"
+          "$type": "other",
+          "$value": "dotted"
         },
         "outline-width": {
-          "value": "{voorbeeld.border-width.md}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.md}"
         }
       },
       "form-control": {
         "background-color": {
-          "value": "{voorbeeld.color.white}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.white}"
         },
         "border-color": {
-          "value": "{voorbeeld.color.gray.500}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.500}"
         },
         "border-width": {
-          "value": "{voorbeeld.border-width.sm}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
         },
         "color": {
-          "value": "{voorbeeld.color.gray.950}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.950}"
         },
         "disabled": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.50}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.500}"
+          },
           "color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.500}"
           }
         },
         "focus": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
+          },
           "border-color": {
-            "value": "{voorbeeld.color.black}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.black}"
           },
           "color": {
-            "value": "{voorbeeld.color.black}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.black}"
           }
         },
         "invalid": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.negative.border-color}"
+          },
           "color": {
-            "value": "{voorbeeld.feedback.negative.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.negative.color}"
+          },
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.md}"
           }
         },
         "read-only": {
           "background-color": {
-            "value": "{voorbeeld.color.gray.50}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.50}"
           },
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "value": "{voorbeeld.color.gray.950}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.950}"
           }
         },
         "placeholder": {
           "color": {
-            "value": "{voorbeeld.color.gray.600}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.600}"
           }
         }
       },
       "pointer-target": {
         "min-size": {
-          "value": "{voorbeeld.size.md}",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "{voorbeeld.size.md}"
         }
       },
       "feedback": {
         "warning": {
           "background-color": {
-            "value": "{voorbeeld.color.yellow.100}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.yellow.100}"
           },
           "border-color": {
-            "value": "{voorbeeld.color.yellow.600}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.yellow.600}"
           },
           "color": {
-            "value": "{voorbeeld.color.yellow.600}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.yellow.600}"
           }
         }
       }
     },
     "voorbeeld": {
+      "root": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.50}"
+        }
+      },
       "container": {
         "border-width": {
-          "value": "{voorbeeld.border-width.sm}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
         },
         "border-color": {
-          "value": "{voorbeeld.color.gray.200}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.200}"
         }
       },
       "line": {
         "border-width": {
-          "value": "{voorbeeld.border-width.sm}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
         },
         "border-color": {
-          "value": "{voorbeeld.color.gray.200}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.200}"
         }
       },
       "focus": {
         "color": {
-          "value": "{voorbeeld.color.black}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.black}"
         }
       },
       "form-control": {
         "active": {
           "border-width": {
-            "value": "{voorbeeld.border-width.md}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.md}"
           },
           "accent-color": {
-            "value": "{voorbeeld.interaction.active.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.active.color}"
           },
           "background-color": {
-            "value": "{voorbeeld.color.gray.100}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.100}"
           },
           "border-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.500}"
           },
           "color": {
-            "value": "{voorbeeld.color.gray.950}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.950}"
           }
         },
         "focus": {
-          "background-color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
-          },
           "border-width": {
-            "value": "{voorbeeld.border-width.md}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.md}"
           }
         },
         "hover": {
           "border-width": {
-            "value": "{voorbeeld.border-width.md}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.md}"
           },
           "accent-color": {
-            "value": "{voorbeeld.interaction.hover.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.hover.color}"
           },
           "background-color": {
-            "value": "{voorbeeld.color.gray.50}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.50}"
           },
           "border-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.500}"
           },
           "color": {
-            "value": "{voorbeeld.color.gray.950}",
-            "type": "color"
-          }
-        },
-        "invalid": {
-          "border-width": {
-            "value": "{voorbeeld.border-width.md}",
-            "type": "borderWidth"
-          },
-          "background-color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{voorbeeld.feedback.negative.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.950}"
           }
         },
         "accent-color": {
-          "value": "{voorbeeld.interaction.color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.interaction.color}"
         },
         "disabled": {
           "accent-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
-          },
-          "background-color": {
-            "value": "{voorbeeld.color.gray.50}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.500}"
           }
         }
       },
       "document": {
         "inverse": {
           "background-color": {
-            "value": "{voorbeeld.color.gray.950}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.950}"
           },
           "color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
           }
         },
         "subtle": {
           "color": {
-            "value": "{voorbeeld.color.gray.600}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.600}"
           }
         },
         "strong": {
           "font-weight": {
-            "value": "{voorbeeld.typography.font-weight.bold}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{voorbeeld.typography.font-weight.bold}"
           }
         }
       },
       "heading": {
         "color": {
-          "value": "{voorbeeld.color.gray.900}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.900}"
         }
       },
       "interaction": {
         "color": {
-          "value": "{voorbeeld.color.violet.700}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.violet.700}"
         },
         "active": {
           "color": {
-            "value": "{voorbeeld.color.violet.900}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.violet.900}"
           }
         },
         "hover": {
           "color": {
-            "value": "{voorbeeld.color.violet.800}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.violet.800}"
           }
         }
       },
       "icon": {
         "functional": {
           "size": {
-            "value": "{voorbeeld.size.icon.md}",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "{voorbeeld.size.icon.md}"
           }
         },
         "toptask": {
           "size": {
-            "value": "{voorbeeld.size.icon.4xl}",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "{voorbeeld.size.icon.4xl}"
           }
         }
       },
       "feedback": {
         "informative": {
           "background-color": {
-            "value": "{voorbeeld.color.blue.100}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.blue.100}"
           },
           "border-color": {
-            "value": "{voorbeeld.color.blue.600}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.blue.600}"
           },
           "color": {
-            "value": "{voorbeeld.color.blue.600}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.blue.600}"
           }
         },
         "negative": {
           "background-color": {
-            "value": "{voorbeeld.color.red.100}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.red.100}"
           },
           "border-color": {
-            "value": "{voorbeeld.color.red.600}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.red.600}"
           },
           "color": {
-            "value": "{voorbeeld.color.red.600}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.red.600}"
           }
         },
         "positive": {
           "background-color": {
-            "value": "{voorbeeld.color.green.100}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.green.100}"
           },
           "border-color": {
-            "value": "{voorbeeld.color.green.600}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.green.600}"
           },
           "color": {
-            "value": "{voorbeeld.color.green.600}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.green.600}"
           }
         }
       },
       "space": {
         "relation": {
           "kind": {
-            "value": "0px",
-            "type": "dimension"
+            "$type": "dimension",
+            "$value": "0px"
           },
           "besties": {
-            "value": "{voorbeeld.space.row.snail}",
-            "type": "dimension"
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.row.snail}"
           },
           "vrienden": {
-            "value": "{voorbeeld.space.row.rat}",
-            "type": "dimension"
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.row.rat}"
           },
           "bekenden": {
-            "value": "{voorbeeld.space.row.cat}",
-            "type": "dimension"
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.row.cat}"
           },
           "onbekenden": {
-            "value": "{voorbeeld.space.row.pig}",
-            "type": "dimension"
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.row.pig}"
           },
           "onbemind": {
-            "value": "{voorbeeld.space.row.horse}",
-            "type": "dimension"
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.row.horse}"
           }
         }
       }
@@ -1319,193 +1317,193 @@
     "utrecht": {
       "accordion": {
         "border-radius": {
-          "type": "borderRadius",
-          "value": "0px"
+          "$type": "borderRadius",
+          "$value": "0px"
         },
         "panel": {
           "border-width": {
-            "type": "borderWidth",
-            "value": "0px"
+            "$type": "borderWidth",
+            "$value": "0px"
           },
           "padding-block-end": {
-            "type": "spacing",
-            "value": "{voorbeeld.space.block.rabbit}"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-block-start": {
-            "type": "spacing",
-            "value": "{voorbeeld.space.block.rabbit}"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-inline-end": {
-            "type": "spacing",
-            "value": "{voorbeeld.space.inline.mouse}"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-start": {
-            "type": "spacing",
-            "value": "{voorbeeld.space.inline.mouse}"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           }
         },
         "section": {
           "border-block-end-width": {
-            "type": "borderWidth",
-            "value": "{voorbeeld.border-width.sm}"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           },
           "border-width": {
-            "type": "borderWidth",
-            "value": "auto"
+            "$type": "borderWidth",
+            "$value": "auto"
           },
           "border-color": {
-            "value": "{voorbeeld.line.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.line.border-color}"
           }
         },
         "body": {
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "border-width": {
-            "type": "borderWidth",
-            "value": "{voorbeeld.border-width.lg}"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.lg}"
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.rabbit}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.rabbit}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-inline-end": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-start": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           }
         },
         "button": {
           "font-size": {
-            "value": "{utrecht.document.font-size}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{utrecht.document.font-size}"
           },
           "gap": {
-            "type": "spacing",
-            "value": "{voorbeeld.space.text.mouse}"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.text.mouse}"
           },
           "line-height": {
-            "value": "{utrecht.document.line-height}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
           },
           "icon": {
             "margin-inline": {
-              "value": "{voorbeeld.space.text.mouse}",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.text.mouse}"
             },
             "size": {
-              "type": "sizing",
-              "value": "{voorbeeld.icon.functional.size}"
+              "$type": "sizing",
+              "$value": "{voorbeeld.icon.functional.size}"
             }
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-start": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "hover": {
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.color.gray.100}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.100}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.hover.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
             }
           },
           "expanded": {
             "background-color": {
-              "value": "{voorbeeld.color.gray.50}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.50}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.color}"
             }
           },
           "background-color": {
-            "type": "color",
-            "value": "{voorbeeld.color.gray.50}"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.50}"
           },
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.interaction.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
           },
           "focus": {
             "background-color": {
-              "type": "color",
-              "value": "{utrecht.focus.background-color}"
+              "$type": "color",
+              "$value": "{utrecht.focus.background-color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.focus.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "active": {
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.color.gray.200}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.200}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.active.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.active.color}"
             }
           },
           "border-width": {
-            "type": "borderWidth",
-            "value": "{voorbeeld.border-width.sm}"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           },
           "border-radius": {
-            "type": "borderRadius",
-            "value": "0px"
+            "$type": "borderRadius",
+            "$value": "0px"
           },
           "font-family": {
-            "value": "{utrecht.document.font-family}",
-            "type": "fontFamilies"
+            "$type": "fontFamilies",
+            "$value": "{utrecht.document.font-family}"
           },
           "font-weight": {
-            "value": "{voorbeeld.document.strong.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{voorbeeld.document.strong.font-weight}"
           }
         }
       }
@@ -1516,165 +1514,165 @@
       "alert": {
         "heading": {
           "font-family": {
-            "value": "{utrecht.heading.font-family}",
-            "type": "fontFamilies"
+            "$type": "fontFamilies",
+            "$value": "{utrecht.heading.font-family}"
           },
           "font-weight": {
-            "value": "{utrecht.heading.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{utrecht.heading.font-weight}"
           },
           "line-height": {
-            "value": "{voorbeeld.typography.line-height.sm}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{voorbeeld.typography.line-height.sm}"
           },
           "font-size": {
-            "value": "{voorbeeld.typography.font-size.xl}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{voorbeeld.typography.font-size.xl}"
           }
         },
         "column-gap": {
-          "value": "{voorbeeld.space.column.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.column.snail}"
         },
         "border-width": {
-          "value": "{voorbeeld.border-width.md}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.md}"
         },
         "margin-block-end": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "margin-block-start": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-end": {
-          "value": "{voorbeeld.space.block.rat}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.rat}"
         },
         "padding-block-start": {
-          "value": "{voorbeeld.space.block.mouse}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.mouse}"
         },
         "padding-inline-end": {
-          "value": "{voorbeeld.space.inline.mouse}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.mouse}"
         },
         "padding-inline-start": {
-          "value": "{voorbeeld.space.inline.mouse}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.mouse}"
         },
         "background-color": {
-          "value": "{voorbeeld.feedback.informative.background-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.feedback.informative.background-color}"
         },
         "border-color": {
-          "value": "{voorbeeld.feedback.informative.border-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.feedback.informative.border-color}"
         },
         "color": {
-          "value": "{utrecht.document.color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
         },
         "info": {
           "background-color": {
-            "value": "{voorbeeld.feedback.informative.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.informative.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.feedback.informative.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.informative.border-color}"
           },
           "color": {
-            "value": "{utrecht.document.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           }
         },
         "error": {
           "background-color": {
-            "value": "{voorbeeld.feedback.negative.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.negative.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.feedback.negative.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.negative.border-color}"
           },
           "color": {
-            "value": "{utrecht.document.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           }
         },
         "ok": {
           "background-color": {
-            "value": "{voorbeeld.feedback.positive.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.positive.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.feedback.positive.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.positive.border-color}"
           },
           "color": {
-            "value": "{utrecht.document.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           }
         },
         "warning": {
           "background-color": {
-            "value": "{utrecht.feedback.warning.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.feedback.warning.background-color}"
           },
           "border-color": {
-            "value": "{utrecht.feedback.warning.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.feedback.warning.border-color}"
           },
           "color": {
-            "value": "{utrecht.document.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           }
         },
         "icon": {
           "inset-block-start": {
-            "value": "{voorbeeld.space.block.flea}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.flea}"
           },
           "info": {
             "color": {
-              "value": "{voorbeeld.feedback.informative.color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.feedback.informative.color}"
             }
           },
           "error": {
             "color": {
-              "value": "{voorbeeld.feedback.negative.color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.feedback.negative.color}"
             }
           },
           "ok": {
             "color": {
-              "value": "{voorbeeld.feedback.positive.color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.feedback.positive.color}"
             }
           },
           "warning": {
             "color": {
-              "value": "{utrecht.feedback.warning.color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.feedback.warning.color}"
             }
           },
           "size": {
-            "type": "sizing",
-            "value": "{voorbeeld.icon.functional.size}"
+            "$type": "sizing",
+            "$value": "{voorbeeld.icon.functional.size}"
           }
         },
         "message": {
           "row-gap": {
-            "value": "{voorbeeld.space.row.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.row.snail}"
           }
         },
         "border-radius": {
-          "value": "0px",
-          "type": "borderRadius"
+          "$type": "borderRadius",
+          "$value": "0px"
         }
       }
     }
@@ -1683,69 +1681,69 @@
     "todo": {
       "avatar": {
         "background-color": {
-          "value": "{voorbeeld.interaction.color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.interaction.color}"
         },
         "border-radius": {
-          "value": "{voorbeeld.border-radius.round}",
-          "type": "borderRadius"
+          "$type": "borderRadius",
+          "$value": "{voorbeeld.border-radius.round}"
         },
         "size": {
-          "value": "{utrecht.pointer-target.min-size}",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "{utrecht.pointer-target.min-size}"
         },
         "icon": {
           "icon-size": {
-            "value": "{voorbeeld.icon.functional.size}",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "{voorbeeld.icon.functional.size}"
           }
         },
         "border-color": {
-          "value": "transparent",
-          "type": "color"
+          "$type": "color",
+          "$value": "transparent"
         },
         "color": {
-          "value": "{voorbeeld.color.white}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.white}"
         },
         "text": {
           "font-family": {
-            "value": "{utrecht.document.font-family}",
-            "type": "fontFamilies"
+            "$type": "fontFamilies",
+            "$value": "{utrecht.document.font-family}"
           },
           "font-weight": {
-            "value": "{voorbeeld.document.strong.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{voorbeeld.document.strong.font-weight}"
           },
           "line-height": {
-            "value": "{utrecht.document.line-height}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
           },
           "text-transform": {
-            "value": "uppercase",
-            "type": "textCase"
+            "$type": "textCase",
+            "$value": "uppercase"
           },
           "font-size": {
-            "value": "{utrecht.document.font-size}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{utrecht.document.font-size}"
           }
         },
         "border-width": {
-          "value": "{voorbeeld.border-width.sm}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
         },
         "hover": {
           "background-color": {
-            "value": "{voorbeeld.interaction.hover.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.hover.color}"
           },
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
           }
         }
       }
@@ -1755,31 +1753,31 @@
     "utrecht": {
       "backdrop": {
         "background-color": {
-          "value": "{voorbeeld.color.black}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.black}"
         },
         "color": {
-          "value": "{voorbeeld.color.white}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.color.white}"
         },
         "opacity": {
-          "value": "0.2",
-          "type": "opacity"
+          "$type": "opacity",
+          "$value": "0.2"
         },
         "reduced-transparency": {
           "opacity": {
-            "value": "0.98",
-            "type": "opacity"
+            "$type": "opacity",
+            "$value": "0.98"
           }
         },
         "z-index": {
-          "value": "auto",
-          "type": "other"
+          "$type": "other",
+          "$value": "auto"
         },
         "fade-in": {
           "animation-duration": {
-            "value": "0.4s",
-            "type": "other"
+            "$type": "other",
+            "$value": "0.4s"
           }
         }
       }
@@ -1790,71 +1788,71 @@
       "blockquote": {
         "attribution": {
           "font-size": {
-            "value": "{voorbeeld.typography.font-size.sm}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{voorbeeld.typography.font-size.sm}"
           },
           "font-family": {
-            "value": "{utrecht.document.font-family}",
-            "type": "fontFamilies"
+            "$type": "fontFamilies",
+            "$value": "{utrecht.document.font-family}"
           },
           "line-height": {
-            "value": "{voorbeeld.typography.line-height.md}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{voorbeeld.typography.line-height.md}"
           },
           "font-weight": {
-            "value": "{utrecht.document.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "color": {
-            "value": "{voorbeeld.document.subtle.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.document.subtle.color}"
           }
         },
         "content": {
           "font-family": {
-            "value": "{utrecht.heading.font-family}",
-            "type": "fontFamilies"
+            "$type": "fontFamilies",
+            "$value": "{utrecht.heading.font-family}"
           },
           "line-height": {
-            "value": "{voorbeeld.typography.line-height.sm}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{voorbeeld.typography.line-height.sm}"
           },
           "font-weight": {
-            "value": "{utrecht.document.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
           },
           "font-size": {
-            "value": "{voorbeeld.typography.font-size.xl}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{voorbeeld.typography.font-size.xl}"
           },
           "color": {
-            "value": "{utrecht.document.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           }
         },
         "padding-block-end": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "value": "0px",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "0px"
         },
         "padding-inline-start": {
-          "value": "0px",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "0px"
         },
         "background-color": {
-          "value": "transparent",
-          "type": "color"
+          "$type": "color",
+          "$value": "transparent"
         }
       }
     }
@@ -1863,110 +1861,110 @@
     "todo": {
       "breadcrumb-nav": {
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "link": {
           "icon": {
             "size": {
-              "type": "sizing",
-              "value": "{voorbeeld.icon.functional.size}"
+              "$type": "sizing",
+              "$value": "{voorbeeld.icon.functional.size}"
             },
             "margin-inline": {
-              "value": "{voorbeeld.space.text.beetle}",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.text.beetle}"
             }
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "value": "0px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "0px"
           },
           "padding-inline-start": {
-            "value": "0px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "0px"
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.interaction.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
           },
           "active": {
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.active.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.active.color}"
             },
             "text-decoration": {
-              "value": "None",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "None"
             }
           },
           "focus": {
             "background-color": {
-              "type": "color",
-              "value": "{utrecht.focus.background-color}"
+              "$type": "color",
+              "$value": "{utrecht.focus.background-color}"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.focus.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.focus.color}"
             },
             "text-decoration": {
-              "value": "None",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "None"
             }
           },
           "hover": {
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.hover.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
             },
             "text-decoration": {
-              "value": "None",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "None"
             }
           },
           "current": {
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.document.subtle.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.document.subtle.color}"
             }
           },
           "text-decoration": {
-            "value": "underline",
-            "type": "textDecoration"
+            "$type": "textDecoration",
+            "$value": "underline"
           }
         },
         "divider": {
           "size": {
-            "type": "sizing",
-            "value": "{voorbeeld.size.2xs}"
+            "$type": "sizing",
+            "$value": "{voorbeeld.size.2xs}"
           },
           "color": {
-            "value": "{voorbeeld.document.subtle.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.document.subtle.color}"
           }
         },
         "margin-inline": {
-          "value": "{voorbeeld.space.inline.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.beetle}"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-weight": {
-          "value": "{utrecht.document.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         }
       }
     }
@@ -1975,375 +1973,375 @@
     "utrecht": {
       "button": {
         "background-color": {
-          "type": "color",
-          "value": "transparent"
+          "$type": "color",
+          "$value": "transparent"
         },
         "border-color": {
-          "type": "color",
-          "value": "{voorbeeld.color.gray.900}"
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.900}"
         },
         "color": {
-          "type": "color",
-          "value": "{voorbeeld.color.gray.900}"
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.900}"
         },
         "border-radius": {
-          "type": "borderRadius",
-          "value": "{voorbeeld.border-radius.md}"
+          "$type": "borderRadius",
+          "$value": "{voorbeeld.border-radius.md}"
         },
         "border-width": {
-          "type": "borderWidth",
-          "value": "{voorbeeld.border-width.sm}"
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
         },
         "icon": {
           "size": {
-            "type": "sizing",
-            "value": "{voorbeeld.icon.functional.size}"
+            "$type": "sizing",
+            "$value": "{voorbeeld.icon.functional.size}"
           }
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "font-weight": {
-          "value": "{voorbeeld.document.strong.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.document.strong.font-weight}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "padding-block-end": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "value": "{voorbeeld.space.inline.mouse}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.mouse}"
         },
         "padding-inline-start": {
-          "value": "{voorbeeld.space.inline.mouse}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.mouse}"
         },
         "disabled": {
           "background-color": {
-            "value": "{voorbeeld.color.gray.50}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.50}"
           },
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.500}"
           }
         },
         "focus": {
           "background-color": {
-            "value": "{utrecht.focus.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.focus.background-color}"
           },
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "value": "{voorbeeld.focus.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.focus.color}"
           }
         },
         "hover": {
           "background-color": {
-            "value": "{voorbeeld.color.gray.50}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.50}"
           },
           "border-color": {
-            "value": "{voorbeeld.interaction.hover.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.hover.color}"
           },
           "color": {
-            "value": "{voorbeeld.interaction.hover.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.hover.color}"
           }
         },
         "active": {
           "background-color": {
-            "value": "{voorbeeld.color.gray.100}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.100}"
           },
           "border-color": {
-            "value": "{voorbeeld.interaction.active.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.active.color}"
           },
           "color": {
-            "value": "{voorbeeld.interaction.active.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.active.color}"
           }
         },
         "min-block-size": {
-          "type": "sizing",
-          "value": "{utrecht.pointer-target.min-size}"
+          "$type": "sizing",
+          "$value": "{utrecht.pointer-target.min-size}"
         },
         "min-inline-size": {
-          "type": "sizing",
-          "value": "{utrecht.pointer-target.min-size}"
+          "$type": "sizing",
+          "$value": "{utrecht.pointer-target.min-size}"
         },
         "column-gap": {
-          "value": "{voorbeeld.space.text.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.text.beetle}"
         },
         "primary-action": {
           "hover": {
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.hover.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.color.white}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             }
           },
           "background-color": {
-            "type": "color",
-            "value": "{voorbeeld.interaction.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
           },
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.color.white}"
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
           },
           "disabled": {
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.color.gray.50}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.50}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.color.gray.500}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.500}"
             }
           },
           "focus": {
             "background-color": {
-              "type": "color",
-              "value": "{utrecht.focus.background-color}"
+              "$type": "color",
+              "$value": "{utrecht.focus.background-color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.focus.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "font-weight": {
-            "value": "{voorbeeld.document.strong.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{voorbeeld.document.strong.font-weight}"
           },
           "active": {
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.active.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.active.color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.color.white}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             }
           },
           "font-size": {
-            "value": "{utrecht.document.font-size}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{utrecht.document.font-size}"
           },
           "line-height": {
-            "value": "{utrecht.document.line-height}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
           }
         },
         "secondary-action": {
           "hover": {
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.color.gray.50}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.50}"
             },
             "border-color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.hover.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.hover.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
             }
           },
           "background-color": {
-            "type": "color",
-            "value": "{voorbeeld.color.white}"
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
           },
           "border-color": {
-            "type": "color",
-            "value": "{voorbeeld.interaction.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.interaction.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
           },
           "disabled": {
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.color.gray.50}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.50}"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.color.gray.500}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.500}"
             }
           },
           "focus": {
             "background-color": {
-              "type": "color",
-              "value": "{utrecht.focus.background-color}"
+              "$type": "color",
+              "$value": "{utrecht.focus.background-color}"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.focus.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "font-weight": {
-            "value": "{voorbeeld.document.strong.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{voorbeeld.document.strong.font-weight}"
           },
           "active": {
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.color.gray.100}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.100}"
             },
             "border-color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.active.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.active.color}"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.active.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.active.color}"
             }
           },
           "font-size": {
-            "value": "{utrecht.document.font-size}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{utrecht.document.font-size}"
           },
           "line-height": {
-            "value": "{utrecht.document.line-height}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
           }
         },
         "subtle": {
           "font-size": {
-            "value": "{utrecht.document.font-size}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{utrecht.document.font-size}"
           },
           "font-weight": {
-            "value": "{voorbeeld.document.strong.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{voorbeeld.document.strong.font-weight}"
           },
           "hover": {
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.color.dark.alpha.50}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.dark.alpha.50}"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.hover.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
             }
           },
           "background-color": {
-            "type": "color",
-            "value": "transparent"
+            "$type": "color",
+            "$value": "transparent"
           },
           "border-color": {
-            "type": "color",
-            "value": "transparent"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.interaction.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
           },
           "disabled": {
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.color.gray.50}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.50}"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.color.gray.500}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.500}"
             }
           },
           "focus": {
             "background-color": {
-              "type": "color",
-              "value": "{utrecht.focus.background-color}"
+              "$type": "color",
+              "$value": "{utrecht.focus.background-color}"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.focus.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "active": {
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.color.dark.alpha.100}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.dark.alpha.100}"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.active.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.active.color}"
             }
           },
           "line-height": {
-            "value": "{utrecht.document.line-height}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
           }
         }
       }
@@ -2353,32 +2351,32 @@
     "utrecht": {
       "button-group": {
         "background-color": {
-          "value": "transparent",
-          "type": "color"
+          "$type": "color",
+          "$value": "transparent"
         },
         "column-gap": {
-          "value": "{voorbeeld.space.column.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.column.snail}"
         },
         "margin-block-end": {
-          "value": "0px",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "0px"
         },
         "margin-block-start": {
-          "value": "0px",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "0px"
         },
         "padding-block-end": {
-          "value": "0px",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "0px"
         },
         "padding-block-start": {
-          "value": "0px",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "0px"
         },
         "row-gap": {
-          "value": "{voorbeeld.space.row.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.row.snail}"
         }
       }
     }
@@ -2387,267 +2385,267 @@
     "utrecht": {
       "checkbox": {
         "border-radius": {
-          "type": "borderRadius",
-          "value": "0px"
+          "$type": "borderRadius",
+          "$value": "0px"
         },
         "size": {
-          "type": "sizing",
-          "value": "{voorbeeld.size.xs}"
+          "$type": "sizing",
+          "$value": "{voorbeeld.size.xs}"
         },
         "icon": {
           "size": {
-            "type": "sizing",
-            "value": "{voorbeeld.icon.functional.size}"
+            "$type": "sizing",
+            "$value": "{voorbeeld.icon.functional.size}"
           }
         },
         "background-color": {
-          "value": "{utrecht.form-control.background-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.background-color}"
         },
         "border-color": {
-          "value": "{utrecht.form-control.border-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.border-color}"
         },
         "invalid": {
           "background-color": {
-            "value": "{voorbeeld.form-control.invalid.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.invalid.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.border-color}"
           },
           "border-width": {
-            "value": "{voorbeeld.form-control.invalid.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.invalid.border-width}"
           }
         },
         "focus": {
           "background-color": {
-            "value": "{voorbeeld.form-control.focus.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.background-color}"
           },
           "border-color": {
-            "value": "{utrecht.form-control.focus.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.border-color}"
           },
           "border-width": {
-            "value": "{voorbeeld.form-control.focus.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.focus.border-width}"
           }
         },
         "disabled": {
           "background-color": {
-            "value": "{voorbeeld.form-control.disabled.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.disabled.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.border-color}"
           }
         },
         "checked": {
           "background-color": {
-            "value": "{voorbeeld.form-control.accent-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.accent-color}"
           },
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
           },
           "border-width": {
-            "value": "{utrecht.form-control.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.border-width}"
           },
           "disabled": {
             "background-color": {
-              "value": "{voorbeeld.form-control.disabled.accent-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.form-control.disabled.accent-color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "value": "{voorbeeld.color.white}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             }
           },
           "focus": {
             "border-width": {
-              "value": "{voorbeeld.form-control.focus.border-width}",
-              "type": "borderWidth"
+              "$type": "borderWidth",
+              "$value": "{voorbeeld.form-control.focus.border-width}"
             },
             "background-color": {
-              "value": "{voorbeeld.form-control.focus.background-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.form-control.focus.background-color}"
             },
             "border-color": {
-              "value": "{utrecht.form-control.focus.border-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.form-control.focus.border-color}"
             },
             "color": {
-              "value": "{utrecht.form-control.focus.color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.form-control.focus.color}"
             }
           },
           "hover": {
             "border-width": {
-              "value": "{voorbeeld.form-control.hover.border-width}",
-              "type": "borderWidth"
+              "$type": "borderWidth",
+              "$value": "{voorbeeld.form-control.hover.border-width}"
             },
             "background-color": {
-              "value": "{voorbeeld.form-control.hover.accent-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.form-control.hover.accent-color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "value": "{voorbeeld.color.white}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             }
           },
           "active": {
             "border-width": {
-              "value": "{voorbeeld.form-control.active.border-width}",
-              "type": "borderWidth"
+              "$type": "borderWidth",
+              "$value": "{voorbeeld.form-control.active.border-width}"
             },
             "background-color": {
-              "value": "{voorbeeld.form-control.active.accent-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.form-control.active.accent-color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "value": "{voorbeeld.color.white}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             }
           }
         },
         "indeterminate": {
           "background-color": {
-            "value": "{voorbeeld.form-control.accent-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.accent-color}"
           },
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
           },
           "border-width": {
-            "value": "{utrecht.form-control.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.border-width}"
           },
           "disabled": {
             "background-color": {
-              "value": "{voorbeeld.form-control.disabled.accent-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.form-control.disabled.accent-color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "value": "{voorbeeld.color.white}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             }
           },
           "active": {
             "background-color": {
-              "value": "{voorbeeld.form-control.active.accent-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.form-control.active.accent-color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "value": "{voorbeeld.color.white}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             },
             "border-width": {
-              "value": "{voorbeeld.form-control.active.border-width}",
-              "type": "borderWidth"
+              "$type": "borderWidth",
+              "$value": "{voorbeeld.form-control.active.border-width}"
             }
           },
           "hover": {
             "background-color": {
-              "value": "{voorbeeld.form-control.hover.accent-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.form-control.hover.accent-color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "value": "{voorbeeld.color.white}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             },
             "border-width": {
-              "value": "{voorbeeld.form-control.hover.border-width}",
-              "type": "borderWidth"
+              "$type": "borderWidth",
+              "$value": "{voorbeeld.form-control.hover.border-width}"
             }
           },
           "focus": {
             "background-color": {
-              "value": "{voorbeeld.form-control.focus.background-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.form-control.focus.background-color}"
             },
             "border-color": {
-              "value": "{utrecht.form-control.focus.border-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.form-control.focus.border-color}"
             },
             "color": {
-              "value": "{utrecht.form-control.focus.color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.form-control.focus.color}"
             },
             "border-width": {
-              "value": "{voorbeeld.form-control.focus.border-width}",
-              "type": "borderWidth"
+              "$type": "borderWidth",
+              "$value": "{voorbeeld.form-control.focus.border-width}"
             }
           }
         },
         "border-width": {
-          "value": "{utrecht.form-control.border-width}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{utrecht.form-control.border-width}"
         },
         "hover": {
           "border-width": {
-            "value": "{voorbeeld.form-control.hover.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.hover.border-width}"
           },
           "background-color": {
-            "value": "{voorbeeld.form-control.hover.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.hover.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.border-color}"
           }
         },
         "active": {
           "border-width": {
-            "value": "{voorbeeld.form-control.active.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.active.border-width}"
           },
           "background-color": {
-            "value": "{voorbeeld.form-control.active.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.active.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.active.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.active.border-color}"
           }
         }
       }
@@ -2657,16 +2655,16 @@
     "todo": {
       "checkbox-group": {
         "padding-block-end": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         },
         "padding-block-start": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         },
         "row-gap": {
-          "value": "{voorbeeld.space.row.rat}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.row.rat}"
         }
       }
     }
@@ -2675,56 +2673,56 @@
     "utrecht": {
       "counter-badge": {
         "font-size": {
-          "value": "{voorbeeld.typography.font-size.sm}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.sm}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "min-block-size": {
-          "type": "sizing",
-          "value": "{voorbeeld.size.xs}"
+          "$type": "sizing",
+          "$value": "{voorbeeld.size.xs}"
         },
         "min-inline-size": {
-          "type": "sizing",
-          "value": "{voorbeeld.size.xs}"
+          "$type": "sizing",
+          "$value": "{voorbeeld.size.xs}"
         },
         "font-weight": {
-          "value": "{voorbeeld.document.strong.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.document.strong.font-weight}"
         },
         "border-width": {
-          "value": "{voorbeeld.border-width.sm}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
         },
         "border-radius": {
-          "type": "borderRadius",
-          "value": "{voorbeeld.border-radius.round}"
+          "$type": "borderRadius",
+          "$value": "{voorbeeld.border-radius.round}"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "background-color": {
-          "type": "color",
-          "value": "{voorbeeld.color.violet.100}"
+          "$type": "color",
+          "$value": "{voorbeeld.color.violet.100}"
         },
         "border-color": {
-          "type": "color",
-          "value": "transparent"
+          "$type": "color",
+          "$value": "transparent"
         },
         "color": {
-          "type": "color",
-          "value": "{utrecht.document.color}"
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
         },
         "padding-inline": {
-          "value": "{voorbeeld.space.inline.ant}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.ant}"
         },
         "padding-block": {
-          "value": "{voorbeeld.space.block.ant}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.ant}"
         }
       }
     }
@@ -2734,111 +2732,111 @@
       "drawer": {
         "header": {
           "border-width": {
-            "type": "borderWidth",
-            "value": "{voorbeeld.border-width.sm}"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           },
           "label": {
             "color": {
-              "value": "{utrecht.document.color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.document.color}"
             }
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.beetle}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.beetle}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.beetle}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.beetle}"
           },
           "padding-inline-start": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-end": {
-            "value": "{voorbeeld.space.inline.beetle}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.beetle}"
           },
           "column-gap": {
-            "value": "{voorbeeld.space.column.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.column.snail}"
           },
           "border-color": {
-            "value": "{voorbeeld.line.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.line.border-color}"
           },
           "background-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           }
         },
         "border-radius": {
-          "type": "borderRadius",
-          "value": "0px"
+          "$type": "borderRadius",
+          "$value": "0px"
         },
         "footer": {
           "border-width": {
-            "type": "borderWidth",
-            "value": "{voorbeeld.border-width.sm}"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.mouse}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.mouse}"
           },
           "padding-inline-start": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-end": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "border-color": {
-            "value": "{voorbeeld.line.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.line.border-color}"
           },
           "background-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           }
         },
         "border-width": {
-          "type": "borderWidth",
-          "value": "{voorbeeld.border-width.sm}"
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
         },
         "content": {
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.rabbit}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.rabbit}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-inline": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           }
         },
         "background-color": {
-          "value": "{utrecht.document.background-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.document.background-color}"
         },
         "border-color": {
-          "value": "{voorbeeld.container.border-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.container.border-color}"
         },
         "color": {
-          "value": "{utrecht.document.color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
         },
         "box-shadow": {
-          "value": "{voorbeeld.box-shadow.lg}",
-          "type": "boxShadow"
+          "$type": "boxShadow",
+          "$value": "{voorbeeld.box-shadow.lg}"
         }
       }
     },
@@ -2847,20 +2845,20 @@
         "header": {
           "label": {
             "font-family": {
-              "value": "{utrecht.document.font-family}",
-              "type": "fontFamilies"
+              "$type": "fontFamilies",
+              "$value": "{utrecht.document.font-family}"
             },
             "font-size": {
-              "value": "{utrecht.document.font-size}",
-              "type": "fontSizes"
+              "$type": "fontSizes",
+              "$value": "{utrecht.document.font-size}"
             },
             "font-weight": {
-              "value": "{voorbeeld.document.strong.font-weight}",
-              "type": "fontWeights"
+              "$type": "fontWeights",
+              "$value": "{voorbeeld.document.strong.font-weight}"
             },
             "line-height": {
-              "value": "{utrecht.document.line-height}",
-              "type": "lineHeights"
+              "$type": "lineHeights",
+              "$value": "{utrecht.document.line-height}"
             }
           }
         }
@@ -2872,16 +2870,16 @@
       "form-field": {
         "invalid": {
           "border-inline-start-color": {
-            "value": "{voorbeeld.feedback.negative.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.negative.border-color}"
           },
           "border-inline-start-width": {
-            "value": "{voorbeeld.border-width.md}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.md}"
           },
           "padding-inline-start": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           }
         }
       }
@@ -2891,8 +2889,8 @@
     "todo": {
       "form-field-checkbox-option": {
         "column-gap": {
-          "value": "{voorbeeld.space.column.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.column.snail}"
         }
       }
     }
@@ -2901,20 +2899,20 @@
     "utrecht": {
       "form-field-description": {
         "color": {
-          "type": "color",
-          "value": "{voorbeeld.document.subtle.color}"
+          "$type": "color",
+          "$value": "{voorbeeld.document.subtle.color}"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         }
       }
     }
@@ -2924,29 +2922,29 @@
       "form-field-error-message": {
         "icon": {
           "size": {
-            "type": "sizing",
-            "value": "{voorbeeld.icon.functional.size}"
+            "$type": "sizing",
+            "$value": "{voorbeeld.icon.functional.size}"
           },
           "margin-inline-end": {
-            "value": "{voorbeeld.space.text.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.text.mouse}"
           }
         },
         "color": {
-          "type": "color",
-          "value": "{voorbeeld.feedback.negative.color}"
+          "$type": "color",
+          "$value": "{voorbeeld.feedback.negative.color}"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "font-weight": {
-          "value": "{utrecht.document.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         }
       }
     }
@@ -2955,24 +2953,24 @@
     "todo": {
       "form-field-label": {
         "color": {
-          "type": "color",
-          "value": "{utrecht.document.color}"
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "font-weight": {
-          "value": "{voorbeeld.document.strong.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.document.strong.font-weight}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         }
       }
     }
@@ -2981,29 +2979,29 @@
     "todo": {
       "form-field-option-label": {
         "color": {
-          "value": "{utrecht.form-control.color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.color}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-weight": {
-          "value": "{utrecht.document.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         },
         "disabled": {
           "color": {
-            "value": "{voorbeeld.color.gray.600}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.600}"
           }
         }
       }
@@ -3013,8 +3011,8 @@
     "todo": {
       "form-field-radio-option": {
         "column-gap": {
-          "value": "{voorbeeld.space.column.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.column.snail}"
         }
       }
     }
@@ -3023,182 +3021,182 @@
     "utrecht": {
       "heading-1": {
         "color": {
-          "type": "color",
-          "value": "{voorbeeld.heading.color}"
+          "$type": "color",
+          "$value": "{voorbeeld.heading.color}"
         },
         "font-family": {
-          "value": "{utrecht.heading.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.heading.font-family}"
         },
         "font-weight": {
-          "value": "{utrecht.heading.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.heading.font-weight}"
         },
         "line-height": {
-          "value": "{voorbeeld.typography.line-height.sm}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{voorbeeld.typography.line-height.sm}"
         },
         "font-size": {
-          "value": "{voorbeeld.typography.font-size.3xl}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.3xl}"
         },
         "margin-block-end": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         },
         "margin-block-start": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         }
       },
       "heading-2": {
         "color": {
-          "type": "color",
-          "value": "{voorbeeld.heading.color}"
+          "$type": "color",
+          "$value": "{voorbeeld.heading.color}"
         },
         "font-family": {
-          "value": "{utrecht.heading.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.heading.font-family}"
         },
         "font-weight": {
-          "value": "{utrecht.heading.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.heading.font-weight}"
         },
         "line-height": {
-          "value": "{voorbeeld.typography.line-height.sm}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{voorbeeld.typography.line-height.sm}"
         },
         "font-size": {
-          "value": "{voorbeeld.typography.font-size.2xl}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.2xl}"
         },
         "margin-block-end": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         },
         "margin-block-start": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         }
       },
       "heading-3": {
         "color": {
-          "type": "color",
-          "value": "{voorbeeld.heading.color}"
+          "$type": "color",
+          "$value": "{voorbeeld.heading.color}"
         },
         "font-family": {
-          "value": "{utrecht.heading.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.heading.font-family}"
         },
         "font-weight": {
-          "value": "{utrecht.heading.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.heading.font-weight}"
         },
         "line-height": {
-          "value": "{voorbeeld.typography.line-height.sm}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{voorbeeld.typography.line-height.sm}"
         },
         "font-size": {
-          "value": "{voorbeeld.typography.font-size.xl}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.xl}"
         },
         "margin-block-end": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         },
         "margin-block-start": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         }
       },
       "heading-4": {
         "color": {
-          "type": "color",
-          "value": "{voorbeeld.heading.color}"
+          "$type": "color",
+          "$value": "{voorbeeld.heading.color}"
         },
         "font-family": {
-          "value": "{utrecht.heading.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.heading.font-family}"
         },
         "font-weight": {
-          "value": "{utrecht.heading.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.heading.font-weight}"
         },
         "line-height": {
-          "value": "{voorbeeld.typography.line-height.md}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{voorbeeld.typography.line-height.md}"
         },
         "font-size": {
-          "value": "{voorbeeld.typography.font-size.lg}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.lg}"
         },
         "margin-block-end": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         },
         "margin-block-start": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         }
       },
       "heading-5": {
         "color": {
-          "type": "color",
-          "value": "{voorbeeld.heading.color}"
+          "$type": "color",
+          "$value": "{voorbeeld.heading.color}"
         },
         "font-family": {
-          "value": "{utrecht.heading.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.heading.font-family}"
         },
         "font-weight": {
-          "value": "{utrecht.heading.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.heading.font-weight}"
         },
         "line-height": {
-          "value": "{voorbeeld.typography.line-height.md}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{voorbeeld.typography.line-height.md}"
         },
         "font-size": {
-          "value": "{voorbeeld.typography.font-size.md}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.md}"
         },
         "margin-block-end": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         },
         "margin-block-start": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         }
       },
       "heading-6": {
         "color": {
-          "type": "color",
-          "value": "{voorbeeld.heading.color}"
+          "$type": "color",
+          "$value": "{voorbeeld.heading.color}"
         },
         "font-family": {
-          "value": "{utrecht.heading.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.heading.font-family}"
         },
         "font-weight": {
-          "value": "{utrecht.heading.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.heading.font-weight}"
         },
         "line-height": {
-          "value": "{voorbeeld.typography.line-height.md}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{voorbeeld.typography.line-height.md}"
         },
         "font-size": {
-          "value": "{voorbeeld.typography.font-size.sm}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.sm}"
         },
         "margin-block-end": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         },
         "margin-block-start": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         }
       }
     }
@@ -3207,20 +3205,20 @@
     "todo": {
       "icon-only-button": {
         "padding-block-end": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "value": "{voorbeeld.space.inline.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
         },
         "padding-inline-start": {
-          "value": "{voorbeeld.space.inline.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
         }
       }
     }
@@ -3229,82 +3227,82 @@
     "utrecht": {
       "link": {
         "color": {
-          "type": "color",
-          "value": "{voorbeeld.interaction.color}"
+          "$type": "color",
+          "$value": "{voorbeeld.interaction.color}"
         },
         "text-decoration-color": {
-          "type": "color",
-          "value": "{voorbeeld.interaction.color}"
+          "$type": "color",
+          "$value": "{voorbeeld.interaction.color}"
         },
         "active": {
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.interaction.active.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.active.color}"
           },
           "text-decoration": {
-            "value": "None",
-            "type": "textDecoration"
+            "$type": "textDecoration",
+            "$value": "None"
           }
         },
         "focus": {
           "background-color": {
-            "type": "color",
-            "value": "{utrecht.focus.background-color}"
+            "$type": "color",
+            "$value": "{utrecht.focus.background-color}"
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.focus.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.focus.color}"
           },
           "text-decoration": {
-            "value": "None",
-            "type": "textDecoration"
+            "$type": "textDecoration",
+            "$value": "None"
           },
           "text-decoration-thickness": {
-            "value": "auto",
-            "type": "other"
+            "$type": "other",
+            "$value": "auto"
           }
         },
         "hover": {
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.interaction.hover.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.hover.color}"
           },
           "text-decoration": {
-            "value": "None",
-            "type": "textDecoration"
+            "$type": "textDecoration",
+            "$value": "None"
           },
           "text-decoration-thickness": {
-            "value": "auto",
-            "type": "other"
+            "$type": "other",
+            "$value": "auto"
           }
         },
         "visited": {
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.interaction.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
           }
         },
         "text-decoration": {
-          "value": "underline",
-          "type": "textDecoration"
+          "$type": "textDecoration",
+          "$value": "underline"
         },
         "icon": {
           "size": {
-            "type": "sizing",
-            "value": "{voorbeeld.icon.functional.size}"
+            "$type": "sizing",
+            "$value": "{voorbeeld.icon.functional.size}"
           }
         },
         "column-gap": {
-          "value": "{voorbeeld.space.text.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.text.beetle}"
         },
         "text-decoration-thickness": {
-          "value": "auto",
-          "type": "other"
+          "$type": "other",
+          "$value": "auto"
         },
         "text-underline-offset": {
-          "value": "auto",
-          "type": "other"
+          "$type": "other",
+          "$value": "auto"
         }
       }
     }
@@ -3313,128 +3311,128 @@
     "todo": {
       "modal-dialog": {
         "border-radius": {
-          "value": "{voorbeeld.border-radius.lg}",
-          "type": "borderRadius"
+          "$type": "borderRadius",
+          "$value": "{voorbeeld.border-radius.lg}"
         },
         "box-shadow": {
-          "value": "{voorbeeld.box-shadow.lg}",
-          "type": "boxShadow"
+          "$type": "boxShadow",
+          "$value": "{voorbeeld.box-shadow.lg}"
         },
         "header": {
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.beetle}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.beetle}"
           },
           "padding-inline-start": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-end": {
-            "value": "{voorbeeld.space.inline.beetle}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.beetle}"
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.beetle}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.beetle}"
           },
           "background-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "label": {
             "color": {
-              "value": "{utrecht.document.color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.document.color}"
             },
             "font-family": {
-              "value": "{utrecht.document.font-family}",
-              "type": "fontFamilies"
+              "$type": "fontFamilies",
+              "$value": "{utrecht.document.font-family}"
             },
             "font-weight": {
-              "value": "{voorbeeld.document.strong.font-weight}",
-              "type": "fontWeights"
+              "$type": "fontWeights",
+              "$value": "{voorbeeld.document.strong.font-weight}"
             },
             "font-size": {
-              "value": "{utrecht.document.font-size}",
-              "type": "fontSizes"
+              "$type": "fontSizes",
+              "$value": "{utrecht.document.font-size}"
             },
             "line-height": {
-              "value": "{utrecht.document.line-height}",
-              "type": "lineHeights"
+              "$type": "lineHeights",
+              "$value": "{utrecht.document.line-height}"
             }
           },
           "border-color": {
-            "value": "{voorbeeld.line.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.line.border-color}"
           },
           "column-gap": {
-            "value": "{voorbeeld.space.column.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.column.snail}"
           },
           "border-width": {
-            "value": "{voorbeeld.border-width.sm}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           }
         },
         "border-color": {
-          "value": "transparent",
-          "type": "color"
+          "$type": "color",
+          "$value": "transparent"
         },
         "background-color": {
-          "value": "{utrecht.document.background-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.document.background-color}"
         },
         "color": {
-          "value": "{utrecht.document.color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
         },
         "footer": {
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.mouse}"
           },
           "padding-inline-start": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-end": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.mouse}"
           },
           "background-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "border-width": {
-            "value": "{voorbeeld.border-width.sm}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           }
         },
         "content": {
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.rabbit}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.rabbit}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-inline": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           }
         },
         "border-width": {
-          "value": "{voorbeeld.border-width.sm}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
         }
       }
     }
@@ -3443,37 +3441,37 @@
     "utrecht": {
       "ordered-list": {
         "padding-inline-start": {
-          "value": "{voorbeeld.space.inline.rabbit}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.rabbit}"
         },
         "color": {
-          "type": "color",
-          "value": "{utrecht.document.color}"
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-weight": {
-          "value": "{utrecht.document.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "item": {
           "margin-block-end": {
-            "value": "{voorbeeld.space.block.ant}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.ant}"
           },
           "margin-block-start": {
-            "value": "{voorbeeld.space.block.ant}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.ant}"
           }
         }
       }
@@ -3484,304 +3482,304 @@
       "pagination": {
         "relative-link": {
           "border-width": {
-            "type": "borderWidth",
-            "value": "{voorbeeld.border-width.sm}"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           },
           "icon": {
             "margin-inline": {
-              "value": "{voorbeeld.space.text.beetle}",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.text.beetle}"
             },
             "size": {
-              "type": "sizing",
-              "value": "{voorbeeld.icon.functional.size}"
+              "$type": "sizing",
+              "$value": "{voorbeeld.icon.functional.size}"
             }
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-start": {
-            "value": "0px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "0px"
           },
           "padding-inline-end": {
-            "value": "0px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "0px"
           },
           "background-color": {
-            "type": "color",
-            "value": "transparent"
+            "$type": "color",
+            "$value": "transparent"
           },
           "border-color": {
-            "type": "color",
-            "value": "transparent"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.interaction.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
           },
           "active": {
             "background-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.active.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.active.color}"
             },
             "text-decoration": {
-              "value": "underline",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "underline"
             }
           },
           "focus": {
             "background-color": {
-              "type": "color",
-              "value": "{utrecht.focus.background-color}"
+              "$type": "color",
+              "$value": "{utrecht.focus.background-color}"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.focus.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.focus.color}"
             },
             "text-decoration": {
-              "value": "None",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "None"
             }
           },
           "hover": {
             "background-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.hover.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
             },
             "text-decoration": {
-              "value": "underline",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "underline"
             }
           },
           "text-decoration": {
-            "value": "None",
-            "type": "textDecoration"
+            "$type": "textDecoration",
+            "$value": "None"
           },
           "border-radius": {
-            "value": "0px",
-            "type": "borderRadius"
+            "$type": "borderRadius",
+            "$value": "0px"
           },
           "font-weight": {
-            "value": "{utrecht.document.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
           },
           "min-block-size": {
-            "type": "sizing",
-            "value": "{utrecht.pointer-target.min-size}"
+            "$type": "sizing",
+            "$value": "{utrecht.pointer-target.min-size}"
           },
           "min-inline-size": {
-            "type": "sizing",
-            "value": "{utrecht.pointer-target.min-size}"
+            "$type": "sizing",
+            "$value": "{utrecht.pointer-target.min-size}"
           },
           "disabled": {
             "background-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.color.gray.500}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.500}"
             }
           }
         },
         "page-link": {
           "border-width": {
-            "type": "borderWidth",
-            "value": "{voorbeeld.border-width.sm}"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           },
           "font-weight": {
-            "value": "{utrecht.document.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
           },
           "current": {
             "font-weight": {
-              "value": "{voorbeeld.document.strong.font-weight}",
-              "type": "fontWeights"
+              "$type": "fontWeights",
+              "$value": "{voorbeeld.document.strong.font-weight}"
             },
             "text-decoration": {
-              "value": "None",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "None"
             },
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.color.gray.100}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.100}"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{utrecht.document.color}"
+              "$type": "color",
+              "$value": "{utrecht.document.color}"
             }
           },
           "border-radius": {
-            "value": "0px",
-            "type": "borderRadius"
+            "$type": "borderRadius",
+            "$value": "0px"
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "value": "{voorbeeld.space.inline.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.snail}"
           },
           "padding-inline-start": {
-            "value": "{voorbeeld.space.inline.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.snail}"
           },
           "focus": {
             "text-decoration": {
-              "value": "None",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "None"
             },
             "background-color": {
-              "type": "color",
-              "value": "{utrecht.focus.background-color}"
+              "$type": "color",
+              "$value": "{utrecht.focus.background-color}"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.focus.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "hover": {
             "text-decoration": {
-              "value": "underline",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "underline"
             },
             "background-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.hover.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
             }
           },
           "text-decoration": {
-            "value": "None",
-            "type": "textDecoration"
+            "$type": "textDecoration",
+            "$value": "None"
           },
           "active": {
             "text-decoration": {
-              "value": "underline",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "underline"
             },
             "background-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.active.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.active.color}"
             }
           },
           "background-color": {
-            "type": "color",
-            "value": "transparent"
+            "$type": "color",
+            "$value": "transparent"
           },
           "border-color": {
-            "type": "color",
-            "value": "transparent"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.interaction.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
           },
           "min-block-size": {
-            "type": "sizing",
-            "value": "{utrecht.pointer-target.min-size}"
+            "$type": "sizing",
+            "$value": "{utrecht.pointer-target.min-size}"
           },
           "min-inline-size": {
-            "type": "sizing",
-            "value": "{utrecht.pointer-target.min-size}"
+            "$type": "sizing",
+            "$value": "{utrecht.pointer-target.min-size}"
           }
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "ellipses": {
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "value": "{voorbeeld.space.inline.ant}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.ant}"
           },
           "padding-inline-start": {
-            "value": "{voorbeeld.space.inline.ant}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.ant}"
           },
           "color": {
-            "value": "{voorbeeld.document.subtle.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.document.subtle.color}"
           },
           "font-weight": {
-            "value": "{utrecht.document.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
           }
         },
         "description": {
           "color": {
-            "value": "{utrecht.document.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           },
           "font-weight": {
-            "value": "{utrecht.document.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
           }
         }
       }
@@ -3791,68 +3789,68 @@
     "utrecht": {
       "paragraph": {
         "color": {
-          "type": "color",
-          "value": "{utrecht.document.color}"
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "font-weight": {
-          "value": "{utrecht.document.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "margin-block-end": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         },
         "margin-block-start": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         }
       },
       "paragraph-lead": {
         "color": {
-          "type": "color",
-          "value": "{utrecht.document.color}"
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
         },
         "font-size": {
-          "value": "{voorbeeld.typography.font-size.lg}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.lg}"
         },
         "font-weight": {
-          "value": "{utrecht.document.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         }
       },
       "paragraph-small-print": {
         "color": {
-          "type": "color",
-          "value": "{utrecht.document.color}"
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
         },
         "font-size": {
-          "value": "{voorbeeld.typography.font-size.sm}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.sm}"
         },
         "font-weight": {
-          "value": "{utrecht.document.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         }
       }
     }
@@ -3862,181 +3860,181 @@
       "radio": {
         "active": {
           "border-width": {
-            "value": "{voorbeeld.form-control.active.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.active.border-width}"
           },
           "background-color": {
-            "value": "{voorbeeld.form-control.active.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.active.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.active.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.active.border-color}"
           }
         },
         "size": {
-          "type": "sizing",
-          "value": "{voorbeeld.size.xs}"
+          "$type": "sizing",
+          "$value": "{voorbeeld.size.xs}"
         },
         "dot": {
           "size": {
-            "type": "sizing",
-            "value": "{voorbeeld.size.3xs}"
+            "$type": "sizing",
+            "$value": "{voorbeeld.size.3xs}"
           }
         },
         "background-color": {
-          "value": "{utrecht.form-control.background-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.background-color}"
         },
         "border-color": {
-          "value": "{utrecht.form-control.border-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.border-color}"
         },
         "invalid": {
           "background-color": {
-            "value": "{voorbeeld.form-control.invalid.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.invalid.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.border-color}"
           },
           "border-width": {
-            "value": "{voorbeeld.form-control.invalid.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.invalid.border-width}"
           }
         },
         "focus": {
           "background-color": {
-            "value": "{voorbeeld.form-control.focus.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.background-color}"
           },
           "border-color": {
-            "value": "{utrecht.form-control.focus.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.border-color}"
           },
           "border-width": {
-            "value": "{voorbeeld.form-control.focus.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.focus.border-width}"
           }
         },
         "disabled": {
           "background-color": {
-            "value": "{voorbeeld.form-control.disabled.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.disabled.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.border-color}"
           }
         },
         "checked": {
           "background-color": {
-            "value": "{voorbeeld.form-control.accent-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.accent-color}"
           },
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
           },
           "hover": {
             "background-color": {
-              "value": "{voorbeeld.form-control.hover.accent-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.form-control.hover.accent-color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "value": "{voorbeeld.color.white}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             },
             "border-width": {
-              "value": "{voorbeeld.form-control.hover.border-width}",
-              "type": "borderWidth"
+              "$type": "borderWidth",
+              "$value": "{voorbeeld.form-control.hover.border-width}"
             }
           },
           "active": {
             "background-color": {
-              "value": "{voorbeeld.form-control.active.accent-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.form-control.active.accent-color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "value": "{voorbeeld.color.white}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             },
             "border-width": {
-              "value": "{voorbeeld.form-control.active.border-width}",
-              "type": "borderWidth"
+              "$type": "borderWidth",
+              "$value": "{voorbeeld.form-control.active.border-width}"
             }
           },
           "focus": {
             "background-color": {
-              "value": "{voorbeeld.form-control.focus.background-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.form-control.focus.background-color}"
             },
             "border-color": {
-              "value": "{utrecht.form-control.focus.border-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.form-control.focus.border-color}"
             },
             "color": {
-              "value": "{utrecht.form-control.focus.color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.form-control.focus.color}"
             },
             "border-width": {
-              "value": "{voorbeeld.form-control.focus.border-width}",
-              "type": "borderWidth"
+              "$type": "borderWidth",
+              "$value": "{voorbeeld.form-control.focus.border-width}"
             }
           },
           "disabled": {
             "background-color": {
-              "value": "{voorbeeld.form-control.disabled.accent-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.form-control.disabled.accent-color}"
             },
             "border-color": {
-              "value": "transparent",
-              "type": "color"
+              "$type": "color",
+              "$value": "transparent"
             },
             "color": {
-              "value": "{voorbeeld.color.white}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             }
           },
           "border-width": {
-            "value": "{utrecht.form-control.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.border-width}"
           }
         },
         "hover": {
           "background-color": {
-            "value": "{voorbeeld.form-control.hover.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.hover.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.border-color}"
           },
           "border-width": {
-            "value": "{voorbeeld.form-control.hover.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.hover.border-width}"
           }
         },
         "border-radius": {
-          "type": "borderRadius",
-          "value": "{voorbeeld.border-radius.round}"
+          "$type": "borderRadius",
+          "$value": "{voorbeeld.border-radius.round}"
         },
         "border-width": {
-          "value": "{utrecht.form-control.border-width}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{utrecht.form-control.border-width}"
         }
       }
     }
@@ -4045,16 +4043,16 @@
     "todo": {
       "radio-group": {
         "padding-block-end": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         },
         "padding-block-start": {
-          "value": "{voorbeeld.space.block.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.beetle}"
         },
         "row-gap": {
-          "value": "{voorbeeld.space.row.rat}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.row.rat}"
         }
       }
     }
@@ -4064,137 +4062,137 @@
       "select": {
         "icon": {
           "size": {
-            "type": "sizing",
-            "value": "{voorbeeld.icon.functional.size}"
+            "$type": "sizing",
+            "$value": "{voorbeeld.icon.functional.size}"
           }
         },
         "background-color": {
-          "value": "{utrecht.form-control.background-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.background-color}"
         },
         "border-color": {
-          "value": "{utrecht.form-control.border-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.border-color}"
         },
         "color": {
-          "value": "{utrecht.form-control.color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.color}"
         },
         "invalid": {
           "background-color": {
-            "value": "{voorbeeld.form-control.invalid.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.invalid.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.border-color}"
           },
           "color": {
-            "value": "{utrecht.form-control.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.color}"
           },
           "border-width": {
-            "value": "{voorbeeld.form-control.invalid.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.invalid.border-width}"
           }
         },
         "focus": {
           "background-color": {
-            "value": "{voorbeeld.form-control.focus.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.background-color}"
           },
           "border-color": {
-            "value": "{utrecht.form-control.focus.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.border-color}"
           },
           "color": {
-            "value": "{utrecht.form-control.focus.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.color}"
           },
           "border-width": {
-            "value": "{voorbeeld.form-control.focus.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.focus.border-width}"
           }
         },
         "disabled": {
           "background-color": {
-            "value": "{voorbeeld.form-control.disabled.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.disabled.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.border-color}"
           },
           "color": {
-            "value": "{utrecht.form-control.disabled.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.color}"
           }
         },
         "hover": {
           "background-color": {
-            "value": "{voorbeeld.form-control.hover.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.hover.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.border-color}"
           },
           "color": {
-            "value": "{voorbeeld.form-control.hover.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.color}"
           },
           "border-width": {
-            "value": "{voorbeeld.form-control.hover.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.hover.border-width}"
           }
         },
         "padding-block-end": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "value": "{voorbeeld.space.inline.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
         },
         "padding-inline-start": {
-          "value": "{voorbeeld.space.inline.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
         },
         "border-radius": {
-          "type": "borderRadius",
-          "value": "0px"
+          "$type": "borderRadius",
+          "$value": "0px"
         },
         "border-bottom-width": {
-          "value": "auto",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "auto"
         },
         "border-width": {
-          "value": "{utrecht.form-control.border-width}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{utrecht.form-control.border-width}"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-weight": {
-          "value": "{utrecht.document.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "max-inline-size": {
-          "value": "400px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "400px"
         }
       }
     }
@@ -4203,20 +4201,20 @@
     "utrecht": {
       "separator": {
         "color": {
-          "value": "{voorbeeld.line.border-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{voorbeeld.line.border-color}"
         },
         "block-size": {
-          "value": "{voorbeeld.size.4xs}",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "{voorbeeld.size.4xs}"
         },
         "padding-block-end": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         }
       }
     }
@@ -4226,90 +4224,90 @@
       "sidenav": {
         "link": {
           "line-height": {
-            "value": "{utrecht.document.line-height}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
           },
           "icon": {
             "size": {
-              "type": "sizing",
-              "value": "{voorbeeld.icon.functional.size}"
+              "$type": "sizing",
+              "$value": "{voorbeeld.icon.functional.size}"
             },
             "margin-inline": {
-              "value": "{voorbeeld.space.text.mouse}",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.text.mouse}"
             }
           },
           "font-size": {
-            "value": "{utrecht.document.font-size}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{utrecht.document.font-size}"
           },
           "font-family": {
-            "value": "{utrecht.document.font-family}",
-            "type": "fontFamilies"
+            "$type": "fontFamilies",
+            "$value": "{utrecht.document.font-family}"
           },
           "font-weight": {
-            "value": "{utrecht.document.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
           },
           "current": {
             "font-weight": {
-              "value": "{voorbeeld.document.strong.font-weight}",
-              "type": "fontWeights"
+              "$type": "fontWeights",
+              "$value": "{voorbeeld.document.strong.font-weight}"
             },
             "color": {
-              "type": "color",
-              "value": "{utrecht.document.color}"
+              "$type": "color",
+              "$value": "{utrecht.document.color}"
             }
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.interaction.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
           },
           "active": {
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.active.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.active.color}"
             },
             "text-decoration": {
-              "value": "underline",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "underline"
             }
           },
           "focus": {
             "background-color": {
-              "type": "color",
-              "value": "{utrecht.focus.background-color}"
+              "$type": "color",
+              "$value": "{utrecht.focus.background-color}"
             },
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.focus.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.focus.color}"
             },
             "text-decoration": {
-              "value": "None",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "None"
             }
           },
           "hover": {
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.interaction.hover.color}"
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
             },
             "text-decoration": {
-              "value": "underline",
-              "type": "textDecoration"
+              "$type": "textDecoration",
+              "$value": "underline"
             }
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "text-decoration": {
-            "value": "None",
-            "type": "textDecoration"
+            "$type": "textDecoration",
+            "$value": "None"
           }
         }
       }
@@ -4319,86 +4317,86 @@
     "utrecht": {
       "skip-link": {
         "font-weight": {
-          "value": "{voorbeeld.document.strong.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.document.strong.font-weight}"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "min-block-size": {
-          "type": "sizing",
-          "value": "{utrecht.pointer-target.min-size}"
+          "$type": "sizing",
+          "$value": "{utrecht.pointer-target.min-size}"
         },
         "min-inline-size": {
-          "type": "sizing",
-          "value": "{utrecht.pointer-target.min-size}"
+          "$type": "sizing",
+          "$value": "{utrecht.pointer-target.min-size}"
         },
         "padding-block-end": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "value": "{voorbeeld.space.inline.mouse}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.mouse}"
         },
         "padding-inline-start": {
-          "value": "{voorbeeld.space.inline.mouse}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.mouse}"
         },
         "focus": {
           "background-color": {
-            "type": "color",
-            "value": "{utrecht.focus.background-color}"
+            "$type": "color",
+            "$value": "{utrecht.focus.background-color}"
           },
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.focus.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.focus.color}"
           },
           "text-decoration": {
-            "value": "None",
-            "type": "textDecoration"
+            "$type": "textDecoration",
+            "$value": "None"
           }
         },
         "background-color": {
-          "type": "color",
-          "value": "{voorbeeld.document.inverse.background-color}"
+          "$type": "color",
+          "$value": "{voorbeeld.document.inverse.background-color}"
         },
         "border-color": {
-          "value": "transparent",
-          "type": "color"
+          "$type": "color",
+          "$value": "transparent"
         },
         "color": {
-          "type": "color",
-          "value": "{voorbeeld.document.inverse.color}"
+          "$type": "color",
+          "$value": "{voorbeeld.document.inverse.color}"
         },
         "border-width": {
-          "type": "borderWidth",
-          "value": "{voorbeeld.border-width.sm}"
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
         },
         "box-block-end-shadow": {
-          "value": "{voorbeeld.box-shadow.lg}",
-          "type": "boxShadow"
+          "$type": "boxShadow",
+          "$value": "{voorbeeld.box-shadow.lg}"
         },
         "text-decoration": {
-          "value": "underline",
-          "type": "textDecoration"
+          "$type": "textDecoration",
+          "$value": "underline"
         }
       }
     }
@@ -4407,104 +4405,104 @@
     "utrecht": {
       "status-badge": {
         "font-size": {
-          "value": "{voorbeeld.typography.font-size.sm}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.sm}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "font-weight": {
-          "value": "{voorbeeld.document.strong.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.document.strong.font-weight}"
         },
         "border-width": {
-          "value": "{voorbeeld.border-width.sm}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "border-radius": {
-          "type": "borderRadius",
-          "value": "{voorbeeld.border-radius.sm}"
+          "$type": "borderRadius",
+          "$value": "{voorbeeld.border-radius.sm}"
         },
         "padding-inline": {
-          "value": "{voorbeeld.space.inline.ant}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.ant}"
         },
         "padding-block": {
-          "value": "{voorbeeld.space.block.flea}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.flea}"
         },
         "informative": {
           "background-color": {
-            "type": "color",
-            "value": "{utrecht.alert.info.background-color}"
+            "$type": "color",
+            "$value": "{utrecht.alert.info.background-color}"
           },
           "border-color": {
-            "type": "color",
-            "value": "transparent"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.feedback.informative.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.informative.color}"
           }
         },
         "positive": {
           "background-color": {
-            "type": "color",
-            "value": "{utrecht.alert.ok.background-color}"
+            "$type": "color",
+            "$value": "{utrecht.alert.ok.background-color}"
           },
           "border-color": {
-            "type": "color",
-            "value": "transparent"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.feedback.positive.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.positive.color}"
           }
         },
         "negative": {
           "background-color": {
-            "type": "color",
-            "value": "{voorbeeld.feedback.negative.background-color}"
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.negative.background-color}"
           },
           "border-color": {
-            "type": "color",
-            "value": "transparent"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "type": "color",
-            "value": "{voorbeeld.feedback.negative.color}"
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.negative.color}"
           }
         },
         "warning": {
           "background-color": {
-            "type": "color",
-            "value": "{utrecht.feedback.warning.background-color}"
+            "$type": "color",
+            "$value": "{utrecht.feedback.warning.background-color}"
           },
           "border-color": {
-            "type": "color",
-            "value": "transparent"
+            "$type": "color",
+            "$value": "transparent"
           },
           "color": {
-            "type": "color",
-            "value": "{utrecht.feedback.warning.color}"
+            "$type": "color",
+            "$value": "{utrecht.feedback.warning.color}"
           }
         },
         "background-color": {
-          "type": "color",
-          "value": "{voorbeeld.color.violet.100}"
+          "$type": "color",
+          "$value": "{voorbeeld.color.violet.100}"
         },
         "border-color": {
-          "type": "color",
-          "value": "transparent"
+          "$type": "color",
+          "$value": "transparent"
         },
         "color": {
-          "type": "color",
-          "value": "{utrecht.document.color}"
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
         }
       }
     }
@@ -4513,145 +4511,145 @@
     "todo": {
       "summary-list": {
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "item-value": {
           "font-weight": {
-            "value": "{utrecht.document.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
           },
           "row": {
             "padding-block-end": {
-              "value": "{voorbeeld.space.block.snail}",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.block.snail}"
             },
             "padding-block-start": {
-              "value": "{voorbeeld.space.block.snail}",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.block.snail}"
             },
             "padding-inline-end": {
-              "value": "0px",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "0px"
             },
             "padding-inline-start": {
-              "value": "0px",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "0px"
             }
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.ant}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.ant}"
           },
           "padding-inline-end": {
-            "value": "0px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "0px"
           },
           "padding-inline-start": {
-            "value": "0px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "0px"
           }
         },
         "item-key": {
           "font-weight": {
-            "value": "{voorbeeld.document.strong.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{voorbeeld.document.strong.font-weight}"
           },
           "row": {
             "padding-block-end": {
-              "value": "{voorbeeld.space.block.snail}",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.block.snail}"
             },
             "padding-block-start": {
-              "value": "{voorbeeld.space.block.snail}",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.block.snail}"
             },
             "padding-inline-end": {
-              "value": "{voorbeeld.space.inline.mouse}",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.inline.mouse}"
             },
             "padding-inline-start": {
-              "value": "0px",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "0px"
             }
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.ant}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.ant}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "value": "0px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "0px"
           },
           "padding-inline-start": {
-            "value": "0px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "0px"
           }
         },
         "item": {
           "border-width": {
-            "type": "borderWidth",
-            "value": "{voorbeeld.border-width.sm}"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           },
           "border-color": {
-            "value": "{voorbeeld.line.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.line.border-color}"
           },
           "color": {
-            "value": "{utrecht.document.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           }
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "item-action": {
           "row": {
             "padding-block-end": {
-              "value": "{voorbeeld.space.block.snail}",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.block.snail}"
             },
             "padding-block-start": {
-              "value": "{voorbeeld.space.block.snail}",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.block.snail}"
             },
             "padding-inline-end": {
-              "value": "0px",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "0px"
             },
             "padding-inline-start": {
-              "value": "{voorbeeld.space.inline.mouse}",
-              "type": "spacing"
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.inline.mouse}"
             }
           },
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-start": {
-            "value": "0px",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "0px"
           }
         }
       }
@@ -4662,154 +4660,154 @@
       "switch": {
         "track": {
           "background-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.500}"
           },
           "active": {
             "background-color": {
-              "value": "{voorbeeld.color.gray.700}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.700}"
             }
           },
           "hover": {
             "background-color": {
-              "value": "{voorbeeld.color.gray.600}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.600}"
             }
           },
           "focus": {
             "background-color": {
-              "value": "{utrecht.focus.background-color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{utrecht.focus.background-color}"
             }
           },
           "disabled": {
             "background-color": {
-              "value": "{voorbeeld.color.gray.300}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.300}"
             }
           },
           "checked": {
             "background-color": {
-              "value": "{voorbeeld.color.green.500}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.green.500}"
             },
             "hover": {
               "background-color": {
-                "value": "{voorbeeld.color.green.600}",
-                "type": "color"
+                "$type": "color",
+                "$value": "{voorbeeld.color.green.600}"
               }
             },
             "active": {
               "background-color": {
-                "value": "{voorbeeld.color.green.700}",
-                "type": "color"
+                "$type": "color",
+                "$value": "{voorbeeld.color.green.700}"
               }
             },
             "focus": {
               "background-color": {
-                "value": "{utrecht.focus.background-color}",
-                "type": "color"
+                "$type": "color",
+                "$value": "{utrecht.focus.background-color}"
               }
             },
             "disabled": {
               "background-color": {
-                "value": "{voorbeeld.color.gray.300}",
-                "type": "color"
+                "$type": "color",
+                "$value": "{voorbeeld.color.gray.300}"
               }
             }
           },
           "border-radius": {
-            "value": "{voorbeeld.border-radius.round}",
-            "type": "borderRadius"
+            "$type": "borderRadius",
+            "$value": "{voorbeeld.border-radius.round}"
           },
           "padding-block": {
-            "value": "{voorbeeld.space.inline.ant}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.ant}"
           },
           "padding-inline": {
-            "value": "{voorbeeld.space.inline.ant}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.ant}"
           },
           "inline-size": {
-            "value": "5rem",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "5rem"
           },
           "border-width": {
-            "value": "{voorbeeld.border-width.sm}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           }
         },
         "icon": {
           "color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
           },
           "focus": {
             "color": {
-              "value": "{voorbeeld.focus.color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "disabled": {
             "color": {
-              "value": "{voorbeeld.color.gray.600}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.600}"
             }
           },
           "size": {
-            "value": "{voorbeeld.icon.functional.size}",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "{voorbeeld.icon.functional.size}"
           }
         },
         "border-color": {
-          "value": "transparent",
-          "type": "color"
+          "$type": "color",
+          "$value": "transparent"
         },
         "thumb": {
           "disabled": {
             "background-color": {
-              "value": "{voorbeeld.color.white}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             },
             "box-shadow": {
-              "value": "None",
-              "type": "boxShadow"
+              "$type": "boxShadow",
+              "$value": "None"
             }
           },
           "background-color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
           },
           "border-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           },
           "focus": {
             "background-color": {
-              "value": "{voorbeeld.focus.color}",
-              "type": "color"
+              "$type": "color",
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "min-inline-size": {
-            "value": "{voorbeeld.size.sm}",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "{voorbeeld.size.sm}"
           },
           "min-block-size": {
-            "value": "{voorbeeld.size.sm}",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "{voorbeeld.size.sm}"
           },
           "box-shadow": {
-            "value": "{voorbeeld.box-shadow.sm}",
-            "type": "boxShadow"
+            "$type": "boxShadow",
+            "$value": "{voorbeeld.box-shadow.sm}"
           },
           "border-radius": {
-            "value": "{voorbeeld.border-radius.round}",
-            "type": "borderRadius"
+            "$type": "borderRadius",
+            "$value": "{voorbeeld.border-radius.round}"
           },
           "border-width": {
-            "value": "{voorbeeld.border-width.sm}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           }
         }
       }
@@ -4820,164 +4818,164 @@
       "table": {
         "header-cell": {
           "line-height": {
-            "value": "{utrecht.document.line-height}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
           },
           "color": {
-            "value": "{utrecht.document.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           },
           "font-family": {
-            "value": "{utrecht.document.font-family}",
-            "type": "fontFamilies"
+            "$type": "fontFamilies",
+            "$value": "{utrecht.document.font-family}"
           },
           "font-weight": {
-            "value": "{voorbeeld.document.strong.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{voorbeeld.document.strong.font-weight}"
           },
           "font-size": {
-            "value": "{utrecht.document.font-size}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{utrecht.document.font-size}"
           }
         },
         "caption": {
           "line-height": {
-            "value": "{voorbeeld.typography.line-height.sm}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{voorbeeld.typography.line-height.sm}"
           },
           "margin-block-end": {
-            "value": "{voorbeeld.space.block.rabbit}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.rabbit}"
           },
           "color": {
-            "value": "{voorbeeld.heading.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.heading.color}"
           },
           "font-family": {
-            "value": "{utrecht.heading.font-family}",
-            "type": "fontFamilies"
+            "$type": "fontFamilies",
+            "$value": "{utrecht.heading.font-family}"
           },
           "font-weight": {
-            "value": "{utrecht.heading.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{utrecht.heading.font-weight}"
           },
           "font-size": {
-            "value": "{voorbeeld.typography.font-size.xl}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{voorbeeld.typography.font-size.xl}"
           }
         },
         "cell": {
           "padding-block-end": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "value": "{voorbeeld.space.block.snail}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-start": {
-            "value": "{voorbeeld.space.inline.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.mouse}"
           }
         },
         "data-cell": {
           "color": {
-            "value": "{utrecht.document.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           },
           "font-family": {
-            "value": "{utrecht.document.font-family}",
-            "type": "fontFamilies"
+            "$type": "fontFamilies",
+            "$value": "{utrecht.document.font-family}"
           },
           "font-weight": {
-            "value": "{utrecht.document.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
           },
           "line-height": {
-            "value": "{utrecht.document.line-height}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
           },
           "font-size": {
-            "value": "{utrecht.document.font-size}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{utrecht.document.font-size}"
           }
         },
         "header": {
           "border-block-end-width": {
-            "value": "{voorbeeld.border-width.md}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.md}"
           },
           "border-block-end-color": {
-            "value": "{voorbeeld.line.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.line.border-color}"
           },
           "background-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           }
         },
         "footer": {
           "border-block-end-width": {
-            "value": "{voorbeeld.border-width.sm}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           },
           "border-block-end-color": {
-            "value": "{voorbeeld.line.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.line.border-color}"
           },
           "background-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           }
         },
         "row": {
           "border-block-end-width": {
-            "value": "{voorbeeld.border-width.sm}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
           },
           "border-block-end-color": {
-            "value": "{voorbeeld.line.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.line.border-color}"
           },
           "background-color": {
-            "value": "transparent",
-            "type": "color"
+            "$type": "color",
+            "$value": "transparent"
           }
         },
         "footer-cell": {
           "font-weight": {
-            "value": "{voorbeeld.document.strong.font-weight}",
-            "type": "fontWeights"
+            "$type": "fontWeights",
+            "$value": "{voorbeeld.document.strong.font-weight}"
           },
           "font-size": {
-            "value": "{utrecht.document.font-size}",
-            "type": "fontSizes"
+            "$type": "fontSizes",
+            "$value": "{utrecht.document.font-size}"
           },
           "color": {
-            "value": "{utrecht.document.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           },
           "font-family": {
-            "value": "{utrecht.document.font-family}",
-            "type": "fontFamilies"
+            "$type": "fontFamilies",
+            "$value": "{utrecht.document.font-family}"
           },
           "line-height": {
-            "value": "{utrecht.document.line-height}",
-            "type": "lineHeights"
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
           }
         },
         "container": {
           "box-inline-end-shadow": {
-            "value": "{voorbeeld.box-shadow.lg}",
-            "type": "boxShadow"
+            "$type": "boxShadow",
+            "$value": "{voorbeeld.box-shadow.lg}"
           },
           "box-inline-start-shadow": {
-            "value": "{voorbeeld.box-shadow.lg}",
-            "type": "boxShadow"
+            "$type": "boxShadow",
+            "$value": "{voorbeeld.box-shadow.lg}"
           }
         }
       }
@@ -4987,86 +4985,86 @@
     "todo": {
       "task-list": {
         "color": {
-          "type": "color",
-          "value": "{utrecht.document.color}"
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
         },
         "marker": {
           "checked": {
             "color": {
-              "type": "color",
-              "value": "{voorbeeld.color.white}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
             },
             "background-color": {
-              "type": "color",
-              "value": "{voorbeeld.color.green.600}"
+              "$type": "color",
+              "$value": "{voorbeeld.color.green.600}"
             },
             "border-color": {
-              "type": "color",
-              "value": "transparent"
+              "$type": "color",
+              "$value": "transparent"
             }
           },
           "size": {
-            "value": "{voorbeeld.size.xs}",
-            "type": "sizing"
+            "$type": "sizing",
+            "$value": "{voorbeeld.size.xs}"
           },
           "icon": {
             "size": {
-              "value": "{voorbeeld.size.icon.sm}",
-              "type": "sizing"
+              "$type": "sizing",
+              "$value": "{voorbeeld.size.icon.sm}"
             }
           },
           "border-width": {
-            "value": "{utrecht.form-control.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.border-width}"
           },
           "not-checked": {
             "background-color": {
-              "type": "color",
-              "value": "{utrecht.form-control.read-only.background-color}"
+              "$type": "color",
+              "$value": "{utrecht.form-control.read-only.background-color}"
             },
             "border-color": {
-              "type": "color",
-              "value": "{utrecht.form-control.read-only.border-color}"
+              "$type": "color",
+              "$value": "{utrecht.form-control.read-only.border-color}"
             }
           },
           "border-radius": {
-            "value": "0px",
-            "type": "borderRadius"
+            "$type": "borderRadius",
+            "$value": "0px"
           }
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "font-weight": {
-          "value": "{utrecht.document.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "item": {
           "column-gap": {
-            "value": "{voorbeeld.space.column.mouse}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.column.mouse}"
           },
           "margin-block-end": {
-            "value": "{voorbeeld.space.block.ant}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.ant}"
           },
           "margin-block-start": {
-            "value": "{voorbeeld.space.block.ant}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.ant}"
           }
         },
         "row-gap": {
-          "value": "{voorbeeld.space.row.rat}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.row.rat}"
         }
       }
     }
@@ -5075,152 +5073,152 @@
     "utrecht": {
       "textarea": {
         "max-inline-size": {
-          "value": "400px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "400px"
         },
         "padding-block-end": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "value": "{voorbeeld.space.inline.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
         },
         "padding-inline-start": {
-          "value": "{voorbeeld.space.inline.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
         },
         "background-color": {
-          "value": "{utrecht.form-control.background-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.background-color}"
         },
         "border-color": {
-          "value": "{utrecht.form-control.border-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.border-color}"
         },
         "color": {
-          "value": "{utrecht.form-control.color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.color}"
         },
         "invalid": {
           "background-color": {
-            "value": "{voorbeeld.form-control.invalid.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.invalid.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.border-color}"
           },
           "color": {
-            "value": "{utrecht.form-control.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.color}"
           },
           "border-width": {
-            "value": "{voorbeeld.form-control.invalid.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.invalid.border-width}"
           }
         },
         "placeholder": {
           "color": {
-            "value": "{utrecht.form-control.placeholder.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.placeholder.color}"
           }
         },
         "focus": {
           "background-color": {
-            "value": "{voorbeeld.form-control.focus.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.background-color}"
           },
           "border-color": {
-            "value": "{utrecht.form-control.focus.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.border-color}"
           },
           "color": {
-            "value": "{utrecht.form-control.focus.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.color}"
           },
           "border-width": {
-            "value": "{voorbeeld.form-control.focus.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.focus.border-width}"
           }
         },
         "disabled": {
           "background-color": {
-            "value": "{voorbeeld.form-control.disabled.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.disabled.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.border-color}"
           },
           "color": {
-            "value": "{utrecht.form-control.disabled.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.color}"
           }
         },
         "read-only": {
           "background-color": {
-            "value": "{utrecht.form-control.read-only.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.read-only.background-color}"
           },
           "border-color": {
-            "value": "{utrecht.form-control.read-only.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.read-only.border-color}"
           },
           "color": {
-            "value": "{utrecht.form-control.read-only.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.read-only.color}"
           }
         },
         "hover": {
           "background-color": {
-            "value": "{voorbeeld.form-control.hover.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.hover.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.border-color}"
           },
           "color": {
-            "value": "{voorbeeld.form-control.hover.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.color}"
           },
           "border-width": {
-            "value": "{voorbeeld.form-control.hover.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.hover.border-width}"
           }
         },
         "border-radius": {
-          "type": "borderRadius",
-          "value": "0px"
+          "$type": "borderRadius",
+          "$value": "0px"
         },
         "border-bottom-width": {
-          "value": "auto",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "auto"
         },
         "border-width": {
-          "value": "{utrecht.form-control.border-width}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{utrecht.form-control.border-width}"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-weight": {
-          "value": "{utrecht.document.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         }
       }
     }
@@ -5229,151 +5227,151 @@
     "utrecht": {
       "textbox": {
         "border-radius": {
-          "type": "borderRadius",
-          "value": "0px"
+          "$type": "borderRadius",
+          "$value": "0px"
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "font-weight": {
-          "value": "{utrecht.document.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "max-inline-size": {
-          "value": "400px",
-          "type": "sizing"
+          "$type": "sizing",
+          "$value": "400px"
         },
         "padding-block-end": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "value": "{voorbeeld.space.inline.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
         },
         "padding-inline-start": {
-          "value": "{voorbeeld.space.inline.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
         },
         "background-color": {
-          "value": "{utrecht.form-control.background-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.background-color}"
         },
         "border-color": {
-          "value": "{utrecht.form-control.border-color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.border-color}"
         },
         "color": {
-          "value": "{utrecht.form-control.color}",
-          "type": "color"
+          "$type": "color",
+          "$value": "{utrecht.form-control.color}"
         },
         "invalid": {
           "background-color": {
-            "value": "{voorbeeld.form-control.invalid.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.invalid.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.border-color}"
           },
           "color": {
-            "value": "{utrecht.form-control.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.color}"
           },
           "border-width": {
-            "value": "{voorbeeld.form-control.invalid.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.invalid.border-width}"
           }
         },
         "placeholder": {
           "color": {
-            "value": "{utrecht.form-control.placeholder.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.placeholder.color}"
           }
         },
         "border-block-end-width": {
-          "value": "auto",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "auto"
         },
         "border-width": {
-          "value": "{utrecht.form-control.border-width}",
-          "type": "borderWidth"
+          "$type": "borderWidth",
+          "$value": "{utrecht.form-control.border-width}"
         },
         "focus": {
           "border-width": {
-            "value": "{voorbeeld.form-control.focus.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.focus.border-width}"
           },
           "background-color": {
-            "value": "{voorbeeld.form-control.focus.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.background-color}"
           },
           "border-color": {
-            "value": "{utrecht.form-control.focus.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.border-color}"
           },
           "color": {
-            "value": "{utrecht.form-control.focus.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.color}"
           }
         },
         "disabled": {
           "background-color": {
-            "value": "{voorbeeld.form-control.disabled.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.disabled.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.border-color}"
           },
           "color": {
-            "value": "{utrecht.form-control.disabled.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.color}"
           }
         },
         "read-only": {
           "background-color": {
-            "value": "{utrecht.form-control.read-only.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.read-only.background-color}"
           },
           "border-color": {
-            "value": "{utrecht.form-control.read-only.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.read-only.border-color}"
           },
           "color": {
-            "value": "{utrecht.form-control.read-only.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{utrecht.form-control.read-only.color}"
           }
         },
         "hover": {
           "border-width": {
-            "value": "{voorbeeld.form-control.hover.border-width}",
-            "type": "borderWidth"
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.hover.border-width}"
           },
           "background-color": {
-            "value": "{voorbeeld.form-control.hover.background-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.background-color}"
           },
           "border-color": {
-            "value": "{voorbeeld.form-control.hover.border-color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.border-color}"
           },
           "color": {
-            "value": "{voorbeeld.form-control.hover.color}",
-            "type": "color"
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.color}"
           }
         }
       }
@@ -5384,25 +5382,25 @@
       "toolbar-button": {
         "icon": {
           "margin-inline": {
-            "value": "{voorbeeld.space.text.beetle}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.text.beetle}"
           }
         },
         "padding-block-end": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "value": "{voorbeeld.space.block.snail}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "value": "{voorbeeld.space.inline.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.beetle}"
         },
         "padding-inline-start": {
-          "value": "{voorbeeld.space.inline.beetle}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.beetle}"
         }
       }
     }
@@ -5411,47 +5409,47 @@
     "utrecht": {
       "unordered-list": {
         "color": {
-          "type": "color",
-          "value": "{utrecht.document.color}"
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
         },
         "marker": {
           "border-color": {
-            "type": "color",
-            "value": "{utrecht.document.color}"
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           },
           "color": {
-            "type": "color",
-            "value": "{utrecht.document.color}"
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           }
         },
         "font-family": {
-          "value": "{utrecht.document.font-family}",
-          "type": "fontFamilies"
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-size": {
-          "value": "{utrecht.document.font-size}",
-          "type": "fontSizes"
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "font-weight": {
-          "value": "{utrecht.document.font-weight}",
-          "type": "fontWeights"
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         },
         "line-height": {
-          "value": "{utrecht.document.line-height}",
-          "type": "lineHeights"
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         },
         "padding-inline-start": {
-          "value": "{voorbeeld.space.inline.rabbit}",
-          "type": "spacing"
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.rabbit}"
         },
         "item": {
           "margin-block-end": {
-            "value": "{voorbeeld.space.block.ant}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.ant}"
           },
           "margin-block-start": {
-            "value": "{voorbeeld.space.block.ant}",
-            "type": "spacing"
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.ant}"
           }
         }
       }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -953,25 +953,9 @@
           "type": "fontWeights"
         }
       },
-      "container": {
-        "border-width": {
-          "value": "{voorbeeld.border-width.sm}",
-          "type": "borderWidth"
-        }
-      },
-      "line": {
-        "border-width": {
-          "value": "{voorbeeld.border-width.sm}",
-          "type": "borderWidth"
-        }
-      },
       "focus": {
         "background-color": {
           "value": "{voorbeeld.color.yellow.200}",
-          "type": "color"
-        },
-        "color": {
-          "value": "{voorbeeld.color.black}",
           "type": "color"
         },
         "outline-color": {
@@ -1014,12 +998,6 @@
           "value": "{voorbeeld.color.gray.950}",
           "type": "color"
         },
-        "active": {
-          "border-width": {
-            "value": "{voorbeeld.border-width.md}",
-            "type": "borderWidth"
-          }
-        },
         "disabled": {
           "color": {
             "value": "{voorbeeld.color.gray.500}",
@@ -1027,34 +1005,16 @@
           }
         },
         "focus": {
-          "background-color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
-          },
           "border-color": {
             "value": "{voorbeeld.color.black}",
             "type": "color"
-          },
-          "border-width": {
-            "value": "{voorbeeld.border-width.md}",
-            "type": "borderWidth"
           },
           "color": {
             "value": "{voorbeeld.color.black}",
             "type": "color"
           }
         },
-        "hover": {
-          "border-width": {
-            "value": "{voorbeeld.border-width.md}",
-            "type": "borderWidth"
-          }
-        },
         "invalid": {
-          "border-width": {
-            "value": "{voorbeeld.border-width.md}",
-            "type": "borderWidth"
-          },
           "color": {
             "value": "{voorbeeld.feedback.negative.color}",
             "type": "color"
@@ -1105,6 +1065,120 @@
       }
     },
     "voorbeeld": {
+      "container": {
+        "border-width": {
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
+        },
+        "border-color": {
+          "value": "{voorbeeld.color.gray.200}",
+          "type": "color"
+        }
+      },
+      "line": {
+        "border-width": {
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
+        },
+        "border-color": {
+          "value": "{voorbeeld.color.gray.200}",
+          "type": "color"
+        }
+      },
+      "focus": {
+        "color": {
+          "value": "{voorbeeld.color.black}",
+          "type": "color"
+        }
+      },
+      "form-control": {
+        "active": {
+          "border-width": {
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
+          },
+          "accent-color": {
+            "value": "{voorbeeld.interaction.active.color}",
+            "type": "color"
+          },
+          "background-color": {
+            "value": "{voorbeeld.color.gray.100}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{voorbeeld.color.gray.950}",
+            "type": "color"
+          }
+        },
+        "focus": {
+          "background-color": {
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
+          },
+          "border-width": {
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
+          }
+        },
+        "hover": {
+          "border-width": {
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
+          },
+          "accent-color": {
+            "value": "{voorbeeld.interaction.hover.color}",
+            "type": "color"
+          },
+          "background-color": {
+            "value": "{voorbeeld.color.gray.50}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
+          },
+          "color": {
+            "value": "{voorbeeld.color.gray.950}",
+            "type": "color"
+          }
+        },
+        "invalid": {
+          "border-width": {
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
+          },
+          "background-color": {
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{voorbeeld.feedback.negative.border-color}",
+            "type": "color"
+          }
+        },
+        "accent-color": {
+          "value": "{voorbeeld.interaction.color}",
+          "type": "color"
+        },
+        "disabled": {
+          "accent-color": {
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
+          },
+          "background-color": {
+            "value": "{voorbeeld.color.gray.50}",
+            "type": "color"
+          },
+          "border-color": {
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
+          }
+        }
+      },
       "document": {
         "inverse": {
           "background-color": {
@@ -1135,18 +1209,6 @@
           "type": "color"
         }
       },
-      "container": {
-        "border-color": {
-          "value": "{voorbeeld.color.gray.200}",
-          "type": "color"
-        }
-      },
-      "line": {
-        "border-color": {
-          "value": "{voorbeeld.color.gray.200}",
-          "type": "color"
-        }
-      },
       "interaction": {
         "color": {
           "value": "{voorbeeld.color.violet.700}",
@@ -1161,72 +1223,6 @@
         "hover": {
           "color": {
             "value": "{voorbeeld.color.violet.800}",
-            "type": "color"
-          }
-        }
-      },
-      "form-control": {
-        "accent-color": {
-          "value": "{voorbeeld.interaction.color}",
-          "type": "color"
-        },
-        "active": {
-          "accent-color": {
-            "value": "{voorbeeld.interaction.active.color}",
-            "type": "color"
-          },
-          "background-color": {
-            "value": "{voorbeeld.color.gray.100}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
-          },
-          "color": {
-            "value": "{voorbeeld.color.gray.950}",
-            "type": "color"
-          }
-        },
-        "disabled": {
-          "accent-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
-          },
-          "background-color": {
-            "value": "{voorbeeld.color.gray.50}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
-          }
-        },
-        "hover": {
-          "accent-color": {
-            "value": "{voorbeeld.interaction.hover.color}",
-            "type": "color"
-          },
-          "background-color": {
-            "value": "{voorbeeld.color.gray.50}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{voorbeeld.color.gray.500}",
-            "type": "color"
-          },
-          "color": {
-            "value": "{voorbeeld.color.gray.950}",
-            "type": "color"
-          }
-        },
-        "invalid": {
-          "background-color": {
-            "value": "{voorbeeld.color.white}",
-            "type": "color"
-          },
-          "border-color": {
-            "value": "{voorbeeld.feedback.negative.border-color}",
             "type": "color"
           }
         }
@@ -1478,7 +1474,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.focus.color}"
+              "value": "{voorbeeld.focus.color}"
             }
           },
           "active": {
@@ -1922,7 +1918,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.focus.color}"
+              "value": "{voorbeeld.focus.color}"
             },
             "text-decoration": {
               "value": "None",
@@ -2060,7 +2056,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{utrecht.focus.color}",
+            "value": "{voorbeeld.focus.color}",
             "type": "color"
           }
         },
@@ -2156,7 +2152,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.focus.color}"
+              "value": "{voorbeeld.focus.color}"
             }
           },
           "font-weight": {
@@ -2238,7 +2234,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.focus.color}"
+              "value": "{voorbeeld.focus.color}"
             }
           },
           "font-weight": {
@@ -2328,7 +2324,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.focus.color}"
+              "value": "{voorbeeld.focus.color}"
             }
           },
           "active": {
@@ -2422,13 +2418,13 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{utrecht.form-control.invalid.border-width}",
+            "value": "{voorbeeld.form-control.invalid.border-width}",
             "type": "borderWidth"
           }
         },
         "focus": {
           "background-color": {
-            "value": "{utrecht.form-control.focus.background-color}",
+            "value": "{voorbeeld.form-control.focus.background-color}",
             "type": "color"
           },
           "border-color": {
@@ -2436,7 +2432,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{utrecht.form-control.focus.border-width}",
+            "value": "{voorbeeld.form-control.focus.border-width}",
             "type": "borderWidth"
           }
         },
@@ -2483,11 +2479,11 @@
           },
           "focus": {
             "border-width": {
-              "value": "{utrecht.form-control.focus.border-width}",
+              "value": "{voorbeeld.form-control.focus.border-width}",
               "type": "borderWidth"
             },
             "background-color": {
-              "value": "{utrecht.form-control.focus.background-color}",
+              "value": "{voorbeeld.form-control.focus.background-color}",
               "type": "color"
             },
             "border-color": {
@@ -2501,7 +2497,7 @@
           },
           "hover": {
             "border-width": {
-              "value": "{utrecht.form-control.hover.border-width}",
+              "value": "{voorbeeld.form-control.hover.border-width}",
               "type": "borderWidth"
             },
             "background-color": {
@@ -2519,7 +2515,7 @@
           },
           "active": {
             "border-width": {
-              "value": "{utrecht.form-control.active.border-width}",
+              "value": "{voorbeeld.form-control.active.border-width}",
               "type": "borderWidth"
             },
             "background-color": {
@@ -2581,7 +2577,7 @@
               "type": "color"
             },
             "border-width": {
-              "value": "{utrecht.form-control.active.border-width}",
+              "value": "{voorbeeld.form-control.active.border-width}",
               "type": "borderWidth"
             }
           },
@@ -2599,13 +2595,13 @@
               "type": "color"
             },
             "border-width": {
-              "value": "{utrecht.form-control.hover.border-width}",
+              "value": "{voorbeeld.form-control.hover.border-width}",
               "type": "borderWidth"
             }
           },
           "focus": {
             "background-color": {
-              "value": "{utrecht.form-control.focus.background-color}",
+              "value": "{voorbeeld.form-control.focus.background-color}",
               "type": "color"
             },
             "border-color": {
@@ -2617,7 +2613,7 @@
               "type": "color"
             },
             "border-width": {
-              "value": "{utrecht.form-control.focus.border-width}",
+              "value": "{voorbeeld.form-control.focus.border-width}",
               "type": "borderWidth"
             }
           }
@@ -2628,7 +2624,7 @@
         },
         "hover": {
           "border-width": {
-            "value": "{utrecht.form-control.hover.border-width}",
+            "value": "{voorbeeld.form-control.hover.border-width}",
             "type": "borderWidth"
           },
           "background-color": {
@@ -2642,7 +2638,7 @@
         },
         "active": {
           "border-width": {
-            "value": "{utrecht.form-control.active.border-width}",
+            "value": "{voorbeeld.form-control.active.border-width}",
             "type": "borderWidth"
           },
           "background-color": {
@@ -3257,7 +3253,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{utrecht.focus.color}"
+            "value": "{voorbeeld.focus.color}"
           },
           "text-decoration": {
             "value": "None",
@@ -3554,7 +3550,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.focus.color}"
+              "value": "{voorbeeld.focus.color}"
             },
             "text-decoration": {
               "value": "None",
@@ -3676,7 +3672,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.focus.color}"
+              "value": "{voorbeeld.focus.color}"
             }
           },
           "hover": {
@@ -3866,7 +3862,7 @@
       "radio": {
         "active": {
           "border-width": {
-            "value": "{utrecht.form-control.active.border-width}",
+            "value": "{voorbeeld.form-control.active.border-width}",
             "type": "borderWidth"
           },
           "background-color": {
@@ -3906,13 +3902,13 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{utrecht.form-control.invalid.border-width}",
+            "value": "{voorbeeld.form-control.invalid.border-width}",
             "type": "borderWidth"
           }
         },
         "focus": {
           "background-color": {
-            "value": "{utrecht.form-control.focus.background-color}",
+            "value": "{voorbeeld.form-control.focus.background-color}",
             "type": "color"
           },
           "border-color": {
@@ -3920,7 +3916,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{utrecht.form-control.focus.border-width}",
+            "value": "{voorbeeld.form-control.focus.border-width}",
             "type": "borderWidth"
           }
         },
@@ -3961,7 +3957,7 @@
               "type": "color"
             },
             "border-width": {
-              "value": "{utrecht.form-control.hover.border-width}",
+              "value": "{voorbeeld.form-control.hover.border-width}",
               "type": "borderWidth"
             }
           },
@@ -3979,13 +3975,13 @@
               "type": "color"
             },
             "border-width": {
-              "value": "{utrecht.form-control.active.border-width}",
+              "value": "{voorbeeld.form-control.active.border-width}",
               "type": "borderWidth"
             }
           },
           "focus": {
             "background-color": {
-              "value": "{utrecht.form-control.focus.background-color}",
+              "value": "{voorbeeld.form-control.focus.background-color}",
               "type": "color"
             },
             "border-color": {
@@ -3997,7 +3993,7 @@
               "type": "color"
             },
             "border-width": {
-              "value": "{utrecht.form-control.focus.border-width}",
+              "value": "{voorbeeld.form-control.focus.border-width}",
               "type": "borderWidth"
             }
           },
@@ -4030,7 +4026,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{utrecht.form-control.hover.border-width}",
+            "value": "{voorbeeld.form-control.hover.border-width}",
             "type": "borderWidth"
           }
         },
@@ -4098,13 +4094,13 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{utrecht.form-control.invalid.border-width}",
+            "value": "{voorbeeld.form-control.invalid.border-width}",
             "type": "borderWidth"
           }
         },
         "focus": {
           "background-color": {
-            "value": "{utrecht.form-control.focus.background-color}",
+            "value": "{voorbeeld.form-control.focus.background-color}",
             "type": "color"
           },
           "border-color": {
@@ -4116,7 +4112,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{utrecht.form-control.focus.border-width}",
+            "value": "{voorbeeld.form-control.focus.border-width}",
             "type": "borderWidth"
           }
         },
@@ -4148,7 +4144,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{utrecht.form-control.hover.border-width}",
+            "value": "{voorbeeld.form-control.hover.border-width}",
             "type": "borderWidth"
           }
         },
@@ -4286,7 +4282,7 @@
             },
             "color": {
               "type": "color",
-              "value": "{utrecht.focus.color}"
+              "value": "{voorbeeld.focus.color}"
             },
             "text-decoration": {
               "value": "None",
@@ -4373,7 +4369,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{utrecht.focus.color}"
+            "value": "{voorbeeld.focus.color}"
           },
           "text-decoration": {
             "value": "None",
@@ -4751,7 +4747,7 @@
           },
           "focus": {
             "color": {
-              "value": "{utrecht.focus.color}",
+              "value": "{voorbeeld.focus.color}",
               "type": "color"
             }
           },
@@ -4791,7 +4787,7 @@
           },
           "focus": {
             "background-color": {
-              "value": "{utrecht.focus.color}",
+              "value": "{voorbeeld.focus.color}",
               "type": "color"
             }
           },
@@ -5124,7 +5120,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{utrecht.form-control.invalid.border-width}",
+            "value": "{voorbeeld.form-control.invalid.border-width}",
             "type": "borderWidth"
           }
         },
@@ -5136,7 +5132,7 @@
         },
         "focus": {
           "background-color": {
-            "value": "{utrecht.form-control.focus.background-color}",
+            "value": "{voorbeeld.form-control.focus.background-color}",
             "type": "color"
           },
           "border-color": {
@@ -5148,7 +5144,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{utrecht.form-control.focus.border-width}",
+            "value": "{voorbeeld.form-control.focus.border-width}",
             "type": "borderWidth"
           }
         },
@@ -5194,7 +5190,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{utrecht.form-control.hover.border-width}",
+            "value": "{voorbeeld.form-control.hover.border-width}",
             "type": "borderWidth"
           }
         },
@@ -5298,7 +5294,7 @@
             "type": "color"
           },
           "border-width": {
-            "value": "{utrecht.form-control.invalid.border-width}",
+            "value": "{voorbeeld.form-control.invalid.border-width}",
             "type": "borderWidth"
           }
         },
@@ -5318,11 +5314,11 @@
         },
         "focus": {
           "border-width": {
-            "value": "{utrecht.form-control.focus.border-width}",
+            "value": "{voorbeeld.form-control.focus.border-width}",
             "type": "borderWidth"
           },
           "background-color": {
-            "value": "{utrecht.form-control.focus.background-color}",
+            "value": "{voorbeeld.form-control.focus.background-color}",
             "type": "color"
           },
           "border-color": {
@@ -5364,7 +5360,7 @@
         },
         "hover": {
           "border-width": {
-            "value": "{utrecht.form-control.hover.border-width}",
+            "value": "{voorbeeld.form-control.hover.border-width}",
             "type": "borderWidth"
           },
           "background-color": {


### PR DESCRIPTION
Relates to ticket: https://github.com/nl-design-system/kernteam/issues/846

Overview of tokens that had the `utrecht` prefix and now have the `voorbeeld` prefix:

**Typography**
.document.strong.font-weight

**Colors**
.root.background-color
.document.subtle.color
.document.inverse.color
.document.inverse.background-color
.container.border-color
.line.border-color
.interaction.* (all)
.form-control.accent-color
.form-control.active.* (all)
.form-control.hover.* (all)
.form-control.disabled.accent-color
.feedback.informative.* (all)
.feedback.negative.* (all)
.feedback.positive.* (all)

**Size**
icon.functional.size
icon.toptask.size

**Border**
.container.border-width
.line.border-width
.form-control.active.border-width
.form-control.focus.border-width
.form-control.hover.border-width 

**Focus**
.focus.color