### PR TITLE
Common tokens split

### DIFF
--- a/.changeset/2024-08-15--jeff.md
+++ b/.changeset/2024-08-15--jeff.md
@@ -1,0 +1,43 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Overview of tokens that had the utrecht prefix and now have the voorbeeld prefix:
+
+Typography
+.document.strong.font-weight
+
+Colors
+.root.background-color
+.document.subtle.color
+.document.inverse.color
+.document.inverse.background-color
+.container.border-color
+.line.border-color
+.interaction.* (all)
+.form-control.accent-color
+.form-control.active.* (all)
+.form-control.hover.* (all)
+.form-control.disabled.accent-color
+.feedback.informative.* (all)
+.feedback.negative.* (all)
+.feedback.positive.* (all)
+
+Size
+icon.functional.size
+icon.toptask.size
+
+Border
+.container.border-width
+.line.border-width
+.form-control.active.border-width
+.form-control.focus.border-width
+.form-control.hover.border-width
+
+Focus
+.focus.color
+`.form-control.focus.border-width`
+`.form-control.hover.border-width`
+
+Focus
+`.focus.color`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1472,7 +1472,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "active": {
@@ -1916,7 +1916,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "$value": "{voorbeeld.focus.color}"
             },
             "text-decoration": {
               "$type": "textDecoration",
@@ -2055,7 +2055,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{utrecht.focus.color}"
+            "$value": "{voorbeeld.focus.color}"
           }
         },
         "hover": {
@@ -2150,7 +2150,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "font-weight": {
@@ -2232,7 +2232,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "font-weight": {
@@ -2322,7 +2322,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "active": {
@@ -2409,11 +2409,11 @@
         "invalid": {
           "background-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.invalid.background-color}"
+            "$value": "{utrecht.form-control.invalid.background-color}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.invalid.border-color}"
+            "$value": "{utrecht.form-control.invalid.border-color}"
           },
           "border-width": {
             "$type": "borderWidth",
@@ -2431,17 +2431,17 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.focus.border-width}"
+            "$value": "{voorbeeld.form-control.focus.border-width}"
           }
         },
         "disabled": {
           "background-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.disabled.background-color}"
+            "$value": "{utrecht.form-control.disabled.background-color}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.disabled.border-color}"
+            "$value": "{utrecht.form-control.disabled.border-color}"
           }
         },
         "checked": {
@@ -2478,7 +2478,7 @@
           "focus": {
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{utrecht.form-control.focus.border-width}"
+              "$value": "{voorbeeld.form-control.focus.border-width}"
             },
             "background-color": {
               "$type": "color",
@@ -2496,7 +2496,7 @@
           "hover": {
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{utrecht.form-control.hover.border-width}"
+              "$value": "{voorbeeld.form-control.hover.border-width}"
             },
             "background-color": {
               "$type": "color",
@@ -2514,7 +2514,7 @@
           "active": {
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{utrecht.form-control.active.border-width}"
+              "$value": "{voorbeeld.form-control.active.border-width}"
             },
             "background-color": {
               "$type": "color",
@@ -2576,7 +2576,7 @@
             },
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{utrecht.form-control.active.border-width}"
+              "$value": "{voorbeeld.form-control.active.border-width}"
             }
           },
           "hover": {
@@ -2594,7 +2594,7 @@
             },
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{utrecht.form-control.hover.border-width}"
+              "$value": "{voorbeeld.form-control.hover.border-width}"
             }
           },
           "focus": {
@@ -2612,7 +2612,7 @@
             },
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{utrecht.form-control.focus.border-width}"
+              "$value": "{voorbeeld.form-control.focus.border-width}"
             }
           }
         },
@@ -2623,7 +2623,7 @@
         "hover": {
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.hover.border-width}"
+            "$value": "{voorbeeld.form-control.hover.border-width}"
           },
           "background-color": {
             "$type": "color",
@@ -2637,7 +2637,7 @@
         "active": {
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.active.border-width}"
+            "$value": "{voorbeeld.form-control.active.border-width}"
           },
           "background-color": {
             "$type": "color",
@@ -3251,7 +3251,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{utrecht.focus.color}"
+            "$value": "{voorbeeld.focus.color}"
           },
           "text-decoration": {
             "$type": "textDecoration",
@@ -3548,7 +3548,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "$value": "{voorbeeld.focus.color}"
             },
             "text-decoration": {
               "$type": "textDecoration",
@@ -3670,7 +3670,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "hover": {
@@ -3861,7 +3861,7 @@
         "active": {
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.active.border-width}"
+            "$value": "{voorbeeld.form-control.active.border-width}"
           },
           "background-color": {
             "$type": "color",
@@ -3893,11 +3893,11 @@
         "invalid": {
           "background-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.invalid.background-color}"
+            "$value": "{utrecht.form-control.invalid.background-color}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.invalid.border-color}"
+            "$value": "{utrecht.form-control.invalid.border-color}"
           },
           "border-width": {
             "$type": "borderWidth",
@@ -3915,17 +3915,17 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.focus.border-width}"
+            "$value": "{voorbeeld.form-control.focus.border-width}"
           }
         },
         "disabled": {
           "background-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.disabled.background-color}"
+            "$value": "{utrecht.form-control.disabled.background-color}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.disabled.border-color}"
+            "$value": "{utrecht.form-control.disabled.border-color}"
           }
         },
         "checked": {
@@ -3956,7 +3956,7 @@
             },
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{utrecht.form-control.hover.border-width}"
+              "$value": "{voorbeeld.form-control.hover.border-width}"
             }
           },
           "active": {
@@ -3974,7 +3974,7 @@
             },
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{utrecht.form-control.active.border-width}"
+              "$value": "{voorbeeld.form-control.active.border-width}"
             }
           },
           "focus": {
@@ -3992,7 +3992,7 @@
             },
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{utrecht.form-control.focus.border-width}"
+              "$value": "{voorbeeld.form-control.focus.border-width}"
             }
           },
           "disabled": {
@@ -4025,7 +4025,7 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.hover.border-width}"
+            "$value": "{voorbeeld.form-control.hover.border-width}"
           }
         },
         "border-radius": {
@@ -4081,11 +4081,11 @@
         "invalid": {
           "background-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.invalid.background-color}"
+            "$value": "{utrecht.form-control.invalid.background-color}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.invalid.border-color}"
+            "$value": "{utrecht.form-control.invalid.border-color}"
           },
           "color": {
             "$type": "color",
@@ -4111,17 +4111,17 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.focus.border-width}"
+            "$value": "{voorbeeld.form-control.focus.border-width}"
           }
         },
         "disabled": {
           "background-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.disabled.background-color}"
+            "$value": "{utrecht.form-control.disabled.background-color}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.disabled.border-color}"
+            "$value": "{utrecht.form-control.disabled.border-color}"
           },
           "color": {
             "$type": "color",
@@ -4143,7 +4143,7 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.hover.border-width}"
+            "$value": "{voorbeeld.form-control.hover.border-width}"
           }
         },
         "padding-block-end": {
@@ -4280,7 +4280,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "$value": "{voorbeeld.focus.color}"
             },
             "text-decoration": {
               "$type": "textDecoration",
@@ -4367,7 +4367,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{utrecht.focus.color}"
+            "$value": "{voorbeeld.focus.color}"
           },
           "text-decoration": {
             "$type": "textDecoration",
@@ -4746,7 +4746,7 @@
           "focus": {
             "color": {
               "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "disabled": {
@@ -4786,7 +4786,7 @@
           "focus": {
             "background-color": {
               "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "$value": "{voorbeeld.focus.color}"
             }
           },
           "min-inline-size": {
@@ -5107,11 +5107,11 @@
         "invalid": {
           "background-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.invalid.background-color}"
+            "$value": "{utrecht.form-control.invalid.background-color}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.invalid.border-color}"
+            "$value": "{utrecht.form-control.invalid.border-color}"
           },
           "color": {
             "$type": "color",
@@ -5143,17 +5143,17 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.focus.border-width}"
+            "$value": "{voorbeeld.form-control.focus.border-width}"
           }
         },
         "disabled": {
           "background-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.disabled.background-color}"
+            "$value": "{utrecht.form-control.disabled.background-color}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.disabled.border-color}"
+            "$value": "{utrecht.form-control.disabled.border-color}"
           },
           "color": {
             "$type": "color",
@@ -5189,7 +5189,7 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.hover.border-width}"
+            "$value": "{voorbeeld.form-control.hover.border-width}"
           }
         },
         "border-radius": {
@@ -5281,11 +5281,11 @@
         "invalid": {
           "background-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.invalid.background-color}"
+            "$value": "{utrecht.form-control.invalid.background-color}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.invalid.border-color}"
+            "$value": "{utrecht.form-control.invalid.border-color}"
           },
           "color": {
             "$type": "color",
@@ -5313,7 +5313,7 @@
         "focus": {
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.focus.border-width}"
+            "$value": "{voorbeeld.form-control.focus.border-width}"
           },
           "background-color": {
             "$type": "color",
@@ -5331,11 +5331,11 @@
         "disabled": {
           "background-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.disabled.background-color}"
+            "$value": "{utrecht.form-control.disabled.background-color}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{voorbeeld.form-control.disabled.border-color}"
+            "$value": "{utrecht.form-control.disabled.border-color}"
           },
           "color": {
             "$type": "color",
@@ -5359,7 +5359,7 @@
         "hover": {
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.hover.border-width}"
+            "$value": "{voorbeeld.form-control.hover.border-width}"
           },
           "background-color": {
             "$type": "color",

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -911,12 +911,6 @@
   },
   "common": {
     "utrecht": {
-      "root": {
-        "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.50}"
-        }
-      },
       "document": {
         "background-color": {
           "$type": "color",
@@ -953,26 +947,10 @@
           "$value": "{voorbeeld.typography.font-weight.bold}"
         }
       },
-      "container": {
-        "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
-        }
-      },
-      "line": {
-        "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
-        }
-      },
       "focus": {
         "background-color": {
           "$type": "color",
           "$value": "{voorbeeld.color.yellow.200}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.black}"
         },
         "outline-color": {
           "$type": "color",
@@ -1014,13 +992,15 @@
           "$type": "color",
           "$value": "{voorbeeld.color.gray.950}"
         },
-        "active": {
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
-          }
-        },
         "disabled": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.50}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.500}"
+          },
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.color.gray.500}"
@@ -1035,29 +1015,27 @@
             "$type": "color",
             "$value": "{voorbeeld.color.black}"
           },
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
-          },
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.color.black}"
           }
         },
-        "hover": {
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
-          }
-        },
         "invalid": {
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
+          "background-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.negative.border-color}"
           },
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.feedback.negative.color}"
+          },
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.md}"
           }
         },
         "read-only": {
@@ -1105,6 +1083,100 @@
       }
     },
     "voorbeeld": {
+      "root": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.50}"
+        }
+      },
+      "container": {
+        "border-width": {
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.200}"
+        }
+      },
+      "line": {
+        "border-width": {
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.200}"
+        }
+      },
+      "focus": {
+        "color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.black}"
+        }
+      },
+      "form-control": {
+        "active": {
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.md}"
+          },
+          "accent-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.active.color}"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.100}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.500}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.950}"
+          }
+        },
+        "focus": {
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.md}"
+          }
+        },
+        "hover": {
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.md}"
+          },
+          "accent-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.hover.color}"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.50}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.500}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.950}"
+          }
+        },
+        "accent-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.interaction.color}"
+        },
+        "disabled": {
+          "accent-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.500}"
+          }
+        }
+      },
       "document": {
         "inverse": {
           "background-color": {
@@ -1135,18 +1207,6 @@
           "$value": "{voorbeeld.color.gray.900}"
         }
       },
-      "container": {
-        "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.200}"
-        }
-      },
-      "line": {
-        "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.200}"
-        }
-      },
       "interaction": {
         "color": {
           "$type": "color",
@@ -1162,72 +1222,6 @@
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.color.violet.800}"
-          }
-        }
-      },
-      "form-control": {
-        "accent-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.interaction.color}"
-        },
-        "active": {
-          "accent-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.active.color}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.100}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.950}"
-          }
-        },
-        "disabled": {
-          "accent-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.50}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
-          }
-        },
-        "hover": {
-          "accent-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.hover.color}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.50}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.950}"
-          }
-        },
-        "invalid": {
-          "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.negative.border-color}"
           }
         }
       },


### PR DESCRIPTION
Relates to ticket: https://github.com/nl-design-system/kernteam/issues/846

Overview of tokens that had the utrecht prefix and now have the voorbeeld prefix:

**Typography**
.document.strong.font-weight

**Colors**
.root.background-color
.document.subtle.color
.document.inverse.color
.document.inverse.background-color
.container.border-color
.line.border-color
.interaction.* (all)
.form-control.accent-color
.form-control.active.* (all)
.form-control.hover.* (all)
.form-control.disabled.accent-color
.feedback.informative.* (all)
.feedback.negative.* (all)
.feedback.positive.* (all)

**Size**
icon.functional.size
icon.toptask.size

**Border**
.container.border-width
.line.border-width
.form-control.active.border-width
.form-control.focus.border-width
.form-control.hover.border-width

**Focus**
.focus.color