### PR TITLE
fix: rename paragraph tokens

### DIFF
--- a/.changeset/kwik-kwek-kwak.md
+++ b/.changeset/kwik-kwek-kwak.md
@@ -1,0 +1,6 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+- `paragraph-lead` to `paragraph.lead`
+- `paragraph-small-print` to `paragraph.small`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3815,42 +3815,42 @@
         "margin-block-start": {
           "$type": "spacing",
           "$value": "{voorbeeld.space.block.beetle}"
-        }
-      },
-      "paragraph-lead": {
-        "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
         },
-        "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.lg}"
+        "lead": {
+          "color": {
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
+          },
+          "font-size": {
+            "$type": "fontSizes",
+            "$value": "{voorbeeld.typography.font-size.lg}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
+          },
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
+          }
         },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
-        },
-        "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
-        }
-      },
-      "paragraph-small-print": {
-        "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
-        },
-        "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.sm}"
-        },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
-        },
-        "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+        "small": {
+          "color": {
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
+          },
+          "font-size": {
+            "$type": "fontSizes",
+            "$value": "{voorbeeld.typography.font-size.sm}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
+          },
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
+          }
         }
       }
     }


### PR DESCRIPTION
- `paragraph-lead` to `paragraph.lead`
- `paragraph-small-print` to `paragraph.small`