### PR TITLE
chore: remove storybook version

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@nl-design-system-unstable/storybook",
-  "version": "1.0.0",
   "author": "Community for NL Design System",
   "description": "Storybook for NL Design System themes",
   "keywords": [


### PR DESCRIPTION
Remove the "version" field from the storybook package. This package is never going to be published.

Ik ben benieuwd of the release branch geupdate gaat worden.