### PR TITLE
fix: align accordion tokens with code

### DIFF
--- a/.changeset/koffie-thee-water.md
+++ b/.changeset/koffie-thee-water.md
@@ -1,0 +1,20 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Changed name to align with code:
+- `.accordion.body` to `.accordion.panel`
+- `.accordion.button.icon.margin-inline` to `.accordion.button.gap`
+
+Changed prefix from `.utrecht` to `.todo` for tokens which do not (yet) exist in code:
+- `.accordion.border-radius`
+- `.accordion.button.font-family`
+- `.accordion.button.font-size`
+- `.accordion.button.font-weight`
+- `.accordion.button.line-height`
+- `.accordion.button.expanded.background-color`
+- `.accordion.button.expanded.border-color`
+- `.accordion.button.expanded.color`
+- `.accordion.section.border-color`
+- `.accordion.section.border-width`
+- `.accordion.section.border-block-end-width`

--- a/.changeset/koffie-thee-water.md
+++ b/.changeset/koffie-thee-water.md
@@ -16,5 +16,4 @@ Changed prefix from `.utrecht` to `.todo` for tokens which do not (yet) exist in
 - `.accordion.button.expanded.border-color`
 - `.accordion.button.expanded.color`
 - `.accordion.section.border-color`
-- `.accordion.section.border-width`
 - `.accordion.section.border-block-end-width`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1314,60 +1314,6 @@
     }
   },
   "components/accordion": {
-    "todo": {
-      "accordion": {
-        "border-radius": {
-          "$type": "borderRadius",
-          "$value": "0px"
-        },
-        "section": {
-          "border-block-end-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
-          },
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "auto"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
-          }
-        },
-        "button": {
-          "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
-          },
-          "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
-          },
-          "expanded": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.50}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.color}"
-            }
-          },
-          "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
-          }
-        }
-      }
-    },
     "utrecht": {
       "accordion": {
         "panel": {
@@ -1377,7 +1323,7 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.lg}"
+            "$value": "{voorbeeld.border-width.sm}"
           },
           "padding-block-end": {
             "$type": "spacing",
@@ -1423,6 +1369,18 @@
             "$type": "spacing",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
+          "background-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.50}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "transparent"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
+          },
           "hover": {
             "background-color": {
               "$type": "color",
@@ -1436,18 +1394,6 @@
               "$type": "color",
               "$value": "{voorbeeld.interaction.hover.color}"
             }
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.50}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "transparent"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
           },
           "focus": {
             "background-color": {
@@ -1484,6 +1430,56 @@
           "border-radius": {
             "$type": "borderRadius",
             "$value": "0px"
+          }
+        }
+      }
+    },
+    "todo": {
+      "accordion": {
+        "border-radius": {
+          "$type": "borderRadius",
+          "$value": "0px"
+        },
+        "section": {
+          "border-block-end-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.sm}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.line.border-color}"
+          }
+        },
+        "button": {
+          "font-size": {
+            "$type": "fontSizes",
+            "$value": "{utrecht.document.font-size}"
+          },
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
+          },
+          "expanded": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.50}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.color}"
+            }
+          },
+          "font-family": {
+            "$type": "fontFamilies",
+            "$value": "{utrecht.document.font-family}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{voorbeeld.document.strong.font-weight}"
           }
         }
       }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1314,33 +1314,11 @@
     }
   },
   "components/accordion": {
-    "utrecht": {
+    "todo": {
       "accordion": {
         "border-radius": {
           "$type": "borderRadius",
           "$value": "0px"
-        },
-        "panel": {
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "0px"
-          },
-          "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.rabbit}"
-          },
-          "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.rabbit}"
-          },
-          "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
-          },
-          "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
-          }
         },
         "section": {
           "border-block-end-width": {
@@ -1356,7 +1334,43 @@
             "$value": "{voorbeeld.line.border-color}"
           }
         },
-        "body": {
+        "button": {
+          "font-size": {
+            "$type": "fontSizes",
+            "$value": "{utrecht.document.font-size}"
+          },
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
+          },
+          "expanded": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.50}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.color}"
+            }
+          },
+          "font-family": {
+            "$type": "fontFamilies",
+            "$value": "{utrecht.document.font-family}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{voorbeeld.document.strong.font-weight}"
+          }
+        }
+      }
+    },
+    "utrecht": {
+      "accordion": {
+        "panel": {
           "border-color": {
             "$type": "color",
             "$value": "transparent"
@@ -1383,23 +1397,11 @@
           }
         },
         "button": {
-          "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
-          },
           "gap": {
             "$type": "spacing",
             "$value": "{voorbeeld.space.text.mouse}"
           },
-          "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
-          },
           "icon": {
-            "margin-inline": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.text.mouse}"
-            },
             "size": {
               "$type": "sizing",
               "$value": "{voorbeeld.icon.functional.size}"
@@ -1433,20 +1435,6 @@
             "color": {
               "$type": "color",
               "$value": "{voorbeeld.interaction.hover.color}"
-            }
-          },
-          "expanded": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.50}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.color}"
             }
           },
           "background-color": {
@@ -1496,14 +1484,6 @@
           "border-radius": {
             "$type": "borderRadius",
             "$value": "0px"
-          },
-          "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
           }
         }
       }


### PR DESCRIPTION
Changed name to align with code:
- `.accordion.body` to `.accordion.panel`
- `.accordion.button.icon.margin-inline` to `.accordion.button.gap`

Changed prefix from `.utrecht` to `.todo` for tokens that do not (yet) exist in code:
- `.accordion.border-radius`
- `.accordion.button.font-family`
- `.accordion.button.font-size`
- `.accordion.button.font-weight`
- `.accordion.button.line-height`
- `.accordion.button.expanded.background-color`
- `.accordion.button.expanded.border-color`
- `.accordion.button.expanded.color`
- `.accordion.section.border-color`
- `.accordion.section.border-block-end-width`