### PR TITLE
chore: fix lint-staged config

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec lint-staged
+lint-staged

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,7 +1,0 @@
-{
-  "composer.json": "composer validate",
-  "package.json": "npmPkgJsonLint --allowEmptyTargets",
-  "*.md": ["markdownlint", "prettier --check"],
-  "*.{js,cjs,mjs,jsx,ts,tsx}": ["eslint --no-error-on-unmatched-pattern", "prettier --check"],
-  "*.css": ["stylelint --allow-empty-input", "prettier --check"]
-}

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  '*': 'prettier --ignore-unknown --write',
+  'package.json': 'npmPkgJsonLint --allowEmptyTargets',
+  '*.md': 'markdownlint',
+  '*.{js,cjs,mjs,jsx,ts,tsx}': 'eslint --no-error-on-unmatched-pattern',
+  '*.css': 'stylelint --allow-empty-input',
+};


### PR DESCRIPTION
Use `lint-staged.config.cjs` instead of `.lint-stagedrc.json`.

Run `prettier --ignore-unknown --write` for all files that Prettier can autofix. These fixes are added to the same commit instead of resulting in a new commit.