### PR TITLE
feat: added missing form-control tokens and made reference to them

### DIFF
--- a/.changeset/consider-constituency-survivor.md
+++ b/.changeset/consider-constituency-survivor.md
@@ -4,7 +4,8 @@
 
 New added form-control-tokens:
 
-- `form-control.border.width`
+- `form-control.border-width`
+- `form-control.border-radius`
 - `form-control.font-family`
 - `form-control.font-size`
 - `form-control.line-height`

--- a/.changeset/consider-constituency-survivor.md
+++ b/.changeset/consider-constituency-survivor.md
@@ -1,0 +1,20 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+---
+
+New added form-control-tokens:
+
+- `form-control.border.width`
+- `form-control.font-family`
+- `form-control.font-size`
+- `form-control.line-height`
+- `form-control.max-inline-size`
+- `form-control.padding-block-end`
+- `form-control.padding-block-start`
+- `form-control.padding-inline-end`
+- `form-control.padding-inline-start`
+
+Referenced in components:
+- Select
+- Textarea
+- Text-Input

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -938,6 +938,26 @@
         }
       },
       "form-control": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.white}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.500}"
+        },
+        "border-radius": {
+          "$type": "borderRadius",
+          "$value": "0px"
+        },
+        "border-width": {
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.950}"
+        },
         "font-family": {
           "$type": "fontFamilies",
           "$value": "{voorbeeld.typography.font-family.secondary}"
@@ -950,21 +970,31 @@
           "$type": "lineHeights",
           "$value": "{voorbeeld.typography.line-height.md}"
         },
-        "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.white}"
+        "max-inline-size": {
+          "$type": "sizing",
+          "$value": "400px"
         },
-        "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.500}"
+        "padding-block-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
-        "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+        "padding-block-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
         },
-        "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.950}"
+        "padding-inline-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
+        },
+        "padding-inline-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
+        },
+        "placeholder": {
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.600}"
+          }
         },
         "disabled": {
           "background-color": {
@@ -1029,36 +1059,6 @@
             "$type": "color",
             "$value": "{voorbeeld.color.gray.950}"
           }
-        },
-        "placeholder": {
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.600}"
-          }
-        },
-        "max-inline-size": {
-          "$type": "sizing",
-          "$value": "400px"
-        },
-        "border-radius": {
-          "$type": "borderRadius",
-          "$value": "0px"
-        },
-        "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
-        },
-        "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
-        },
-        "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
-        },
-        "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
         }
       },
       "heading": {

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -937,45 +937,19 @@
           "$value": "{voorbeeld.typography.line-height.md}"
         }
       },
-      "heading": {
+      "form-control": {
         "font-family": {
           "$type": "fontFamilies",
-          "$value": "{voorbeeld.typography.font-family.primary}"
+          "$value": "{voorbeeld.typography.font-family.secondary}"
         },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.typography.font-weight.bold}"
-        }
-      },
-      "focus": {
-        "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.yellow.200}"
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.md}"
         },
-        "outline-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.violet.700}"
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{voorbeeld.typography.line-height.md}"
         },
-        "inverse": {
-          "outline-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
-          }
-        },
-        "outline-offset": {
-          "$type": "other",
-          "$value": "0"
-        },
-        "outline-style": {
-          "$type": "other",
-          "$value": "dotted"
-        },
-        "outline-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.md}"
-        }
-      },
-      "form-control": {
         "background-color": {
           "$type": "color",
           "$value": "{voorbeeld.color.white}"
@@ -1018,6 +992,10 @@
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.color.black}"
+          },
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.md}"
           }
         },
         "invalid": {
@@ -1057,6 +1035,68 @@
             "$type": "color",
             "$value": "{voorbeeld.color.gray.600}"
           }
+        },
+        "max-inline-size": {
+          "$type": "sizing",
+          "$value": "400px"
+        },
+        "border-radius": {
+          "$type": "borderRadius",
+          "$value": "0px"
+        },
+        "padding-block-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
+        },
+        "padding-block-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
+        },
+        "padding-inline-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
+        },
+        "padding-inline-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
+        }
+      },
+      "heading": {
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{voorbeeld.typography.font-family.primary}"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.typography.font-weight.bold}"
+        }
+      },
+      "focus": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.yellow.200}"
+        },
+        "outline-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.violet.700}"
+        },
+        "inverse": {
+          "outline-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
+          }
+        },
+        "outline-offset": {
+          "$type": "other",
+          "$value": "0"
+        },
+        "outline-style": {
+          "$type": "other",
+          "$value": "dotted"
+        },
+        "outline-width": {
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.md}"
         }
       },
       "pointer-target": {
@@ -1136,12 +1176,6 @@
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.color.gray.950}"
-          }
-        },
-        "focus": {
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
           }
         },
         "hover": {
@@ -1510,7 +1544,7 @@
     }
   },
   "components/alert": {
-    "utrecht": {
+    "todo": {
       "alert": {
         "heading": {
           "font-family": {
@@ -1529,7 +1563,11 @@
             "$type": "fontSizes",
             "$value": "{voorbeeld.typography.font-size.xl}"
           }
-        },
+        }
+      }
+    },
+    "utrecht": {
+      "alert": {
         "column-gap": {
           "$type": "spacing",
           "$value": "{voorbeeld.space.column.snail}"
@@ -1635,6 +1673,10 @@
             "$type": "spacing",
             "$value": "{voorbeeld.space.block.flea}"
           },
+          "color": {
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
+          },
           "info": {
             "color": {
               "$type": "color",
@@ -1673,6 +1715,12 @@
         "border-radius": {
           "$type": "borderRadius",
           "$value": "0px"
+        },
+        "content": {
+          "row-gap": {
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.row.rat}"
+          }
         }
       }
     }
@@ -2489,7 +2537,7 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
+            "$value": "{utrecht.form-control.focus.border-width}"
           }
         },
         "disabled": {
@@ -2536,7 +2584,7 @@
           "focus": {
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.focus.border-width}"
+              "$value": "{utrecht.form-control.focus.border-width}"
             },
             "background-color": {
               "$type": "color",
@@ -2670,7 +2718,7 @@
             },
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.focus.border-width}"
+              "$value": "{utrecht.form-control.focus.border-width}"
             }
           }
         },
@@ -3953,7 +4001,7 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
+            "$value": "{utrecht.form-control.focus.border-width}"
           }
         },
         "disabled": {
@@ -4030,7 +4078,7 @@
             },
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.focus.border-width}"
+              "$value": "{utrecht.form-control.focus.border-width}"
             }
           },
           "disabled": {
@@ -4149,7 +4197,7 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
+            "$value": "{utrecht.form-control.focus.border-width}"
           }
         },
         "disabled": {
@@ -4186,23 +4234,23 @@
         },
         "padding-block-end": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "$value": "{utrecht.form-control.padding-block-end}"
         },
         "padding-block-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "$value": "{utrecht.form-control.padding-block-start}"
         },
         "padding-inline-end": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "$value": "{utrecht.form-control.padding-inline-end}"
         },
         "padding-inline-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "$value": "{utrecht.form-control.padding-inline-start}"
         },
         "border-radius": {
           "$type": "borderRadius",
-          "$value": "0px"
+          "$value": "{utrecht.form-control.border-radius}"
         },
         "border-bottom-width": {
           "$type": "borderWidth",
@@ -4214,7 +4262,7 @@
         },
         "font-family": {
           "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "$value": "{utrecht.form-control.font-family}"
         },
         "font-weight": {
           "$type": "fontWeights",
@@ -4222,15 +4270,15 @@
         },
         "line-height": {
           "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "$value": "{utrecht.form-control.line-height}"
         },
         "font-size": {
           "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "$value": "{utrecht.form-control.font-size}"
         },
         "max-inline-size": {
           "$type": "sizing",
-          "$value": "400px"
+          "$value": "{utrecht.form-control.max-inline-size}"
         }
       }
     }
@@ -5112,23 +5160,23 @@
       "textarea": {
         "max-inline-size": {
           "$type": "sizing",
-          "$value": "400px"
+          "$value": "{utrecht.form-control.max-inline-size}"
         },
         "padding-block-end": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "$value": "{utrecht.form-control.padding-block-end}"
         },
         "padding-block-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "$value": "{utrecht.form-control.padding-block-start}"
         },
         "padding-inline-end": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "$value": "{utrecht.form-control.padding-inline-end}"
         },
         "padding-inline-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "$value": "{utrecht.form-control.padding-inline-start}"
         },
         "background-color": {
           "$type": "color",
@@ -5181,7 +5229,7 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
+            "$value": "{utrecht.form-control.focus.border-width}"
           }
         },
         "disabled": {
@@ -5232,7 +5280,7 @@
         },
         "border-radius": {
           "$type": "borderRadius",
-          "$value": "0px"
+          "$value": "{utrecht.form-control.border-radius}"
         },
         "border-bottom-width": {
           "$type": "borderWidth",
@@ -5244,19 +5292,21 @@
         },
         "font-family": {
           "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
+          "$value": "{utrecht.form-control.font-family}"
         },
         "line-height": {
           "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "$value": "{utrecht.form-control.line-height}"
         },
         "font-size": {
           "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "$value": "{utrecht.form-control.font-size}"
+        }
+      },
+      "text-area": {
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
         }
       }
     }
@@ -5266,15 +5316,15 @@
       "textbox": {
         "border-radius": {
           "$type": "borderRadius",
-          "$value": "0px"
+          "$value": "{utrecht.form-control.border-radius}"
         },
         "font-family": {
           "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "$value": "{utrecht.form-control.font-family}"
         },
         "font-size": {
           "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "$value": "{utrecht.form-control.font-size}"
         },
         "font-weight": {
           "$type": "fontWeights",
@@ -5282,27 +5332,27 @@
         },
         "line-height": {
           "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "$value": "{utrecht.form-control.line-height}"
         },
         "max-inline-size": {
           "$type": "sizing",
-          "$value": "400px"
+          "$value": "{utrecht.form-control.max-inline-size}"
         },
         "padding-block-end": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "$value": "{utrecht.form-control.padding-block-end}"
         },
         "padding-block-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "$value": "{utrecht.form-control.padding-block-start}"
         },
         "padding-inline-end": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "$value": "{utrecht.form-control.padding-inline-end}"
         },
         "padding-inline-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "$value": "{utrecht.form-control.padding-inline-start}"
         },
         "background-color": {
           "$type": "color",
@@ -5351,7 +5401,7 @@
         "focus": {
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
+            "$value": "{utrecht.form-control.focus.border-width}"
           },
           "background-color": {
             "$type": "color",

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5303,11 +5303,9 @@
           "$value": "{utrecht.form-control.font-size}"
         }
       },
-      "text-area": {
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
-        }
+      "font-weight": {
+        "$type": "fontWeights",
+        "$value": "{utrecht.document.font-weight}"
       }
     }
   },


### PR DESCRIPTION
This PR will add missing form-control tokens which are available in the code of Utrecht. And will use these 'common' tokens as reference for some `component` tokens.

New added form-control-tokens:

- `form-control.border-width`
- `form-control.border-radius`
- `form-control.font-family`
- `form-control.font-size`
- `form-control.line-height`
- `form-control.max-inline-size`
- `form-control.padding-block-end`
- `form-control.padding-block-start`
- `form-control.padding-inline-end`
- `form-control.padding-inline-start`

Reference in components:
- Select
- Textarea
- Text-Input