### PR TITLE
fix: align alert tokens with code

### DIFF
--- a/.changeset/quaint-clearance-official.md
+++ b/.changeset/quaint-clearance-official.md
@@ -16,3 +16,7 @@ Changed prefix from `.utrecht` to `.todo` for tokens that do not (yet) exist in 
 - `.alert.heading.font-size`
 - `.alert.heading.font-weight`
 - `.alert.heading.line-height`
+
+Removed tokens that are available in code, but have no use in Figma:
+- `.alert.margin-block-end`
+- `.alert.margin-block-start`

--- a/.changeset/quaint-clearance-official.md
+++ b/.changeset/quaint-clearance-official.md
@@ -1,0 +1,18 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Added tokens that are available in code:
+- `.alert.background-color`
+- `.alert.border-color`
+- `.alert.border-radius`
+- `.alert.color`
+- `.alert.content.row-gap`
+- `.alert.message.row-gap`
+- `.alert.icon.color`
+
+Changed prefix from `.utrecht` to `.todo` for tokens that do not (yet) exist in code:
+- `.alert.heading.font-family`
+- `.alert.heading.font-size`
+- `.alert.heading.font-weight`
+- `.alert.heading.line-height`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1510,7 +1510,7 @@
     }
   },
   "components/alert": {
-    "utrecht": {
+    "todo": {
       "alert": {
         "heading": {
           "font-family": {
@@ -1529,22 +1529,14 @@
             "$type": "fontSizes",
             "$value": "{voorbeeld.typography.font-size.xl}"
           }
-        },
+        }
+      }
+    },
+    "utrecht": {
+      "alert": {
         "column-gap": {
           "$type": "spacing",
           "$value": "{voorbeeld.space.column.snail}"
-        },
-        "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.md}"
-        },
-        "margin-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
-        },
-        "margin-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-end": {
           "$type": "spacing",
@@ -1635,6 +1627,14 @@
             "$type": "spacing",
             "$value": "{voorbeeld.space.block.flea}"
           },
+          "size": {
+            "$type": "sizing",
+            "$value": "{voorbeeld.icon.functional.size}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.feedback.informative.color}"
+          },
           "info": {
             "color": {
               "$type": "color",
@@ -1658,10 +1658,6 @@
               "$type": "color",
               "$value": "{utrecht.feedback.warning.color}"
             }
-          },
-          "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
           }
         },
         "message": {
@@ -1670,9 +1666,19 @@
             "$value": "{voorbeeld.space.row.snail}"
           }
         },
+        "content": {
+          "row-gap": {
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.row.rat}"
+          }
+        },
         "border-radius": {
           "$type": "borderRadius",
           "$value": "0px"
+        },
+        "border-width": {
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.md}"
         }
       }
     }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1512,6 +1512,26 @@
   "components/alert": {
     "utrecht": {
       "alert": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.feedback.informative.background-color}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.feedback.informative.border-color}"
+        },
+        "border-radius": {
+          "$type": "borderRadius",
+          "$value": "0px"
+        },
+        "border-width": {
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.md}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        },
         "column-gap": {
           "$type": "spacing",
           "$value": "{voorbeeld.space.column.snail}"
@@ -1532,17 +1552,17 @@
           "$type": "spacing",
           "$value": "{voorbeeld.space.inline.mouse}"
         },
-        "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.feedback.informative.background-color}"
+        "content": {
+          "row-gap": {
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.row.rat}"
+          }
         },
-        "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.feedback.informative.border-color}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+        "message": {
+          "row-gap": {
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.row.snail}"
+          }
         },
         "info": {
           "background-color": {
@@ -1637,26 +1657,6 @@
               "$value": "{utrecht.feedback.warning.color}"
             }
           }
-        },
-        "message": {
-          "row-gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.row.snail}"
-          }
-        },
-        "content": {
-          "row-gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.row.rat}"
-          }
-        },
-        "border-radius": {
-          "$type": "borderRadius",
-          "$value": "0px"
-        },
-        "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.md}"
         }
       }
     },

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1510,28 +1510,6 @@
     }
   },
   "components/alert": {
-    "todo": {
-      "alert": {
-        "heading": {
-          "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.heading.font-family}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.heading.font-weight}"
-          },
-          "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.sm}"
-          },
-          "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.xl}"
-          }
-        }
-      }
-    },
     "utrecht": {
       "alert": {
         "column-gap": {
@@ -1679,6 +1657,28 @@
         "border-width": {
           "$type": "borderWidth",
           "$value": "{voorbeeld.border-width.md}"
+        }
+      }
+    },
+    "todo": {
+      "alert": {
+        "heading": {
+          "font-family": {
+            "$type": "fontFamilies",
+            "$value": "{utrecht.heading.font-family}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{utrecht.heading.font-weight}"
+          },
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{voorbeeld.typography.line-height.sm}"
+          },
+          "font-size": {
+            "$type": "fontSizes",
+            "$value": "{voorbeeld.typography.font-size.xl}"
+          }
         }
       }
     }


### PR DESCRIPTION
Added tokens that are available in code:
- `.alert.background-color`
- `.alert.border-color`
- `.alert.border-radius`
- `.alert.color`
- `.alert.content.row-gap`
- `.alert.message.row-gap`
- `.alert.icon.color`

Changed prefix from `.utrecht` to `.todo` for tokens that do not (yet) exist in code:
- `.alert.heading.font-family`
- `.alert.heading.font-size`
- `.alert.heading.font-weight`
- `.alert.heading.line-height`

Removed tokens that are available in code, but have no use in Figma:
- `.alert.margin-block-end`
- `.alert.margin-block-start`