### PR TITLE
fix: align badge-counter tokens with code

### DIFF
--- a/.changeset/paragraph-choose-mountain.md
+++ b/.changeset/paragraph-choose-mountain.md
@@ -1,0 +1,9 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Changed prefix from .utrecht to .todo for tokens that do not (yet) exist in code:
+
+- `.badge-counter.border-color`
+- `.badge-counter.border-width`
+- `.badge-counter.line-height`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1790,10 +1790,6 @@
           "$type": "fontSizes",
           "$value": "{voorbeeld.typography.font-size.sm}"
         },
-        "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
-        },
         "min-block-size": {
           "$type": "sizing",
           "$value": "{voorbeeld.size.xs}"
@@ -1805,10 +1801,6 @@
         "font-weight": {
           "$type": "fontWeights",
           "$value": "{voorbeeld.document.strong.font-weight}"
-        },
-        "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
         },
         "border-radius": {
           "$type": "borderRadius",
@@ -1822,10 +1814,6 @@
           "$type": "color",
           "$value": "{voorbeeld.color.violet.100}"
         },
-        "border-color": {
-          "$type": "color",
-          "$value": "transparent"
-        },
         "color": {
           "$type": "color",
           "$value": "{utrecht.document.color}"
@@ -1837,6 +1825,22 @@
         "padding-block": {
           "$type": "spacing",
           "$value": "{voorbeeld.space.block.ant}"
+        }
+      }
+    },
+    "todo": {
+      "badge-counter": {
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
+        },
+        "border-width": {
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "transparent"
         }
       }
     }


### PR DESCRIPTION
Changed prefix from .utrecht to .todo for tokens that do not (yet) exist in code:

- `.badge-counter.border-color`
- `.badge-counter.border-width`
- `.badge-counter.line-height`