### PR TITLE
fix: prefix status-badge tokens with `.todo`.

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4440,7 +4440,7 @@
     }
   },
   "components/status-badge": {
-    "utrecht": {
+    "todo": {
       "status-badge": {
         "font-size": {
           "$type": "fontSizes",


### PR DESCRIPTION
Prefixed status-badge tokens with `.todo` because the name of the component and token options differ to much with the code of Utecht.

https://nl-design-system.github.io/utrecht/storybook/?path=/story/css_css-status-badge--design-tokens