### PR TITLE
fix: align blockquote tokens with code

### DIFF
--- a/.changeset/gap-governor-fiction.md
+++ b/.changeset/gap-governor-fiction.md
@@ -1,0 +1,15 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Removed token that did not exist in code:
+- `utrecht.blockquote.attribution.padding-block-start`
+
+Changed prefix from `.utrecht` to `.todo` for tokens which do not (yet) exist in code:
+- `.blockquote.row-gap
+- `.blockquote.attribution.font-family
+- `.blockquote.attribution.font-weight
+- `.blockquote.attribution.line-height
+- `.blockquote.content.font-family
+- `.blockquote.content.font-weight
+- `.blockquote.content.line-height

--- a/.changeset/gap-governor-fiction.md
+++ b/.changeset/gap-governor-fiction.md
@@ -6,10 +6,10 @@ Removed token that did not exist in code:
 - `utrecht.blockquote.attribution.padding-block-start`
 
 Changed prefix from `.utrecht` to `.todo` for tokens which do not (yet) exist in code:
-- `.blockquote.row-gap
-- `.blockquote.attribution.font-family
-- `.blockquote.attribution.font-weight
-- `.blockquote.attribution.line-height
-- `.blockquote.content.font-family
-- `.blockquote.content.font-weight
-- `.blockquote.content.line-height
+- `.blockquote.row-gap`
+- `.blockquote.attribution.font-family`
+- `.blockquote.attribution.font-weight`
+- `.blockquote.attribution.line-height`
+- `.blockquote.content.font-family`
+- `.blockquote.content.font-weight`
+- `.blockquote.content.line-height`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1849,40 +1849,12 @@
             "$type": "fontSizes",
             "$value": "{voorbeeld.typography.font-size.sm}"
           },
-          "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
-          },
-          "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.md}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
-          },
-          "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
-          },
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.document.subtle.color}"
           }
         },
         "content": {
-          "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.heading.font-family}"
-          },
-          "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.sm}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
-          },
           "font-size": {
             "$type": "fontSizes",
             "$value": "{voorbeeld.typography.font-size.xl}"
@@ -1911,6 +1883,42 @@
         "background-color": {
           "$type": "color",
           "$value": "transparent"
+        }
+      }
+    },
+    "todo": {
+      "row-gap": {
+        "$type": "spacing",
+        "$value": "{voorbeeld.space.row.snail}"
+      },
+      "blockquote": {
+        "attribution": {
+          "font-family": {
+            "$type": "fontFamilies",
+            "$value": "{utrecht.document.font-family}"
+          },
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{voorbeeld.typography.line-height.md}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
+          }
+        },
+        "content": {
+          "font-family": {
+            "$type": "fontFamilies",
+            "$value": "{utrecht.heading.font-family}"
+          },
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{voorbeeld.typography.line-height.sm}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
+          }
         }
       }
     }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1844,6 +1844,26 @@
   "components/blockquote": {
     "utrecht": {
       "blockquote": {
+        "background-color": {
+          "$type": "color",
+          "$value": "transparent"
+        },
+        "padding-block-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
+        },
+        "padding-block-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
+        },
+        "padding-inline-end": {
+          "$type": "spacing",
+          "$value": "0px"
+        },
+        "padding-inline-start": {
+          "$type": "spacing",
+          "$value": "0px"
+        },
         "attribution": {
           "font-size": {
             "$type": "fontSizes",
@@ -1863,35 +1883,15 @@
             "$type": "color",
             "$value": "{utrecht.document.color}"
           }
-        },
-        "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
-        },
-        "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
-        },
-        "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "0px"
-        },
-        "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "0px"
-        },
-        "background-color": {
-          "$type": "color",
-          "$value": "transparent"
         }
       }
     },
     "todo": {
-      "row-gap": {
-        "$type": "spacing",
-        "$value": "{voorbeeld.space.row.snail}"
-      },
       "blockquote": {
+        "row-gap": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.row.snail}"
+        },
         "attribution": {
           "font-family": {
             "$type": "fontFamilies",


### PR DESCRIPTION
Removed token that did not exist in code:
- `utrecht.blockquote.attribution.padding-block-start`

Changed prefix from `.utrecht` to `.todo` for tokens which do not (yet) exist in code:
- `.blockquote.row-gap`
- `.blockquote.attribution.font-family`
- `.blockquote.attribution.font-weight`
- `.blockquote.attribution.line-height`
- `.blockquote.content.font-family`
- `.blockquote.content.font-weight`
- `.blockquote.content.line-height`