### PR TITLE
fix: changed name of breadcrumb tokens

### DIFF
--- a/.changeset/hold-motorist-mug.md
+++ b/.changeset/hold-motorist-mug.md
@@ -1,0 +1,10 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Changed name of tokens:
+
+- `.breadcrumb.divider.color` to `.breadcrumb-nav.separator.color`.
+- `.breadcrumb.divider.size` to `.breadcrumb-nav.separator.size`.
+- `.breadcrumb.margin-inline` to `breadcrumb-nav.column-gap`.
+- `.breadcrumb.link.icon.margin-inline` to `.breadcrumb-nav.link.icon.column-gap`.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1932,7 +1932,7 @@
               "$type": "sizing",
               "$value": "{voorbeeld.icon.functional.size}"
             },
-            "margin-inline": {
+            "column-gap": {
               "$type": "spacing",
               "$value": "{voorbeeld.space.text.beetle}"
             }
@@ -2002,7 +2002,7 @@
             "$value": "underline"
           }
         },
-        "divider": {
+        "separator": {
           "size": {
             "$type": "sizing",
             "$value": "{voorbeeld.size.2xs}"
@@ -2012,9 +2012,9 @@
             "$value": "{voorbeeld.document.subtle.color}"
           }
         },
-        "margin-inline": {
+        "column-gap": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.beetle}"
+          "$value": "{voorbeeld.space.column.snail}"
         },
         "font-family": {
           "$type": "fontFamilies",


### PR DESCRIPTION
Changed name of some breadcrumb tokens:

- `.breadcrumb.divider.color` to `.breadcrumb-nav.separator.color`.
- `.breadcrumb.divider.size` to `.breadcrumb-nav.separator.size`.
- `.breadcrumb.margin-inline` to `breadcrumb-nav.column-gap`.
- `.breadcrumb.link.icon.margin-inline` to `.breadcrumb-nav.link.icon.column-gap`.