### PR TITLE
fix: remove button tokens for margin

### DIFF
--- a/.changeset/tear-injury-mold.md
+++ b/.changeset/tear-injury-mold.md
@@ -1,0 +1,8 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Removed tokens that are available in code, but have no use in Figma:
+
+- `.button.margin-block-end`
+- `.button.margin-block-start`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -2416,14 +2416,6 @@
           "$type": "spacing",
           "$value": "{voorbeeld.space.column.snail}"
         },
-        "margin-block-end": {
-          "$type": "spacing",
-          "$value": "0px"
-        },
-        "margin-block-start": {
-          "$type": "spacing",
-          "$value": "0px"
-        },
         "padding-block-end": {
           "$type": "spacing",
           "$value": "0px"


### PR DESCRIPTION
Removed tokens that are available in code, but have no use in Figma:

- `.button.margin-block-end`
- `.button.margin-block-start`