### PR TITLE
fix: align checkbox tokens with code

### DIFF
--- a/.changeset/last-perfume-momentum.md
+++ b/.changeset/last-perfume-momentum.md
@@ -1,0 +1,35 @@
+Changed prefix from `.utrecht` to `.todo` for tokens that do not (yet) exist in code:
+
+Additional states when checked:
+- `.checkbox.checked.active.background-color`
+- `.checkbox.checked.active.border-color`
+- `.checkbox.checked.active.border-width`
+- `.checkbox.checked.active.color`
+- `.checkbox.checked.focus.background-color`
+- `.checkbox.checked.focus.border-color`
+- `.checkbox.checked.focus.border-width`
+- `.checkbox.checked.focus.color`
+- `.checkbox.checked.hover.background-color`
+- `.checkbox.checked.hover.border-color`
+- `.checkbox.checked.hover.border-width`
+- `.checkbox.checked.hover.color`
+- `.checkbox.checked.disabled.background-color`
+- `.checkbox.checked.disabled.border-color`
+- `.checkbox.checked.disabled.color`
+
+Additional states when indeterminate:
+- `.checkbox.indeterminate.active.background-color`
+- `.checkbox.indeterminate.active.border-color`
+- `.checkbox.indeterminate.active.border-width`
+- `.checkbox.indeterminate.active.color`
+- `.checkbox.indeterminate.focus.background-color`
+- `.checkbox.indeterminate.focus.border-color`
+- `.checkbox.indeterminate.focus.border-width`
+- `.checkbox.indeterminate.focus.color`
+- `.checkbox.indeterminate.hover.background-color`
+- `.checkbox.indeterminate.hover.border-color`
+- `.checkbox.indeterminate.hover.border-width`
+- `.checkbox.indeterminate.hover.color`
+- `.checkbox.indeterminate.disabled.background-color`
+- `.checkbox.indeterminate.disabled.border-color`
+- `.checkbox.indeterminate.disabled.color`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -2442,9 +2442,21 @@
   "components/checkbox": {
     "utrecht": {
       "checkbox": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{utrecht.form-control.background-color}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{utrecht.form-control.border-color}"
+        },
         "border-radius": {
           "$type": "borderRadius",
           "$value": "0px"
+        },
+        "border-width": {
+          "$type": "borderWidth",
+          "$value": "{utrecht.form-control.border-width}"
         },
         "size": {
           "$type": "sizing",
@@ -2456,26 +2468,42 @@
             "$value": "{voorbeeld.icon.functional.size}"
           }
         },
-        "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.background-color}"
-        },
-        "border-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.border-color}"
-        },
-        "invalid": {
+        "active": {
           "background-color": {
             "$type": "color",
-            "$value": "{utrecht.form-control.invalid.background-color}"
+            "$value": "{voorbeeld.form-control.active.background-color}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{utrecht.form-control.invalid.border-color}"
+            "$value": "{voorbeeld.form-control.active.border-color}"
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.form-control.invalid.border-width}"
+            "$value": "{voorbeeld.form-control.active.border-width}"
+          }
+        },
+        "disabled": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.background-color}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{utrecht.form-control.disabled.border-color}"
+          }
+        },
+        "hover": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.background-color}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.border-color}"
+          },
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.hover.border-width}"
           }
         },
         "focus": {
@@ -2492,14 +2520,18 @@
             "$value": "{voorbeeld.form-control.focus.border-width}"
           }
         },
-        "disabled": {
+        "invalid": {
           "background-color": {
             "$type": "color",
-            "$value": "{utrecht.form-control.disabled.background-color}"
+            "$value": "{utrecht.form-control.invalid.background-color}"
           },
           "border-color": {
             "$type": "color",
-            "$value": "{utrecht.form-control.disabled.border-color}"
+            "$value": "{utrecht.form-control.invalid.border-color}"
+          },
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.invalid.border-width}"
           }
         },
         "checked": {
@@ -2511,28 +2543,38 @@
             "$type": "color",
             "$value": "transparent"
           },
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.border-width}"
+          },
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.color.white}"
+          }
+        },
+        "indeterminate": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.accent-color}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "transparent"
           },
           "border-width": {
             "$type": "borderWidth",
             "$value": "{utrecht.form-control.border-width}"
           },
-          "disabled": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.form-control.disabled.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
-            }
-          },
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
+          }
+        }
+      }
+    },
+    "todo": {
+      "checkbox": {
+        "checked": {
           "focus": {
             "border-width": {
               "$type": "borderWidth",
@@ -2577,6 +2619,20 @@
             "background-color": {
               "$type": "color",
               "$value": "{voorbeeld.form-control.active.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
+            }
+          },
+          "disabled": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{voorbeeld.form-control.disabled.accent-color}"
             },
             "border-color": {
               "$type": "color",
@@ -2589,21 +2645,59 @@
           }
         },
         "indeterminate": {
-          "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.accent-color}"
+          "active": {
+            "border-width": {
+              "$type": "borderWidth",
+              "$value": "{voorbeeld.form-control.active.border-width}"
+            },
+            "background-color": {
+              "$type": "color",
+              "$value": "{voorbeeld.form-control.active.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
+            }
           },
-          "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+          "hover": {
+            "border-width": {
+              "$type": "borderWidth",
+              "$value": "{voorbeeld.form-control.hover.border-width}"
+            },
+            "background-color": {
+              "$type": "color",
+              "$value": "{voorbeeld.form-control.hover.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.color.white}"
+            }
           },
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
-          },
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.border-width}"
+          "focus": {
+            "border-width": {
+              "$type": "borderWidth",
+              "$value": "{voorbeeld.form-control.focus.border-width}"
+            },
+            "background-color": {
+              "$type": "color",
+              "$value": "{utrecht.form-control.focus.background-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{utrecht.form-control.focus.border-color}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{utrecht.form-control.focus.color}"
+            }
           },
           "disabled": {
             "background-color": {
@@ -2618,92 +2712,6 @@
               "$type": "color",
               "$value": "{voorbeeld.color.white}"
             }
-          },
-          "active": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.form-control.active.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
-            },
-            "border-width": {
-              "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.active.border-width}"
-            }
-          },
-          "hover": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.form-control.hover.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
-            },
-            "border-width": {
-              "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.hover.border-width}"
-            }
-          },
-          "focus": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.focus.background-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.focus.border-color}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.focus.color}"
-            },
-            "border-width": {
-              "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.focus.border-width}"
-            }
-          }
-        },
-        "border-width": {
-          "$type": "borderWidth",
-          "$value": "{utrecht.form-control.border-width}"
-        },
-        "hover": {
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.hover.border-width}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.background-color}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.border-color}"
-          }
-        },
-        "active": {
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.active.border-width}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.active.background-color}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.active.border-color}"
           }
         }
       }


### PR DESCRIPTION
Changed prefix from `.utrecht` to `.todo` for tokens that do not (yet) exist in code:

Additional states when checked:
- `.checkbox.checked.active.background-color`
- `.checkbox.checked.active.border-color`
- `.checkbox.checked.active.border-width`
- `.checkbox.checked.active.color`
- `.checkbox.checked.focus.background-color`
- `.checkbox.checked.focus.border-color`
- `.checkbox.checked.focus.border-width`
- `.checkbox.checked.focus.color`
- `.checkbox.checked.hover.background-color`
- `.checkbox.checked.hover.border-color`
- `.checkbox.checked.hover.border-width`
- `.checkbox.checked.hover.color`
- `.checkbox.checked.disabled.background-color`
- `.checkbox.checked.disabled.border-color`
- `.checkbox.checked.disabled.color`

Additional states when indeterminate:
- `.checkbox.indeterminate.active.background-color`
- `.checkbox.indeterminate.active.border-color`
- `.checkbox.indeterminate.active.border-width`
- `.checkbox.indeterminate.active.color`
- `.checkbox.indeterminate.focus.background-color`
- `.checkbox.indeterminate.focus.border-color`
- `.checkbox.indeterminate.focus.border-width`
- `.checkbox.indeterminate.focus.color`
- `.checkbox.indeterminate.hover.background-color`
- `.checkbox.indeterminate.hover.border-color`
- `.checkbox.indeterminate.hover.border-width`
- `.checkbox.indeterminate.hover.color`
- `.checkbox.indeterminate.disabled.background-color`
- `.checkbox.indeterminate.disabled.border-color`
- `.checkbox.indeterminate.disabled.color`