### PR TITLE
fix: prefix of focus color token

### DIFF
--- a/.changeset/leave-place-negligence.md
+++ b/.changeset/leave-place-negligence.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+fix: focus.color was supported as a token in code of utrecht so get's its utrecht. prefix back.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -952,6 +952,10 @@
           "$type": "color",
           "$value": "{voorbeeld.color.yellow.200}"
         },
+        "color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.black}"
+        },
         "outline-color": {
           "$type": "color",
           "$value": "{voorbeeld.color.violet.700}"
@@ -1107,12 +1111,6 @@
         "border-color": {
           "$type": "color",
           "$value": "{voorbeeld.color.gray.200}"
-        }
-      },
-      "focus": {
-        "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.black}"
         }
       },
       "form-control": {
@@ -1472,7 +1470,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{voorbeeld.focus.color}"
+              "$value": "{utrecht.focus.color}"
             }
           },
           "active": {
@@ -1974,7 +1972,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{voorbeeld.focus.color}"
+              "$value": "{utrecht.focus.color}"
             },
             "text-decoration": {
               "$type": "textDecoration",
@@ -2113,7 +2111,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{voorbeeld.focus.color}"
+            "$value": "{utrecht.focus.color}"
           }
         },
         "hover": {
@@ -2208,7 +2206,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{voorbeeld.focus.color}"
+              "$value": "{utrecht.focus.color}"
             }
           },
           "font-weight": {
@@ -2290,7 +2288,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{voorbeeld.focus.color}"
+              "$value": "{utrecht.focus.color}"
             }
           },
           "font-weight": {
@@ -2380,7 +2378,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{voorbeeld.focus.color}"
+              "$value": "{utrecht.focus.color}"
             }
           },
           "active": {
@@ -3251,7 +3249,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{voorbeeld.focus.color}"
+            "$value": "{utrecht.focus.color}"
           },
           "text-decoration": {
             "$type": "textDecoration",
@@ -3586,7 +3584,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{voorbeeld.focus.color}"
+              "$value": "{utrecht.focus.color}"
             },
             "text-decoration": {
               "$type": "textDecoration",
@@ -3708,7 +3706,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{voorbeeld.focus.color}"
+              "$value": "{utrecht.focus.color}"
             }
           },
           "hover": {
@@ -4318,7 +4316,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "{voorbeeld.focus.color}"
+              "$value": "{utrecht.focus.color}"
             },
             "text-decoration": {
               "$type": "textDecoration",
@@ -4405,7 +4403,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{voorbeeld.focus.color}"
+            "$value": "{utrecht.focus.color}"
           },
           "text-decoration": {
             "$type": "textDecoration",
@@ -4784,7 +4782,7 @@
           "focus": {
             "color": {
               "$type": "color",
-              "$value": "{voorbeeld.focus.color}"
+              "$value": "{utrecht.focus.color}"
             }
           },
           "disabled": {
@@ -4824,7 +4822,7 @@
           "focus": {
             "background-color": {
               "$type": "color",
-              "$value": "{voorbeeld.focus.color}"
+              "$value": "{utrecht.focus.color}"
             }
           },
           "min-inline-size": {


### PR DESCRIPTION
fix: focus.color was supported as a token in code of utrecht so get's its `utrecht.` prefix back.