### PR TITLE
fix: align form-field-error-message tokens with code

### DIFF
--- a/.changeset/enfix-witness-earthflax.md
+++ b/.changeset/enfix-witness-earthflax.md
@@ -1,0 +1,18 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Aligned form-field-error-message tokens with code.
+
+Renamed token:
+`.form-field-error-message.icon.margin-inline-end` to `.form-field-error-message.column-gap`
+
+Prefix from `.utrecht` to `.todo`:
+- `.form-field-error-message.column-gap`
+- `.form-field-error-message.icon.size`
+
+Added tokens:
+- `.form-field-error-message.background-color`
+- `.form-field-error-message.padding*` (all)
+
+Reordered tokens for easier scanning.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -2920,15 +2920,9 @@
   "components/form-field-error-message": {
     "utrecht": {
       "form-field-error-message": {
-        "icon": {
-          "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
-          },
-          "margin-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.text.mouse}"
-          }
+        "background-color": {
+          "$type": "color",
+          "$value": "transparent"
         },
         "color": {
           "$type": "color",
@@ -2945,6 +2939,36 @@
         "font-weight": {
           "$type": "fontWeights",
           "$value": "{utrecht.document.font-weight}"
+        },
+        "padding-block-end": {
+          "$type": "spacing",
+          "$value": "0px"
+        },
+        "padding-block-start": {
+          "$type": "spacing",
+          "$value": "0px"
+        },
+        "padding-inline-end": {
+          "$type": "spacing",
+          "$value": "0px"
+        },
+        "padding-inline-start": {
+          "$type": "spacing",
+          "$value": "0px"
+        }
+      }
+    },
+    "todo": {
+      "form-field-error-message": {
+        "icon": {
+          "size": {
+            "$type": "sizing",
+            "$value": "{voorbeeld.icon.functional.size}"
+          }
+        },
+        "column-gap": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.text.mouse}"
         }
       }
     }


### PR DESCRIPTION
Aligned form-field-error-message tokens with code.

Renamed token:
`.form-field-error-message.icon.margin-inline-end` to `.form-field-error-message.column-gap`

Prefix from `.utrecht` to `.todo`:
- `.form-field-error-message.column-gap`
- `.form-field-error-message.icon.size`

Added tokens:
- `.form-field-error-message.background-color`
- `.form-field-error-message.padding*` (all)

Reordered tokens for easier scanning.