### PR TITLE
fix: prefix of heading color

### DIFF
--- a/.changeset/guide-musical-bloodshed.md
+++ b/.changeset/guide-musical-bloodshed.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Changed prefix of heading.color token from todo. to utrecht. because it is available in code.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -945,6 +945,10 @@
         "font-weight": {
           "$type": "fontWeights",
           "$value": "{voorbeeld.typography.font-weight.bold}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.900}"
         }
       },
       "focus": {
@@ -1199,12 +1203,6 @@
             "$type": "fontWeights",
             "$value": "{voorbeeld.typography.font-weight.bold}"
           }
-        }
-      },
-      "heading": {
-        "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.900}"
         }
       },
       "interaction": {
@@ -3022,7 +3020,7 @@
       "heading-1": {
         "color": {
           "$type": "color",
-          "$value": "{voorbeeld.heading.color}"
+          "$value": "{utrecht.heading.color}"
         },
         "font-family": {
           "$type": "fontFamilies",
@@ -3052,7 +3050,7 @@
       "heading-2": {
         "color": {
           "$type": "color",
-          "$value": "{voorbeeld.heading.color}"
+          "$value": "{utrecht.heading.color}"
         },
         "font-family": {
           "$type": "fontFamilies",
@@ -3082,7 +3080,7 @@
       "heading-3": {
         "color": {
           "$type": "color",
-          "$value": "{voorbeeld.heading.color}"
+          "$value": "{utrecht.heading.color}"
         },
         "font-family": {
           "$type": "fontFamilies",
@@ -3112,7 +3110,7 @@
       "heading-4": {
         "color": {
           "$type": "color",
-          "$value": "{voorbeeld.heading.color}"
+          "$value": "{utrecht.heading.color}"
         },
         "font-family": {
           "$type": "fontFamilies",
@@ -3142,7 +3140,7 @@
       "heading-5": {
         "color": {
           "$type": "color",
-          "$value": "{voorbeeld.heading.color}"
+          "$value": "{utrecht.heading.color}"
         },
         "font-family": {
           "$type": "fontFamilies",
@@ -3172,7 +3170,7 @@
       "heading-6": {
         "color": {
           "$type": "color",
-          "$value": "{voorbeeld.heading.color}"
+          "$value": "{utrecht.heading.color}"
         },
         "font-family": {
           "$type": "fontFamilies",
@@ -4887,7 +4885,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{voorbeeld.heading.color}"
+            "$value": "{utrecht.heading.color}"
           },
           "font-family": {
             "$type": "fontFamilies",


### PR DESCRIPTION
Changed prefix of `heading.color` token from `todo.` to `utrecht.` because it is available in code.