### PR TITLE
fix: removed margin tokens for headings 1 to 6

### DIFF
--- a/.changeset/charm-slump-rubbish.md
+++ b/.changeset/charm-slump-rubbish.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Removed margin tokens from headings 1 to 6 to align with other component tokens within Figma.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3039,14 +3039,6 @@
         "font-size": {
           "$type": "fontSizes",
           "$value": "{voorbeeld.typography.font-size.3xl}"
-        },
-        "margin-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
-        },
-        "margin-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
         }
       },
       "heading-2": {
@@ -3069,14 +3061,6 @@
         "font-size": {
           "$type": "fontSizes",
           "$value": "{voorbeeld.typography.font-size.2xl}"
-        },
-        "margin-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
-        },
-        "margin-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
         }
       },
       "heading-3": {
@@ -3099,14 +3083,6 @@
         "font-size": {
           "$type": "fontSizes",
           "$value": "{voorbeeld.typography.font-size.xl}"
-        },
-        "margin-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
-        },
-        "margin-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
         }
       },
       "heading-4": {
@@ -3129,14 +3105,6 @@
         "font-size": {
           "$type": "fontSizes",
           "$value": "{voorbeeld.typography.font-size.lg}"
-        },
-        "margin-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
-        },
-        "margin-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
         }
       },
       "heading-5": {
@@ -3159,14 +3127,6 @@
         "font-size": {
           "$type": "fontSizes",
           "$value": "{voorbeeld.typography.font-size.md}"
-        },
-        "margin-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
-        },
-        "margin-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
         }
       },
       "heading-6": {
@@ -3189,14 +3149,6 @@
         "font-size": {
           "$type": "fontSizes",
           "$value": "{voorbeeld.typography.font-size.sm}"
-        },
-        "margin-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
-        },
-        "margin-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
         }
       }
     }


### PR DESCRIPTION
Removed margin tokens from headings 1 to 6 to align with other component tokens within Figma.