### PR TITLE
fix: align ordered-list  tokens with code

### DIFF
--- a/.changeset/age-cup-night.md
+++ b/.changeset/age-cup-night.md
@@ -7,6 +7,7 @@ Aligned ordered-list tokens with code.
 Added token `ordered-list.item.padding-inline-start`
 
 Removed tokens:
+
 - `ordered-list.color`
 - `ordered-list.font-family`
 - `ordered-list.font-weight`

--- a/age-cup-night.md
+++ b/age-cup-night.md
@@ -1,0 +1,12 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Aligned ordered-list tokens with code.
+
+Added token `ordered-list.item.padding-inline-start`
+
+Removed tokens:
+- `ordered-list.color`
+- `ordered-list.font-family`
+- `ordered-list.font-weight`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3424,22 +3424,6 @@
   "components/ordered-list": {
     "utrecht": {
       "ordered-list": {
-        "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.rabbit}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
-        },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
-        },
         "font-size": {
           "$type": "fontSizes",
           "$value": "{utrecht.document.font-size}"
@@ -3448,7 +3432,15 @@
           "$type": "lineHeights",
           "$value": "{utrecht.document.line-height}"
         },
+        "padding-inline-start": {
+          "$type": "spacing",
+          "$value": "0px"
+        },
         "item": {
+          "padding-inline-start": {
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.rabbit}"
+          },
           "margin-block-end": {
             "$type": "spacing",
             "$value": "{voorbeeld.space.block.ant}"


### PR DESCRIPTION
Aligned ordered-list tokens with code.

Added token `ordered-list.item.padding-inline-start`

Removed tokens:

- `ordered-list.color`
- `ordered-list.font-family`
- `ordered-list.font-weight`
