### PR TITLE
fix: align paragraph tokens with code

### DIFF
--- a/.changeset/grave-think-goat.md
+++ b/.changeset/grave-think-goat.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Aligned paragraph tokens with code.

--- a/.changeset/grave-think-goat.md
+++ b/.changeset/grave-think-goat.md
@@ -2,4 +2,4 @@
 "@nl-design-system-unstable/voorbeeld-design-tokens": major
 ---
 
-Aligned paragraph tokens with code.
+Removed margin tokens from Paragraph to align with other component tokens within Figma.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3846,14 +3846,6 @@
           "$type": "lineHeights",
           "$value": "{utrecht.document.line-height}"
         },
-        "margin-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
-        },
-        "margin-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
-        },
         "lead": {
           "color": {
             "$type": "color",


### PR DESCRIPTION
Removed margin tokens from Paragraph to align with other component tokens within Figma.