### PR TITLE
feat: new design token package layout

### DIFF
--- a/packages/theme-toolkit/src/style-dictionary.test.ts
+++ b/packages/theme-toolkit/src/style-dictionary.test.ts
@@ -1,0 +1,307 @@
+/* eslint-env jest */
+
+import { describe, expect, beforeAll, it } from '@jest/globals';
+import { access, constants, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const fileExists = async (path: string) => {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+const testDirectory = (distPath: string) => {
+  describe('Style Dictionary build', () => {
+    describe('.less output', () => {
+      const path = resolve(distPath, './variables.less');
+      it('has a `dist/variables.less` file', async () => {
+        expect(await fileExists(path)).toBe(true);
+      });
+
+      describe('file contents', () => {
+        let content = '';
+        beforeAll(async () => {
+          content = await readFile(path, 'utf-8');
+        });
+
+        it('has variable declaration in Less syntax', () => {
+          expect(content).toContain('@utrecht-button-color: @voorbeeld-color-gray-900;');
+        });
+
+        it.todo('the file `dist/variables.less` has valid Less syntax');
+      });
+    });
+
+    describe('CSS output', () => {
+      describe('./theme.css', () => {
+        const path = resolve(distPath, './theme.css');
+
+        it('has a `dist/theme.css` file', async () => {
+          expect(await fileExists(path)).toBe(true);
+        });
+
+        describe('file contents', () => {
+          let content = '';
+
+          beforeAll(async () => {
+            content = await readFile(path, 'utf-8');
+          });
+
+          it('applies to the `.voorbeeld-theme` selector', () => {
+            expect(content).toContain('.voorbeeld-theme');
+          });
+
+          it('contains a variable declaration', () => {
+            expect(content).toContain('--utrecht-button-color:');
+          });
+
+          it('contains a variable declaration with a variable reference', () => {
+            expect(content).toContain('--utrecht-button-color: var(--voorbeeld-color-gray-900);');
+          });
+        });
+      });
+
+      describe('dist/variables.css', () => {
+        const path = resolve(distPath, './variables.css');
+
+        it('has a `dist/variables.css` file', async () => {
+          expect(await fileExists(path)).toBe(true);
+        });
+
+        describe('file contents', () => {
+          let content = '';
+
+          beforeAll(async () => {
+            content = await readFile(path, 'utf-8');
+          });
+
+          it('applies to the `:root` selector', () => {
+            expect(content).toContain(':root');
+          });
+
+          it('contains a variable declaration', () => {
+            expect(content).toContain('--utrecht-button-color:');
+          });
+
+          it('contains a variable declaration with a variable reference', () => {
+            expect(content).toContain('--utrecht-button-color: var(--voorbeeld-color-gray-900);');
+          });
+        });
+      });
+    });
+
+    describe('SCSS output', () => {
+      describe('./_variables.scss', () => {
+        const path = resolve(distPath, './_variables.scss');
+
+        it('has a `dist/_variables.scss` file', async () => {
+          expect(await fileExists(path)).toBe(true);
+        });
+
+        describe('file contents', () => {
+          let content = '';
+
+          beforeAll(async () => {
+            content = await readFile(path, 'utf-8');
+          });
+
+          it('contains a variable declaration', () => {
+            expect(content).toContain('$utrecht-button-color:');
+          });
+
+          it('contains a variable declaration with a variable reference', () => {
+            expect(content).toContain('$utrecht-button-color: $voorbeeld-color-gray-900;');
+          });
+
+          it('contains no "$token-set-order" artefacts from Token Studio', () => {
+            expect(content).not.toContain('$token-set-order');
+          });
+
+          it.skip('contains valid SASS syntax has no side effects', () => {
+            /*
+            import { compileString } from 'sass';
+            const output = compileString(content);
+            console.log(output);
+            expect(output).toBe('');
+            */
+          });
+        });
+      });
+
+      describe('dist/_mixin.scss', () => {
+        const path = resolve(distPath, './_mixin.scss');
+
+        it('has a `dist/_mixin.scss` file', async () => {
+          expect(await fileExists(path)).toBe(true);
+        });
+
+        describe('file contents', () => {
+          let content = '';
+
+          beforeAll(async () => {
+            content = await readFile(path, 'utf-8');
+          });
+
+          it('contains the `voorbeeld-theme` mixin', () => {
+            expect(content).toContain('@mixin voorbeeld-theme');
+          });
+
+          it('contains a variable declaration', () => {
+            expect(content).toContain('--utrecht-button-color:');
+          });
+
+          it('contains a variable declaration with a variable reference', () => {
+            expect(content).toContain('--utrecht-button-color: var(--voorbeeld-color-gray-900);');
+          });
+        });
+      });
+    });
+
+    describe('JavaScript output', () => {
+      describe('dist/variables.mjs', () => {
+        const path = resolve(distPath, './variables.mjs');
+        it('has a `dist/variables.mjs` file', async () => {
+          expect(await fileExists(path)).toBe(true);
+        });
+        describe('file contents', () => {
+          let content = '';
+
+          beforeAll(async () => {
+            content = await readFile(path, 'utf-8');
+          });
+
+          it('contains a variable declaration', () => {
+            expect(content).toContain('export const utrechtButtonColor = ');
+          });
+        });
+      });
+
+      describe('dist/variables.cjs', () => {
+        const path = resolve(distPath, './variables.cjs');
+        it('has a `dist/variables.cjs` file', async () => {
+          expect(await fileExists(path)).toBe(true);
+        });
+
+        describe('file contents', () => {
+          let content = '';
+
+          beforeAll(async () => {
+            content = await readFile(path, 'utf-8');
+          });
+
+          it('contains a variable declaration', () => {
+            expect(content).toContain('"utrechtButtonColor":');
+          });
+
+          it('contains a variable assignment', () => {
+            expect(content).toContain('"utrechtButtonColor": "hsl(215 78% 18%)"');
+          });
+        });
+      });
+    });
+
+    describe('TypeScript output', () => {
+      describe('variables.d.ts', () => {
+        const path = resolve(distPath, './variables.d.ts');
+        it('has a `dist/variables.d.ts` file', async () => {
+          expect(await fileExists(path)).toBe(true);
+        });
+
+        describe('file contents', () => {
+          let content = '';
+
+          beforeAll(async () => {
+            content = await readFile(path, 'utf-8');
+          });
+          it('contains a variable assignment', () => {
+            expect(content).toContain('export const utrechtButtonColor : string;');
+          });
+        });
+      });
+
+      describe('tokens.d.ts', () => {
+        const path = resolve(distPath, './tokens.d.ts');
+        it('has a `dist/tokens.d.ts` file', async () => {
+          expect(await fileExists(path)).toBe(true);
+        });
+
+        describe('file contents', () => {
+          let content = '';
+
+          beforeAll(async () => {
+            content = await readFile(path, 'utf-8');
+          });
+
+          it('contains a default export', () => {
+            expect(content).toContain('export default tokens');
+          });
+
+          it('contains a type assignment', () => {
+            expect(content).toContain('"color": DesignToken');
+          });
+        });
+      });
+    });
+
+    describe('JSON output', () => {
+      describe('variables.json', () => {
+        const path = resolve(distPath, './variables.json');
+        it('has a `dist/variables.json` file', async () => {
+          expect(await fileExists(path)).toBe(true);
+        });
+
+        describe('file contents', () => {
+          let content = '';
+
+          beforeAll(async () => {
+            content = await readFile(path, 'utf-8');
+          });
+
+          it('contains a property declaration', () => {
+            expect(content).toContain('"utrechtButtonColor":');
+          });
+
+          it('contains a property assignment', () => {
+            expect(content).toContain('"utrechtButtonColor": "hsl(215 78% 18%)"');
+          });
+        });
+      });
+
+      describe('tokens.json', () => {
+        const path = resolve(distPath, './tokens.json');
+        it('has a `dist/tokens.json` file', async () => {
+          expect(await fileExists(path)).toBe(true);
+        });
+
+        describe('file contents', () => {
+          let content = '';
+
+          beforeAll(async () => {
+            content = await readFile(path, 'utf-8');
+          });
+
+          it('contains a property declaration', () => {
+            expect(content).toContain('"utrecht":');
+            expect(content).toContain('"button":');
+            expect(content).toContain('"color":');
+          });
+
+          it.skip('contains a property declaration', () => {
+            expect(content).toContain('"utrecht":');
+            expect(content).toContain('"button":');
+            expect(content).toContain('"color":');
+            expect(content).toContain('"value":');
+          });
+
+          it.skip('contains a property assignment', () => {
+            expect(content).toContain('"value": "hsl(215 78% 18%)"');
+          });
+        });
+      });
+    });
+  });
+};
+
+testDirectory('../voorbeeld-design-tokens/dist/');

--- a/style-dictionary-config.js
+++ b/style-dictionary-config.js
@@ -2,86 +2,147 @@ const stringSort = (a, b) => (a === b ? 0 : a > b ? 1 : -1);
 
 const sortByName = (a, b) => stringSort(a.name, b.name);
 
-const createConfig = ({ selector, source = ['src/**/*.tokens.json'] }) => ({
-  hooks: {
-    formats: {
-      'json/list': function ({ dictionary }) {
-        return JSON.stringify(dictionary.allTokens.sort(sortByName), null, '  ');
+const createConfig = ({ selector, source = ['src/**/tokens.json', 'src/**/*.tokens.json'] }) => {
+  const prefix = selector.replace(/^\.(.+)-theme/, '$1');
+  const themeName = `${prefix}-theme`;
+
+  return {
+    hooks: {
+      formats: {
+        'json/list': function ({ dictionary }) {
+          return JSON.stringify(dictionary.allTokens.sort(sortByName), null, '  ');
+        },
       },
     },
-  },
-  source,
-  platforms: {
-    js: {
-      transformGroups: 'tokens-studio',
-      transforms: ['attribute/cti', 'name/camel', 'color/hsl-4'],
-      buildPath: 'dist/',
-      files: [
-        {
-          destination: 'index.js',
-          format: 'javascript/es6',
-        },
-      ],
-    },
-    json: {
-      transformGroups: 'tokens-studio',
-      transforms: ['attribute/cti', 'name/camel', 'color/hsl-4'],
-      buildPath: 'dist/',
-      files: [
-        {
-          destination: 'tokens.json',
-          format: 'json',
-        },
-        {
-          destination: 'index.json',
-          format: 'json/list',
-        },
-      ],
-    },
-    css: {
-      transformGroups: 'tokens-studio',
-      transforms: ['attribute/cti', 'name/kebab', 'color/hsl-4'],
-      buildPath: 'dist/',
-      files: [
-        {
-          destination: 'design-tokens.css',
-          format: 'css/variables',
-          options: {
-            selector,
-            outputReferences: true,
+    source,
+    platforms: {
+      js: {
+        transformGroups: 'tokens-studio',
+        transforms: ['name/camel', 'color/hsl-4'],
+        buildPath: 'dist/',
+        files: [
+          {
+            destination: 'variables.cjs',
+            format: 'javascript/module-flat',
           },
-        },
-      ],
-    },
-    scss: {
-      transformGroups: 'tokens-studio',
-      transforms: ['attribute/cti', 'name/kebab', 'color/hsl-4'],
-      buildPath: 'dist/',
-      files: [
-        {
-          destination: 'index.scss',
-          format: 'scss/variables',
-          options: {
-            outputReferences: true,
+          {
+            destination: 'variables.mjs',
+            format: 'javascript/es6',
           },
-        },
-      ],
-    },
-    less: {
-      transformGroups: 'tokens-studio',
-      transforms: ['attribute/cti', 'name/kebab', 'color/hsl-4'],
-      buildPath: 'dist/',
-      files: [
-        {
-          destination: 'index.less',
-          format: 'less/variables',
-          options: {
-            outputReferences: true,
+        ],
+      },
+      tokenTree: {
+        transformGroups: 'tokens-studio',
+        transforms: ['color/hsl-4'],
+        buildPath: 'dist/',
+        files: [
+          {
+            format: 'javascript/module',
+            destination: 'tokens.cjs',
           },
-        },
-      ],
+        ],
+      },
+      json: {
+        transformGroups: 'tokens-studio',
+        transforms: ['name/camel', 'color/hsl-4'],
+        buildPath: 'dist/',
+        files: [
+          {
+            destination: 'tokens.json',
+            format: 'json',
+          },
+          {
+            destination: 'list.json',
+            format: 'json/list',
+          },
+          {
+            destination: 'variables.json',
+            format: 'json/flat',
+          },
+        ],
+      },
+      css: {
+        transformGroups: 'tokens-studio',
+        transforms: ['name/kebab', 'color/hsl-4'],
+        buildPath: 'dist/',
+        files: [
+          {
+            destination: 'theme.css',
+            format: 'css/variables',
+            options: {
+              selector: `.${themeName}`,
+              outputReferences: true,
+            },
+          },
+          {
+            destination: 'variables.css',
+            format: 'css/variables',
+            options: {
+              selector: `:root`,
+              outputReferences: true,
+            },
+          },
+        ],
+      },
+      scss: {
+        transformGroups: 'tokens-studio',
+        transforms: ['name/kebab', 'color/hsl-4'],
+        buildPath: 'dist/',
+        files: [
+          {
+            destination: '_variables.scss',
+            format: 'scss/variables',
+            options: {
+              outputReferences: true,
+            },
+          },
+        ],
+      },
+      'scss-theme-mixin': {
+        transforms: ['name/kebab', 'color/hsl-4'],
+        buildPath: 'dist/',
+        files: [
+          {
+            destination: '_mixin.scss',
+            format: 'css/variables',
+            options: {
+              selector: `@mixin ${themeName}`,
+              outputReferences: true,
+            },
+          },
+        ],
+      },
+      less: {
+        transformGroups: 'tokens-studio',
+        transforms: ['name/kebab', 'color/hsl-4'],
+        buildPath: 'dist/',
+        files: [
+          {
+            destination: 'variables.less',
+            format: 'less/variables',
+            options: {
+              outputReferences: true,
+            },
+          },
+        ],
+      },
+      typescript: {
+        transforms: ['name/camel', 'color/hsl-4'],
+        transformGroup: 'js',
+        buildPath: 'dist/',
+        files: [
+          {
+            format: 'typescript/es6-declarations',
+            destination: 'variables.d.ts',
+          },
+          {
+            format: 'typescript/module-declarations',
+            destination: 'tokens.d.ts',
+          },
+        ],
+      },
     },
-  },
-});
+  };
+};
 
 module.exports = { createConfig };


### PR DESCRIPTION
Have a look at the [Spreadsheet comparing various design token packages from the NL Design System community](https://docs.google.com/spreadsheets/d/1_TSC4lcULPxr4IfQYaovIKtuUc5dksE1-0fOIb-NoTM/edit?usp=sharing)

This PR contains a the start of a proposal for a new unified design token package directory structure.

<img width="551" alt="Screenshot 2024-08-25 at 20 25 28" src="https://github.com/user-attachments/assets/f9ca92b8-ae34-42a2-86e1-0a4d34622f28">