### PR TITLE
fix: align separator tokens with code

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4246,11 +4246,11 @@
           "$type": "sizing",
           "$value": "{voorbeeld.size.4xs}"
         },
-        "padding-block-end": {
+        "margin-block-end": {
           "$type": "spacing",
           "$value": "{voorbeeld.space.block.snail}"
         },
-        "padding-block-start": {
+        "margin-block-start": {
           "$type": "spacing",
           "$value": "{voorbeeld.space.block.snail}"
         }


### PR DESCRIPTION
Renamed `separator.padding*` to `separator.margin*`. But still to be discussed.