### PR TITLE
fix: change prefix of drawer header tokens

### DIFF
--- a/.changeset/date-plain-sugar.md
+++ b/.changeset/date-plain-sugar.md
@@ -1,0 +1,9 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Prefix from `.utrecht` to `.todo`
+- `drawer.header.font-family`
+- `drawer.header.font-weight`
+- `drawer.header.font-size`
+- `drawer.header.line-height`

--- a/.changeset/date-plain-sugar.md
+++ b/.changeset/date-plain-sugar.md
@@ -3,7 +3,7 @@
 ---
 
 Prefix from `.utrecht` to `.todo`
-- `drawer.header.font-family`
-- `drawer.header.font-weight`
-- `drawer.header.font-size`
-- `drawer.header.line-height`
+- `drawer.header.label.font-family`
+- `drawer.header.label.font-weight`
+- `drawer.header.label.font-size`
+- `drawer.header.label.line-height`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -2739,6 +2739,22 @@
             "color": {
               "$type": "color",
               "$value": "{utrecht.document.color}"
+            },
+            "font-family": {
+              "$type": "fontFamilies",
+              "$value": "{utrecht.document.font-family}"
+            },
+            "font-size": {
+              "$type": "fontSizes",
+              "$value": "{utrecht.document.font-size}"
+            },
+            "font-weight": {
+              "$type": "fontWeights",
+              "$value": "{voorbeeld.document.strong.font-weight}"
+            },
+            "line-height": {
+              "$type": "lineHeights",
+              "$value": "{utrecht.document.line-height}"
             }
           },
           "padding-block-end": {
@@ -2837,30 +2853,6 @@
         "box-shadow": {
           "$type": "boxShadow",
           "$value": "{voorbeeld.box-shadow.lg}"
-        }
-      }
-    },
-    "utrecht": {
-      "drawer": {
-        "header": {
-          "label": {
-            "font-family": {
-              "$type": "fontFamilies",
-              "$value": "{utrecht.document.font-family}"
-            },
-            "font-size": {
-              "$type": "fontSizes",
-              "$value": "{utrecht.document.font-size}"
-            },
-            "font-weight": {
-              "$type": "fontWeights",
-              "$value": "{voorbeeld.document.strong.font-weight}"
-            },
-            "line-height": {
-              "$type": "lineHeights",
-              "$value": "{utrecht.document.line-height}"
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
Prefix from `.utrecht` to `.todo`
- `drawer.header.label.font-family`
- `drawer.header.label.font-weight`
- `drawer.header.label.font-size`
- `drawer.header.label.line-height`