### PR TITLE
fix: align skip-link tokens with code

### DIFF
--- a/.changeset/duke-equal-crash.md
+++ b/.changeset/duke-equal-crash.md
@@ -1,0 +1,17 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Deleted tokens
+- `skip-link.font-family`
+- `skip-link.font-size`
+- `skip-link.line-height`
+- `skip-link.focus.border-color`
+
+Prefix from `.utrecht` to `.todo`:
+- `skip-link.border-color`
+- `skip-link.border-width`
+- `skip-link.box-block-end-shadow`
+- `skip-link.font-weight`
+
+Renamed token `skip-link.box-block-end-shadow` to `skip-link.box-shadow`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4354,21 +4354,13 @@
   "components/skip-link": {
     "utrecht": {
       "skip-link": {
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.document.inverse.background-color}"
         },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
-        "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
-        },
-        "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+        "color": {
+          "$type": "color",
+          "$value": "{voorbeeld.document.inverse.color}"
         },
         "min-block-size": {
           "$type": "sizing",
@@ -4394,14 +4386,14 @@
           "$type": "spacing",
           "$value": "{voorbeeld.space.inline.mouse}"
         },
+        "text-decoration": {
+          "$type": "textDecoration",
+          "$value": "underline"
+        },
         "focus": {
           "background-color": {
             "$type": "color",
             "$value": "{utrecht.focus.background-color}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "transparent"
           },
           "color": {
             "$type": "color",
@@ -4411,30 +4403,26 @@
             "$type": "textDecoration",
             "$value": "None"
           }
-        },
-        "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.document.inverse.background-color}"
-        },
+        }
+      }
+    },
+    "todo": {
+      "skip-link": {
         "border-color": {
           "$type": "color",
           "$value": "transparent"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.document.inverse.color}"
         },
         "border-width": {
           "$type": "borderWidth",
           "$value": "{voorbeeld.border-width.sm}"
         },
-        "box-block-end-shadow": {
+        "box-shadow": {
           "$type": "boxShadow",
           "$value": "{voorbeeld.box-shadow.lg}"
         },
-        "text-decoration": {
-          "$type": "textDecoration",
-          "$value": "underline"
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.document.strong.font-weight}"
         }
       }
     }


### PR DESCRIPTION
Deleted tokens
- `skip-link.font-family`
- `skip-link.font-size`
- `skip-link.line-height`
- `skip-link.focus.border-color`

Prefix from `.utrecht` to `.todo`:
- `skip-link.border-color`
- `skip-link.border-width`
- `skip-link.box-block-end-shadow`
- `skip-link.font-weight`

Renamed token `skip-link.box-block-end-shadow` to `skip-link.box-shadow`