### PR TITLE
fix: change prefix of table tokens

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4804,7 +4804,7 @@
     }
   },
   "components/table": {
-    "utrecht": {
+    "todo": {
       "table": {
         "header-cell": {
           "line-height": {


### PR DESCRIPTION
Changed prefix of table tokens from `utrecht` to `todo` as design and code are too much out of sync.