### PR TITLE
fix: align unordered-list tokens with code

### DIFF
--- a/.changeset/shout-wheat-coast.md
+++ b/.changeset/shout-wheat-coast.md
@@ -1,0 +1,14 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Aligned unordered-list tokens with code.
+
+Added token `unordered-list.item.padding-inline-start`
+
+Removed tokens:
+
+- `unordered-list.color`
+- `unordered-list.font-family`
+- `unordered-list.font-weight`
+- `unordered-list.marker.border-color`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5398,31 +5398,9 @@
   "components/unordered-list": {
     "utrecht": {
       "unordered-list": {
-        "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
-        },
-        "marker": {
-          "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
-          }
-        },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
         "font-size": {
           "$type": "fontSizes",
           "$value": "{utrecht.document.font-size}"
-        },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
         },
         "line-height": {
           "$type": "lineHeights",
@@ -5430,9 +5408,13 @@
         },
         "padding-inline-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.rabbit}"
+          "$value": "0px"
         },
         "item": {
+          "padding-inline-start": {
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.inline.rabbit}"
+          },
           "margin-block-end": {
             "$type": "spacing",
             "$value": "{voorbeeld.space.block.ant}"
@@ -5440,6 +5422,12 @@
           "margin-block-start": {
             "$type": "spacing",
             "$value": "{voorbeeld.space.block.ant}"
+          }
+        },
+        "marker": {
+          "color": {
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
           }
         }
       }


### PR DESCRIPTION
Aligned unordered-list tokens with code.

Added token `unordered-list.item.padding-inline-start`

Removed tokens:

- `unordered-list.color`
- `unordered-list.font-family`
- `unordered-list.font-weight`
- `unordered-list.marker.border-color`