### PR TITLE
fix: align textarea tokens with code

### DIFF
--- a/.changeset/maid-ditch-shelf.md
+++ b/.changeset/maid-ditch-shelf.md
@@ -1,0 +1,19 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Aligned textarea tokens with code.
+
+Renamed token:
+- `textarea.border-bottom-width` to `textarea.border-block-end-width`
+
+Added token:
+- `textarea.min-block-size`
+- `textarea.invalid.border-block-end-width`
+
+Removed token:
+- `textarea.font-weight`
+
+Prefix from `.utrecht` to `.todo`
+- `textarea.focs.border-width`
+- `textarea.hover.*`

--- a/.changeset/maid-ditch-shelf.md
+++ b/.changeset/maid-ditch-shelf.md
@@ -7,6 +7,10 @@ Aligned textarea tokens with code.
 Renamed token:
 - `textarea.border-bottom-width` to `textarea.border-block-end-width`
 
+Removed tokens:
+- `textarea.hover.border-width`
+- `textarea.focus.border-width`
+
 Added token:
 - `textarea.min-block-size`
 - `textarea.invalid.border-block-end-width`

--- a/.changeset/maid-ditch-shelf.md
+++ b/.changeset/maid-ditch-shelf.md
@@ -11,9 +11,6 @@ Added token:
 - `textarea.min-block-size`
 - `textarea.invalid.border-block-end-width`
 
-Removed token:
-- `textarea.font-weight`
-
 Prefix from `.utrecht` to `.todo`
 - `textarea.focs.border-width`
 - `textarea.hover.*`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -951,39 +951,11 @@
           "$value": "{voorbeeld.color.gray.900}"
         }
       },
-      "focus": {
-        "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.yellow.200}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.black}"
-        },
-        "outline-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.violet.700}"
-        },
-        "inverse": {
-          "outline-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
-          }
-        },
-        "outline-offset": {
-          "$type": "other",
-          "$value": "0"
-        },
-        "outline-style": {
-          "$type": "other",
-          "$value": "dotted"
-        },
-        "outline-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.md}"
-        }
-      },
       "form-control": {
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.typography.font-weight.normal}"
+        },
         "background-color": {
           "$type": "color",
           "$value": "{voorbeeld.color.white}"
@@ -1065,6 +1037,38 @@
             "$type": "color",
             "$value": "{voorbeeld.color.gray.600}"
           }
+        }
+      },
+      "focus": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.yellow.200}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.black}"
+        },
+        "outline-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.violet.700}"
+        },
+        "inverse": {
+          "outline-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.white}"
+          }
+        },
+        "outline-offset": {
+          "$type": "other",
+          "$value": "0"
+        },
+        "outline-style": {
+          "$type": "other",
+          "$value": "dotted"
+        },
+        "outline-width": {
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.md}"
         }
       },
       "pointer-target": {
@@ -5191,6 +5195,10 @@
             "$type": "color",
             "$value": "{utrecht.form-control.read-only.color}"
           }
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{utrecht.form-control.font-weight}"
         }
       }
     },

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5068,7 +5068,7 @@
         },
         "border-block-end-width": {
           "$type": "borderWidth",
-          "$value": "auto"
+          "$value": "{utrecht.textarea.border-width}"
         },
         "border-color": {
           "$type": "color",
@@ -5159,7 +5159,7 @@
         "invalid": {
           "border-block-end-width": {
             "$type": "borderWidth",
-            "$value": "auto"
+            "$value": "{utrecht.textarea.border-width}"
           },
           "background-color": {
             "$type": "color",

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5159,7 +5159,7 @@
         "invalid": {
           "border-block-end-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.textarea.border-width}"
+            "$value": "{utrecht.textarea.invalid.border-width}"
           },
           "background-color": {
             "$type": "color",

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5075,7 +5075,7 @@
           "$value": "{utrecht.form-control.border-color}"
         },
         "border-radius": {
-          "$type": "borderRadius",
+          "$type": "utrecht.form-control.border-radius",
           "$value": "0px"
         },
         "border-width": {
@@ -5088,11 +5088,11 @@
         },
         "font-family": {
           "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "$value": "{utrecht.form-control.font-family}"
         },
         "font-size": {
           "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "$value": "{utrecht.form-control.font-size}"
         },
         "line-height": {
           "$type": "lineHeights",
@@ -5100,7 +5100,7 @@
         },
         "max-inline-size": {
           "$type": "sizing",
-          "$value": "400px"
+          "$value": "utrecht.form-control.max-inline-size"
         },
         "min-block-size": {
           "$type": "sizing",
@@ -5108,19 +5108,19 @@
         },
         "padding-block-end": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "$value": "{utrecht.form-control.padding-block-end}"
         },
         "padding-block-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "$value": "{utrecht.form-control.padding-block-start}"
         },
         "padding-inline-end": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "$value": "{utrecht.form-control.padding-inline-end}"
         },
         "padding-inline-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "$value": "{utrecht.form-control.padding-inline-start}"
         },
         "placeholder": {
           "color": {

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5062,9 +5062,49 @@
   "components/textarea": {
     "utrecht": {
       "textarea": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{utrecht.form-control.background-color}"
+        },
+        "border-block-end-width": {
+          "$type": "borderWidth",
+          "$value": "auto"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{utrecht.form-control.border-color}"
+        },
+        "border-radius": {
+          "$type": "borderRadius",
+          "$value": "0px"
+        },
+        "border-width": {
+          "$type": "borderWidth",
+          "$value": "{utrecht.form-control.border-width}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.form-control.color}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
+        },
         "max-inline-size": {
           "$type": "sizing",
           "$value": "400px"
+        },
+        "min-block-size": {
+          "$type": "sizing",
+          "$value": "{utrecht.pointer-target.min-size}"
         },
         "padding-block-end": {
           "$type": "spacing",
@@ -5081,36 +5121,6 @@
         "padding-inline-start": {
           "$type": "spacing",
           "$value": "{voorbeeld.space.inline.snail}"
-        },
-        "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.background-color}"
-        },
-        "border-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.border-color}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.color}"
-        },
-        "invalid": {
-          "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.background-color}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.border-color}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.color}"
-          },
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.invalid.border-width}"
-          }
         },
         "placeholder": {
           "color": {
@@ -5130,10 +5140,6 @@
           "color": {
             "$type": "color",
             "$value": "{utrecht.form-control.focus.color}"
-          },
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
           }
         },
         "disabled": {
@@ -5150,6 +5156,28 @@
             "$value": "{utrecht.form-control.disabled.color}"
           }
         },
+        "invalid": {
+          "border-block-end-width": {
+            "$type": "borderWidth",
+            "$value": "auto"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.background-color}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.border-color}"
+          },
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.invalid.border-width}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{utrecht.form-control.color}"
+          }
+        },
         "read-only": {
           "background-color": {
             "$type": "color",
@@ -5163,6 +5191,16 @@
             "$type": "color",
             "$value": "{utrecht.form-control.read-only.color}"
           }
+        }
+      }
+    },
+    "todo": {
+      "textarea": {
+        "focus": {
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.focus.border-width}"
+          }
         },
         "hover": {
           "background-color": {
@@ -5173,42 +5211,14 @@
             "$type": "color",
             "$value": "{voorbeeld.form-control.hover.border-color}"
           },
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.color}"
-          },
           "border-width": {
             "$type": "borderWidth",
             "$value": "{voorbeeld.form-control.hover.border-width}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.form-control.hover.color}"
           }
-        },
-        "border-radius": {
-          "$type": "borderRadius",
-          "$value": "0px"
-        },
-        "border-bottom-width": {
-          "$type": "borderWidth",
-          "$value": "auto"
-        },
-        "border-width": {
-          "$type": "borderWidth",
-          "$value": "{utrecht.form-control.border-width}"
-        },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
-        },
-        "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
-        },
-        "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
         }
       }
     }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5204,12 +5204,6 @@
     },
     "todo": {
       "textarea": {
-        "focus": {
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
-          }
-        },
         "hover": {
           "background-color": {
             "$type": "color",
@@ -5218,10 +5212,6 @@
           "border-color": {
             "$type": "color",
             "$value": "{voorbeeld.form-control.hover.border-color}"
-          },
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.hover.border-width}"
           },
           "color": {
             "$type": "color",

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5075,8 +5075,8 @@
           "$value": "{utrecht.form-control.border-color}"
         },
         "border-radius": {
-          "$type": "utrecht.form-control.border-radius",
-          "$value": "0px"
+          "$type": "borderRadius",
+          "$value": "{utrecht.form-control.border-radius}"
         },
         "border-width": {
           "$type": "borderWidth",
@@ -5100,7 +5100,7 @@
         },
         "max-inline-size": {
           "$type": "sizing",
-          "$value": "utrecht.form-control.max-inline-size"
+          "$value": "{utrecht.form-control.max-inline-size}"
         },
         "min-block-size": {
           "$type": "sizing",


### PR DESCRIPTION
Aligned textarea tokens with code.

Renamed token:
- `textarea.border-bottom-width` to `textarea.border-block-end-width`

Removed tokens:
- `textarea.hover.border-width`
- `textarea.focus.border-width`

Added token:
- `textarea.min-block-size`
- `textarea.invalid.border-block-end-width`

Prefix from `.utrecht` to `.todo`
- `textarea.focs.border-width`
- `textarea.hover.*`

Referenced to common form-control tokens.