### PR TITLE
fix: align textbox tokens with code

### DIFF
--- a/.changeset/coin-ideal-coal.md
+++ b/.changeset/coin-ideal-coal.md
@@ -9,9 +9,6 @@ Added token:
 - `textbox.min-block-size`
 - `textbox.invalid.border-block-end-width`
 
-Removed token:
-- `textbox.font-weight`
-
 Prefix from `.utrecht` to `.todo`
 - `textbox.focus.border-width`
 - `textbox.hover.*`

--- a/.changeset/coin-ideal-coal.md
+++ b/.changeset/coin-ideal-coal.md
@@ -5,6 +5,10 @@
 Renamed
 - tokenset from `text input` to `textbox`.
 
+Removed tokens:
+- `textbox.hover.border-width`
+- `textbox.focus.border-width`
+
 Added token:
 - `textbox.min-block-size`
 - `textbox.invalid.border-block-end-width`
@@ -12,3 +16,5 @@ Added token:
 Prefix from `.utrecht` to `.todo`
 - `textbox.focus.border-width`
 - `textbox.hover.*`
+
+Referenced to common form-control tokens.

--- a/.changeset/coin-ideal-coal.md
+++ b/.changeset/coin-ideal-coal.md
@@ -1,0 +1,17 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+---
+
+Renamed
+- tokenset from `text input` to `textbox`.
+
+Added token:
+- `textbox.min-block-size`
+- `textbox.invalid.border-block-end-width`
+
+Removed token:
+- `textbox.font-weight`
+
+Prefix from `.utrecht` to `.todo`
+- `textbox.focus.border-width`
+- `textbox.hover.*`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5213,12 +5213,32 @@
       }
     }
   },
-  "components/text-input": {
+  "components/textbox": {
     "utrecht": {
       "textbox": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{utrecht.form-control.background-color}"
+        },
+        "border-block-end-width": {
+          "$type": "borderWidth",
+          "$value": "auto"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{utrecht.form-control.border-color}"
+        },
         "border-radius": {
           "$type": "borderRadius",
           "$value": "0px"
+        },
+        "border-width": {
+          "$type": "borderWidth",
+          "$value": "{utrecht.form-control.border-width}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.form-control.color}"
         },
         "font-family": {
           "$type": "fontFamilies",
@@ -5228,10 +5248,6 @@
           "$type": "fontSizes",
           "$value": "{utrecht.document.font-size}"
         },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
-        },
         "line-height": {
           "$type": "lineHeights",
           "$value": "{utrecht.document.line-height}"
@@ -5239,6 +5255,10 @@
         "max-inline-size": {
           "$type": "sizing",
           "$value": "400px"
+        },
+        "min-block-size": {
+          "$type": "sizing",
+          "$value": "{utrecht.pointer-target.min-size}"
         },
         "padding-block-end": {
           "$type": "spacing",
@@ -5256,66 +5276,10 @@
           "$type": "spacing",
           "$value": "{voorbeeld.space.inline.snail}"
         },
-        "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.background-color}"
-        },
-        "border-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.border-color}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.color}"
-        },
-        "invalid": {
-          "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.background-color}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.border-color}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.color}"
-          },
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.invalid.border-width}"
-          }
-        },
         "placeholder": {
           "color": {
             "$type": "color",
             "$value": "{utrecht.form-control.placeholder.color}"
-          }
-        },
-        "border-block-end-width": {
-          "$type": "borderWidth",
-          "$value": "auto"
-        },
-        "border-width": {
-          "$type": "borderWidth",
-          "$value": "{utrecht.form-control.border-width}"
-        },
-        "focus": {
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.background-color}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.border-color}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.color}"
           }
         },
         "disabled": {
@@ -5330,6 +5294,46 @@
           "color": {
             "$type": "color",
             "$value": "{utrecht.form-control.disabled.color}"
+          }
+        },
+        "focus": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.background-color}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.border-color}"
+          },
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.focus.border-width}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{utrecht.form-control.focus.color}"
+          }
+        },
+        "invalid": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.background-color}"
+          },
+          "border-block-end-width": {
+            "$type": "borderWidth",
+            "$value": "auto"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{utrecht.form-control.invalid.border-color}"
+          },
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{utrecht.form-control.invalid.border-width}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{utrecht.form-control.color}"
           }
         },
         "read-only": {
@@ -5347,10 +5351,6 @@
           }
         },
         "hover": {
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.hover.border-width}"
-          },
           "background-color": {
             "$type": "color",
             "$value": "{voorbeeld.form-control.hover.background-color}"
@@ -5358,6 +5358,10 @@
           "border-color": {
             "$type": "color",
             "$value": "{voorbeeld.form-control.hover.border-color}"
+          },
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.hover.border-width}"
           },
           "color": {
             "$type": "color",
@@ -5489,7 +5493,7 @@
       "components/table",
       "components/task-list",
       "components/textarea",
-      "components/text-input",
+      "components/textbox",
       "components/toolbar-button",
       "components/unordered-list"
     ]

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5222,7 +5222,7 @@
         },
         "border-block-end-width": {
           "$type": "borderWidth",
-          "$value": "auto"
+          "$value": "{utrecht.textbox.border-width}"
         },
         "border-color": {
           "$type": "color",
@@ -5321,7 +5321,7 @@
           },
           "border-block-end-width": {
             "$type": "borderWidth",
-            "$value": "auto"
+            "$value": "{utrecht.textbox.border-width}"
           },
           "border-color": {
             "$type": "color",

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5345,6 +5345,10 @@
             "$type": "color",
             "$value": "{utrecht.form-control.read-only.color}"
           }
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{utrecht.form-control.font-weight}"
         }
       }
     },

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5321,7 +5321,7 @@
           },
           "border-block-end-width": {
             "$type": "borderWidth",
-            "$value": "{utrecht.textbox.border-width}"
+            "$value": "{utrecht.textbox.invalid.border-width}"
           },
           "border-color": {
             "$type": "color",

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5230,7 +5230,7 @@
         },
         "border-radius": {
           "$type": "borderRadius",
-          "$value": "0px"
+          "$value": "utrecht.form-control.border-radius"
         },
         "border-width": {
           "$type": "borderWidth",
@@ -5242,19 +5242,19 @@
         },
         "font-family": {
           "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "$value": "{utrecht.form-control.font-family}"
         },
         "font-size": {
           "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "$value": "{utrecht.form-control.font-size}"
         },
         "line-height": {
           "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "$value": "{utrecht.form-control.line-height}"
         },
         "max-inline-size": {
           "$type": "sizing",
-          "$value": "400px"
+          "$value": "utrecht.form-control.max-inline-size"
         },
         "min-block-size": {
           "$type": "sizing",
@@ -5262,19 +5262,19 @@
         },
         "padding-block-end": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "$value": "{utrecht.form-control.padding-block-end}"
         },
         "padding-block-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "$value": "{utrecht.form-control.padding-block-start}"
         },
         "padding-inline-end": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "$value": "{utrecht.form-control.padding-inline-end}"
         },
         "padding-inline-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "$value": "{utrecht.form-control.padding-inline-start}"
         },
         "placeholder": {
           "color": {
@@ -5304,10 +5304,6 @@
           "border-color": {
             "$type": "color",
             "$value": "{utrecht.form-control.focus.border-color}"
-          },
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
           },
           "color": {
             "$type": "color",
@@ -5348,6 +5344,16 @@
           "color": {
             "$type": "color",
             "$value": "{utrecht.form-control.read-only.color}"
+          }
+        }
+      }
+    },
+    "todo": {
+      "textbox": {
+        "focus": {
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.form-control.focus.border-width}"
           }
         },
         "hover": {

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5230,7 +5230,7 @@
         },
         "border-radius": {
           "$type": "borderRadius",
-          "$value": "utrecht.form-control.border-radius"
+          "$value": "{utrecht.form-control.border-radius}"
         },
         "border-width": {
           "$type": "borderWidth",
@@ -5254,7 +5254,7 @@
         },
         "max-inline-size": {
           "$type": "sizing",
-          "$value": "utrecht.form-control.max-inline-size"
+          "$value": "{utrecht.form-control.max-inline-size}"
         },
         "min-block-size": {
           "$type": "sizing",

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5354,12 +5354,6 @@
     },
     "todo": {
       "textbox": {
-        "focus": {
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
-          }
-        },
         "hover": {
           "background-color": {
             "$type": "color",
@@ -5368,10 +5362,6 @@
           "border-color": {
             "$type": "color",
             "$value": "{voorbeeld.form-control.hover.border-color}"
-          },
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.hover.border-width}"
           },
           "color": {
             "$type": "color",


### PR DESCRIPTION
Renamed
- tokenset from `text input` to `textbox`.

Removed tokens:
- `textbox.hover.border-width`
- `textbox.focus.border-width`

Added token:
- `textbox.min-block-size`
- `textbox.invalid.border-block-end-width`

Prefix from `.utrecht` to `.todo`
- `textbox.focus.border-width`
- `textbox.hover.*`

Referenced to common form-control tokens.