### PR TITLE
fix: add missing form-control tokens to figma library

### DIFF
--- a/.changeset/fill-beach-hang.md
+++ b/.changeset/fill-beach-hang.md
@@ -1,0 +1,14 @@
+New added form-control-tokens:
+
+- `form-control.border-width`
+- `form-control.border-radius`
+- `form-control.font-family`
+- `form-control.font-size`
+- `form-control.line-height`
+- `form-control.max-inline-size`
+- `form-control.padding-block-end`
+- `form-control.padding-block-start`
+- `form-control.padding-inline-end`
+- `form-control.padding-inline-start`
+
+Referenced in Select component.

--- a/.changeset/fill-beach-hang.md
+++ b/.changeset/fill-beach-hang.md
@@ -1,3 +1,7 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+---
+
 New added form-control-tokens:
 
 - `form-control.border-width`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1065,6 +1065,42 @@
             "$type": "color",
             "$value": "{voorbeeld.color.gray.600}"
           }
+        },
+        "border-radius": {
+          "$type": "borderRadius",
+          "$value": "0px"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{voorbeeld.typography.font-family.secondary}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.md}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{voorbeeld.typography.line-height.md}"
+        },
+        "max-inline-size": {
+          "$type": "sizing",
+          "$value": "400px"
+        },
+        "padding-block-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
+        },
+        "padding-block-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.snail}"
+        },
+        "padding-inline-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
+        },
+        "padding-inline-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.snail}"
         }
       },
       "pointer-target": {
@@ -4070,7 +4106,7 @@
         },
         "border-radius": {
           "$type": "borderRadius",
-          "$value": "0px"
+          "$value": "{utrecht.form-control.border-radius}"
         },
         "border-width": {
           "$type": "borderWidth",
@@ -4082,11 +4118,11 @@
         },
         "font-family": {
           "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "$value": "{utrecht.form-control.font-family}"
         },
         "font-size": {
           "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "$value": "{utrecht.form-control.font-size}"
         },
         "font-weight": {
           "$type": "fontWeights",
@@ -4094,7 +4130,7 @@
         },
         "max-inline-size": {
           "$type": "sizing",
-          "$value": "400px"
+          "$value": "{utrecht.form-control.max-inline-size}"
         },
         "min-block-size": {
           "$type": "sizing",
@@ -4102,19 +4138,19 @@
         },
         "padding-block-end": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "$value": "{utrecht.form-control.padding-block-end}"
         },
         "padding-block-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "$value": "{utrecht.form-control.padding-block-start}"
         },
         "padding-inline-end": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "$value": "{utrecht.form-control.padding-inline-end}"
         },
         "padding-inline-start": {
           "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "$value": "{utrecht.form-control.padding-inline-start}"
         },
         "disabled": {
           "background-color": {
@@ -4164,7 +4200,7 @@
       "select": {
         "line-height": {
           "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "$value": "{utrecht.form-control.line-height}"
         },
         "icon": {
           "size": {


### PR DESCRIPTION
This PR will replace #649 and add missing form-control tokens that are available in the code of Utrecht. And will use these 'common' tokens as reference for some `component` tokens.

New added form-control-tokens:

- `form-control.border-width`
- `form-control.border-radius`
- `form-control.font-family`
- `form-control.font-size`
- `form-control.line-height`
- `form-control.max-inline-size`
- `form-control.padding-block-end`
- `form-control.padding-block-start`
- `form-control.padding-inline-end`
- `form-control.padding-inline-start`

Referenced in Select component.

References for [Textarea](https://github.com/nl-design-system/themes/pull/686) and [Textbox](https://github.com/nl-design-system/themes/pull/688) will be done after the linked PR's.