### PR TITLE
fix: rename prefix for form-control border-width

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -998,6 +998,10 @@
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.color.black}"
+          },
+          "border-width": {
+            "$type": "borderWidth",
+            "$value": "{voorbeeld.border-width.md}"
           }
         },
         "invalid": {
@@ -1178,12 +1182,6 @@
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.color.gray.950}"
-          }
-        },
-        "focus": {
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
           }
         },
         "hover": {
@@ -2477,7 +2475,7 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
+            "$value": "{utrecht.form-control.focus.border-width}"
           }
         },
         "invalid": {
@@ -2538,7 +2536,7 @@
           "focus": {
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.focus.border-width}"
+              "$value": "{utrecht.form-control.focus.border-width}"
             },
             "background-color": {
               "$type": "color",
@@ -2644,7 +2642,7 @@
           "focus": {
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.focus.border-width}"
+              "$value": "{utrecht.form-control.focus.border-width}"
             },
             "background-color": {
               "$type": "color",
@@ -3937,7 +3935,7 @@
           },
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
+            "$value": "{utrecht.form-control.focus.border-width}"
           }
         },
         "hover": {
@@ -4024,7 +4022,7 @@
             },
             "border-width": {
               "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.focus.border-width}"
+              "$value": "{utrecht.form-control.focus.border-width}"
             },
             "color": {
               "$type": "color",
@@ -4211,7 +4209,7 @@
         "focus": {
           "border-width": {
             "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.focus.border-width}"
+            "$value": "{utrecht.form-control.focus.border-width}"
           }
         },
         "hover": {


### PR DESCRIPTION
Renamed `voorbeeld.form-control.focus.border-width` to `utrecht.form-control.focus.border-width` as it was available in code