### PR TITLE
feat: add code, code block and code font tokens

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -71,7 +71,7 @@
           },
           "code": {
             "$type": "fontFamilies",
-            "$value": "Fira Code, Tahoma, Verdana, sans-serif"
+            "$value": "Fira Code, Monaco, monospace"
           }
         }
       },


### PR DESCRIPTION
Also added the brand and common font token:

- `voorbeeld.typography.font-family.code`
- `voorbeeld.code.font-family`

And didn't use the following tokens from the Code block component:

- `margin-block-start`
- `margin-block-end`
- `margin-inline-start`
- `margin-inline-end`

We didn't use these tokens because they are not supported in Figma.