### PR TITLE
feat: add badge data tokens

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1799,6 +1799,88 @@
       }
     }
   },
+  "components/badge-data": {
+    "utrecht": {
+      "badge-data": {
+        "text-transform": {
+          "$type": "textCase",
+          "$value": "None"
+        },
+        "letter-spacing": {
+          "$type": "letterSpacing",
+          "$value": "None"
+        }
+      }
+    },
+    "todo": {
+      "badge-data": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.violet.100}"
+        },
+        "border-radius": {
+          "$type": "borderRadius",
+          "$value": "{voorbeeld.border-radius.sm}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.document.strong.font-weight}"
+        },
+        "max-block-size": {
+          "$type": "sizing",
+          "$value": "None"
+        },
+        "max-inline-size": {
+          "$type": "sizing",
+          "$value": "None"
+        },
+        "min-inline-size": {
+          "$type": "sizing",
+          "$value": "{voorbeeld.size.3xs}"
+        },
+        "min-block-size": {
+          "$type": "sizing",
+          "$value": "{voorbeeld.size.2xs}"
+        },
+        "padding-block-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.flea}"
+        },
+        "padding-block-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.flea}"
+        },
+        "padding-inline-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.ant}"
+        },
+        "padding-inline-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.ant}"
+        },
+        "text-decoration": {
+          "$type": "textDecoration",
+          "$value": "None"
+        }
+      }
+    }
+  },
   "components/blockquote": {
     "utrecht": {
       "blockquote": {
@@ -5456,6 +5538,7 @@
       "components/alert",
       "components/avatar",
       "components/backdrop",
+      "components/badge-data",
       "components/blockquote",
       "components/breadcrumb-nav",
       "components/button",


### PR DESCRIPTION
Also added todo tokens:

- `todo.badge-data.background-color`
- `todo.badge-data.border-radius`
- `todo.badge-data.font-family`
- `todo.badge-data.line-height`
- `todo.badge-data.font-size`
- `todo.badge-data.font-weight`
- `todo.badge-data.max-block-size`
- `todo.badge-data.max-inline-size`
- `todo.badge-data.min-block-size`
- `todo.badge-data.min-inline-size`
- `todo.badge-data.padding-block-end`
- `todo.badge-data.padding-inline-start`
- `todo.badge-data.text-decoration`

We have added these tokens because the Data badge will eventually receive fully independent tokens.

Depends on ["Badge data" component vervangen door "Data badge"](https://github.com/nl-design-system/utrecht/issues/2479).