### PR TITLE
feat: add utrecht drawer tokens

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -2821,6 +2821,68 @@
           "$value": "{voorbeeld.box-shadow.lg}"
         }
       }
+    },
+    "utrecht": {
+      "drawer": {
+        "border-width": {
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
+        },
+        "padding-inline-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.mouse}"
+        },
+        "padding-inline-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.mouse}"
+        },
+        "background-color": {
+          "$type": "color",
+          "$value": "{utrecht.document.background-color}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.container.border-color}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        },
+        "border-radius": {
+          "$type": "borderRadius",
+          "$value": "0px"
+        },
+        "max-block-size": {
+          "$type": "sizing",
+          "$value": "800px"
+        },
+        "max-inline-size": {
+          "$type": "sizing",
+          "$value": "1440px"
+        },
+        "min-inline-size": {
+          "$type": "sizing",
+          "$value": "312px"
+        },
+        "min-block-size": {
+          "$type": "sizing",
+          "$value": "0px"
+        },
+        "padding-block-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.rabbit}"
+        },
+        "padding-block-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.rabbit}"
+        },
+        "backdrop": {
+          "min-size": {
+            "$type": "sizing",
+            "$value": "{utrecht.pointer-target.min-size}"
+          }
+        }
+      }
     }
   },
   "components/form-field": {


### PR DESCRIPTION
Didn't use the following token:

- `utrecht.drawer.z-index`

We didn't use this token because it is not supported in Figma.

