### PR TITLE
feat: add pre-heading tokens

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3885,6 +3885,32 @@
       }
     }
   },
+  "components/pre-heading": {
+    "utrecht": {
+      "pre-heading": {
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{voorbeeld.typography.font-size.sm}"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.document.strong.font-weight}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
+        }
+      }
+    }
+  },
   "components/radio-button": {
     "utrecht": {
       "radio-button": {
@@ -5479,6 +5505,7 @@
       "components/ordered-list",
       "components/pagination",
       "components/paragraph",
+      "components/pre-heading",
       "components/radio-button",
       "components/radio-group",
       "components/select",


### PR DESCRIPTION
Didn't use the following tokens:

- `margin-block-start`
- `margin-block-end`

We didn't use these tokens because they are not supported in Figma.