### PR TITLE
fix: align sidenav tokens with code

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4432,6 +4432,24 @@
           "$type": "spacing",
           "$value": "{voorbeeld.space.row.cat}"
         },
+        "item": {
+          "font-family": {
+            "$type": "fontFamilies",
+            "$value": "{utrecht.document.font-family}"
+          },
+          "font-size": {
+            "$type": "fontSizes",
+            "$value": "{utrecht.document.font-size}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
+          },
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
+          }
+        },
         "link": {
           "color": {
             "$type": "color",
@@ -4454,10 +4472,6 @@
             "$value": "None"
           },
           "current": {
-            "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
-            },
             "font-weight": {
               "$type": "fontWeights",
               "$value": "{voorbeeld.document.strong.font-weight}"
@@ -4468,24 +4482,12 @@
               "$type": "color",
               "$value": "{voorbeeld.interaction.hover.color}"
             }
-          }
-        },
-        "item": {
-          "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
           },
-          "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
-          },
-          "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+          "active": {
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.active.color}"
+            }
           }
         },
         "list": {
@@ -4507,11 +4509,13 @@
     "todo": {
       "sidenav": {
         "link": {
-          "active": {
+          "current": {
             "color": {
               "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
-            },
+              "$value": "{utrecht.document.color}"
+            }
+          },
+          "active": {
             "text-decoration": {
               "$type": "textDecoration",
               "$value": "underline"

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4424,47 +4424,89 @@
   "components/side-nav": {
     "denhaag": {
       "sidenav": {
+        "min-width": {
+          "$type": "sizing",
+          "$value": "240px"
+        },
+        "row-gap": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.row.cat}"
+        },
         "link": {
-          "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
           },
-          "icon": {
-            "size": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.icon.functional.size}"
+          "column-gap": {
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.text.mouse}"
+          },
+          "padding-block-end": {
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
+          },
+          "padding-block-start": {
+            "$type": "spacing",
+            "$value": "{voorbeeld.space.block.snail}"
+          },
+          "text-decoration": {
+            "$type": "textDecoration",
+            "$value": "None"
+          },
+          "current": {
+            "color": {
+              "$type": "color",
+              "$value": "{utrecht.document.color}"
             },
-            "margin-inline": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.text.mouse}"
+            "font-weight": {
+              "$type": "fontWeights",
+              "$value": "{voorbeeld.document.strong.font-weight}"
             }
+          },
+          "hover": {
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
+            }
+          }
+        },
+        "item": {
+          "font-family": {
+            "$type": "fontFamilies",
+            "$value": "{utrecht.document.font-family}"
           },
           "font-size": {
             "$type": "fontSizes",
             "$value": "{utrecht.document.font-size}"
           },
-          "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
-          },
           "font-weight": {
             "$type": "fontWeights",
             "$value": "{utrecht.document.font-weight}"
           },
-          "current": {
-            "font-weight": {
-              "$type": "fontWeights",
-              "$value": "{voorbeeld.document.strong.font-weight}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
-            }
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{utrecht.document.line-height}"
+          }
+        },
+        "list": {
+          "padding-block-end": {
+            "$type": "spacing",
+            "$value": "0px"
           },
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+          "padding-block-start": {
+            "$type": "spacing",
+            "$value": "0px"
           },
+          "padding-inline-start": {
+            "$type": "spacing",
+            "$value": "0px"
+          }
+        }
+      }
+    },
+    "todo": {
+      "sidenav": {
+        "link": {
           "active": {
             "color": {
               "$type": "color",
@@ -4490,26 +4532,16 @@
             }
           },
           "hover": {
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
-            },
             "text-decoration": {
               "$type": "textDecoration",
               "$value": "underline"
             }
           },
-          "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
-          },
-          "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
-          },
-          "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
+          "icon": {
+            "size": {
+              "$type": "sizing",
+              "$value": "{voorbeeld.icon.functional.size}"
+            }
           }
         }
       }


### PR DESCRIPTION
I alined sidenav tokens with code. But these still need to be added to the Den Haag component.

Renamed tokens
- `sidenav.link.icon.margin-inline` to `sidenav.link.column-gap`
- `sidenav.link.font-familiy` to `sidenav.item.font-familiy`
- `sidenav.link.font-weight` to `sidenav.item.font-weight`
- `sidenav.link.line-height` to `sidenav.item.line-height`
- `sidenav.link.font-size` to `sidenav.item.font-size`

Added tokens
- `sidenav.min-width`
- `sidenav.row-gap`
- `sidenav.list.padding-block-end`
- `sidenav.list.padding-block-start`
- `sidenav.list.padding-inline-start`

Prefix from `.denhaag` to `.todo`:
- `sidenav.link.icon.size`
- `sidenav.link.current.color`
- `sidenav.link.focus.color`
- `sidenav.link.focus.background-color`
- `sidenav.link.active.text-decoration`
- `sidenav.link.focus.text-decoration`
- `sidenav.link.hover.text-decoration`

I also reordered the tokens for better scanning.