### PR TITLE
fix: renamed toolbar button token

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5984,11 +5984,9 @@
   "components/toolbar-button": {
     "todo": {
       "toolbar-button": {
-        "icon": {
-          "margin-inline": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.text.beetle}"
-          }
+        "column-gap": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.text.beetle}"
         },
         "padding-block-end": {
           "$type": "spacing",


### PR DESCRIPTION
Renamed token: `toolbar-button.icon.margin-inline` to `toolbar-button.column-gap`.