### PR TITLE
fix: add missing line-height token for Form Field Error Message

### DIFF
--- a/.changeset/soul-tempt-tool.md
+++ b/.changeset/soul-tempt-tool.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/form-field-error-message-css": minor
+---
+
+Added missing line-height token for Form field Error Message.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3443,6 +3443,10 @@
         "padding-inline-start": {
           "$type": "spacing",
           "$value": "0px"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
         }
       }
     },


### PR DESCRIPTION
Add missing line-height token for Form Field Error Message