### PR TITLE
feat: changed tokens for separator

### DIFF
--- a/.changeset/patch-fur-pair.md
+++ b/.changeset/patch-fur-pair.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/separator-css": minor
+---
+
+- Removed margin tokens to align component with all other components within Figma.
+- Changed color of Separator because of WCAG non-text-contrast.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4806,19 +4806,11 @@
       "separator": {
         "color": {
           "$type": "color",
-          "$value": "{voorbeeld.line.border-color}"
+          "$value": "{utrecht.document.color}"
         },
         "block-size": {
           "$type": "sizing",
           "$value": "{voorbeeld.size.4xs}"
-        },
-        "margin-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
-        },
-        "margin-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
         }
       }
     }


### PR DESCRIPTION
- Removed margin tokens to align component with all other components within Figma.
- Changed color of Separator because of WCAG non-text-contrast.