### PR TITLE
Large VW tokens naar apart css bestand schrijven

### DIFF
--- a/.changeset/update-nora-design-tokens.md
+++ b/.changeset/update-nora-design-tokens.md
@@ -1,0 +1,8 @@
+---
+"@nl-design-system-community/nora-design-tokens": minor
+---
+
+set underline tokens to none
+change utrecht-heading tokens
+add nora-page-layout tokens
+add nora-page-section tokens

--- a/.changeset/update-nora-design-tokens.md
+++ b/.changeset/update-nora-design-tokens.md
@@ -2,7 +2,9 @@
 "@nl-design-system-community/nora-design-tokens": minor
 ---
 
-set underline tokens to none
-change utrecht-heading tokens
-add nora-page-layout tokens
-add nora-page-section tokens
+feat: set underline tokens to none
+feat: change utrecht-heading tokens
+feat: add nora-page-layout tokens
+feat: add nora-page-section tokens
+feat: add large-vw tokens to separate files
+fix: change link in index.scss

--- a/proprietary/nora-design-tokens/figma/figma.tokens.json
+++ b/proprietary/nora-design-tokens/figma/figma.tokens.json
@@ -539,6 +539,18 @@
             "$type": "fontFamilies",
             "$value": "\"Fira Code\", Tahoma, Verdana, sans-serif"
           }
+        },
+        "heading": {
+          "scale": {
+            "$type": "number",
+            "$value": "1.15"
+          },
+          "large-vw": {
+            "scale": {
+              "$type": "number",
+              "$value": "1.2"
+            }
+          }
         }
       },
       "border-radius": {
@@ -605,6 +617,14 @@
             "spread": "0",
             "color": "{nora.color.dark.alpha.100}",
             "type": "dropShadow"
+          }
+        }
+      },
+      "breakpoint": {
+        "large-vw": {
+          "min-width": {
+            "$type": "dimension",
+            "$value": "64rem"
           }
         }
       }
@@ -677,7 +697,7 @@
         },
         "color": {
           "$type": "color",
-          "$value": "{nora.color.black}"
+          "$value": "{nora.document.color}"
         }
       },
       "form-control": {
@@ -1069,6 +1089,10 @@
           "$type": "sizing",
           "$value": "45.25rem"
         }
+      },
+      "no-text-decoration": {
+        "$type": "textDecoration",
+        "$value": "none"
       }
     }
   },
@@ -1121,7 +1145,7 @@
             },
             "text-decoration": {
               "$type": "textDecoration",
-              "$value": "None"
+              "$value": "{nora.no-text-decoration}"
             }
           },
           "focus": {
@@ -1135,7 +1159,7 @@
             },
             "text-decoration": {
               "$type": "textDecoration",
-              "$value": "None"
+              "$value": "{nora.no-text-decoration}"
             }
           },
           "hover": {
@@ -1145,7 +1169,7 @@
             },
             "text-decoration": {
               "$type": "textDecoration",
-              "$value": "None"
+              "$value": "{nora.no-text-decoration}"
             }
           },
           "current": {
@@ -1156,7 +1180,7 @@
           },
           "text-decoration": {
             "$type": "textDecoration",
-            "$value": "none"
+            "$value": "{nora.no-text-decoration}"
           }
         },
         "separator": {
@@ -1441,12 +1465,12 @@
         },
         "font-size": {
           "$type": "fontSizes",
-          "$value": "{nora.typography.font-size.2xl}"
+          "$value": "{utrecht.heading-2.font-size} * {nora.typography.heading.scale}"
         },
         "large-vw": {
           "font-size": {
             "$type": "fontSizes",
-            "$value": "{nora.typography.font-size.3xl}"
+            "$value": "{utrecht.heading-2.large-vw.font-size} * {nora.typography.heading.large-vw.scale}"
           }
         }
       },
@@ -1469,12 +1493,12 @@
         },
         "font-size": {
           "$type": "fontSizes",
-          "$value": "{nora.typography.font-size.xl}"
+          "$value": "{utrecht.heading-3.font-size} * {nora.typography.heading.scale}"
         },
         "large-vw": {
           "font-size": {
             "$type": "fontSizes",
-            "$value": "{nora.typography.font-size.2xl}"
+            "$value": "{utrecht.heading-3.large-vw.font-size} * {nora.typography.heading.large-vw.scale}"
           }
         }
       },
@@ -1497,12 +1521,12 @@
         },
         "font-size": {
           "$type": "fontSizes",
-          "$value": "{nora.typography.font-size.lg}"
+          "$value": "{utrecht.heading-4.font-size} * {nora.typography.heading.scale}"
         },
         "large-vw": {
           "font-size": {
             "$type": "fontSizes",
-            "$value": "{nora.typography.font-size.xl}"
+            "$value": "{utrecht.heading-4.large-vw.font-size} * {nora.typography.heading.large-vw.scale}"
           }
         }
       },
@@ -1525,12 +1549,12 @@
         },
         "font-size": {
           "$type": "fontSizes",
-          "$value": "{nora.typography.font-size.md}"
+          "$value": "{utrecht.heading-5.font-size} * {nora.typography.heading.scale}"
         },
         "large-vw": {
           "font-size": {
             "$type": "fontSizes",
-            "$value": "{nora.typography.font-size.lg}"
+            "$value": "{utrecht.heading-5.large-vw.font-size} * {nora.typography.heading.large-vw.scale}"
           }
         }
       },
@@ -1553,12 +1577,12 @@
         },
         "font-size": {
           "$type": "fontSizes",
-          "$value": "{nora.typography.font-size.sm}"
+          "$value": "{nora.document.font-size}"
         },
         "large-vw": {
           "font-size": {
             "$type": "fontSizes",
-            "$value": "{nora.typography.font-size.md}"
+            "$value": "{nora.document.large-vw.font-size}"
           }
         }
       },
@@ -1581,12 +1605,12 @@
         },
         "font-size": {
           "$type": "fontSizes",
-          "$value": "{nora.typography.font-size.sm}"
+          "$value": "{nora.document.font-size}"
         },
         "large-vw": {
           "font-size": {
             "$type": "fontSizes",
-            "$value": "{nora.typography.font-size.md}"
+            "$value": "{nora.document.large-vw.font-size}"
           }
         }
       }
@@ -2166,6 +2190,105 @@
       }
     }
   },
+  "components/page-section": {
+    "nora": {
+      "page-section": {
+        "article": {
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{nora.space.300}"
+          },
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{nora.space.300}"
+          },
+          "padding-inline-start": {
+            "$type": "dimension",
+            "$value": "{nora.space.200}"
+          },
+          "padding-inline-end": {
+            "$type": "dimension",
+            "$value": "{nora.space.200}"
+          },
+          "container": {
+            "gap": {
+              "$type": "dimension",
+              "$value": "{nora.space.300}"
+            },
+            "large-vw": {
+              "gap": {
+                "$type": "dimension",
+                "$value": "4rem"
+              },
+              "min-width": {
+                "$type": "dimension",
+                "$value": "61.5rem"
+              },
+              "max-width": {
+                "$type": "dimension",
+                "$value": "72rem"
+              }
+            }
+          },
+          "large-vw": {
+            "padding-block-start": {
+              "$type": "dimension",
+              "$value": "{nora.space.600}"
+            },
+            "padding-block-end": {
+              "$type": "dimension",
+              "$value": "{nora.space.600}"
+            },
+            "padding-inline-start": {
+              "$type": "dimension",
+              "$value": "{nora.space.250}"
+            },
+            "padding-inline-end": {
+              "$type": "dimension",
+              "$value": "{nora.space.250}"
+            }
+          },
+          "content": {
+            "large-vw": {
+              "min-width": {
+                "$type": "dimension",
+                "$value": "40rem",
+                "$description": "640px"
+              },
+              "max-width": {
+                "$type": "dimension",
+                "$value": "46rem",
+                "$description": "736px"
+              }
+            }
+          },
+          "navigation": {
+            "large-vw": {
+              "max-width": {
+                "$type": "dimension",
+                "$value": "22rem",
+                "$description": "352px"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components/page-layout": {
+    "nora": {
+      "page-layout": {
+        "scrolled": {
+          "header-container": {
+            "box-shadow": {
+              "$type": "boxShadow",
+              "$value": "{nora.box-shadow.sm}"
+            }
+          }
+        }
+      }
+    }
+  },
   "components/unordered-list": {
     "utrecht": {
       "unordered-list": {
@@ -2403,6 +2526,8 @@
       "components/navigation-bar",
       "components/ordered-list",
       "components/paragraph",
+      "components/page-section",
+      "components/page-layout",
       "components/unordered-list",
       "drafts/breadcrumbs-tools-bar",
       "drafts/link-overview",

--- a/proprietary/nora-design-tokens/src/index.scss
+++ b/proprietary/nora-design-tokens/src/index.scss
@@ -4,4 +4,4 @@
  * All rights reserved
  */
 
-@import "./design-tokens.css";
+@import "./theme.css";

--- a/proprietary/nora-design-tokens/style-dictionary.config.mjs
+++ b/proprietary/nora-design-tokens/style-dictionary.config.mjs
@@ -4,6 +4,10 @@ import { typeDtcgDelegate } from 'style-dictionary/utils';
 import { readFile } from 'node:fs/promises';
 import { createConfig } from '../../style-dictionary-config.js';
 
+const isLargeVwToken = (token) => {
+  return token.path && token.path.includes('large-vw');
+};
+
 const build = async () => {
   const themeConfig = JSON.parse(await readFile('./src/config.json', 'utf-8'));
   StyleDictionary.registerPreprocessor({
@@ -15,13 +19,55 @@ const build = async () => {
     excludeParentKeys: true,
   });
 
+  const themeSelector = `.${themeConfig.prefix}-theme`;
+
   const sd = new StyleDictionary({
     ...createConfig({
-      selector: `.${themeConfig.prefix}-theme`,
+      selector: themeSelector,
     }),
     preprocessors: ['tokens-studio', 'dtcg-delegate'],
     source: ['figma/**/*.tokens.json'],
   });
+
+  sd.registerFilter({
+    name: 'filter-large-vw',
+    filter: isLargeVwToken,
+  });
+
+  sd.registerTransform({
+    name: 'name/remove-large-vw',
+    type: 'name',
+    filter: isLargeVwToken,
+    transform: (token) => {
+      return token.name.replace(/-large-vw/g, '');
+    },
+  });
+
+  sd.platforms.largeCss = {
+    transformGroup: 'tokens-studio',
+    transforms: ['name/kebab', 'name/remove-large-vw'],
+    buildPath: 'dist/',
+    files: [
+      {
+        destination: 'theme-large-vw.css',
+        format: 'css/variables',
+        filter: 'filter-large-vw',
+        options: {
+          selector: themeSelector,
+          outputReferences: true,
+        },
+      },
+      {
+        destination: 'variables-large-vw.css',
+        format: 'css/variables',
+        filter: 'filter-large-vw',
+        options: {
+          selector: `:root`,
+          outputReferences: true,
+        },
+      },
+    ],
+  };
 
   await sd.cleanAllPlatforms();
   await sd.buildAllPlatforms();


### PR DESCRIPTION
* Tokens die `large-vw` in hun path hebben worden nu als variabelen naar `theme-large-vw.css` en `variables-large-vw.css` geschreven. 
* De namen van deze tokens worden in deze bestanden herschreven zonder de `large-vw` aanduiding
* De tokens blijven ook nog als variabele bestaan met `large-vw` aanduiding in `theme.css` en `variables.css`

Dit maakt het mogelijk om tokens die specifiek bedoeld zijn voor een grotere viewport width te gebruiken in combinatie met een media-query, bijvoorbeeld als volgt:

`@import '@nl-design-system-community/nora-design-tokens/dist/theme-large-vw.css' (min-width: 992px);`


