### PR TITLE
style: add candidate tokens for code and code-block

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3141,6 +3141,46 @@
           "$value": "{voorbeeld.space.inline.mouse}"
         }
       }
+    },
+    "nl": {
+      "code-block": {
+        "padding-block-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.mouse}"
+        },
+        "padding-block-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.mouse}"
+        },
+        "padding-inline-end": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.mouse}"
+        },
+        "padding-inline-start": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.mouse}"
+        },
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.100}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{voorbeeld.code.font-family}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
+        }
+      }
     }
   },
   "components/color-sample": {

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3075,6 +3075,30 @@
           "$value": "{utrecht.document.line-height}"
         }
       }
+    },
+    "nl": {
+      "code": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.100}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{voorbeeld.code.font-family}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
+        }
+      }
     }
   },
   "components/code-block": {

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3098,12 +3098,6 @@
           "$type": "fontSizes",
           "$value": "{utrecht.document.font-size}"
         }
-      },
-      "code-block": {
-        "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{voorbeeld.border-radius.sm}"
-        }
       }
     }
   },
@@ -3150,19 +3144,11 @@
     },
     "nl": {
       "code-block": {
-        "padding-block-start": {
+        "padding-block": {
           "$type": "spacing",
           "$value": "{voorbeeld.space.block.mouse}"
         },
-        "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.mouse}"
-        },
-        "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
-        },
-        "padding-inline-start": {
+        "padding-inline": {
           "$type": "spacing",
           "$value": "{voorbeeld.space.inline.mouse}"
         },
@@ -3185,6 +3171,10 @@
         "font-size": {
           "$type": "fontSizes",
           "$value": "{utrecht.document.font-size}"
+        },
+        "border-radius": {
+          "$type": "borderRadius",
+          "$value": "{voorbeeld.border-radius.sm}"
         }
       }
     }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3098,6 +3098,12 @@
           "$type": "fontSizes",
           "$value": "{utrecht.document.font-size}"
         }
+      },
+      "code-block": {
+        "border-radius": {
+          "$type": "borderRadius",
+          "$value": "{voorbeeld.border-radius.sm}"
+        }
       }
     }
   },


### PR DESCRIPTION
Added candidate tokens for Code and Code Block.

Removed the following tokens:

- `nl.code-block.padding-block-start`
- `nl.code-block.padding-block-end`
- `nl.code-block.padding-inline-start`
- `nl.code-block.padding-inline-end`

Added the following tokens:

- `nl.code-block.padding-block`
- `nl.code-block.padding-inline`
- `nl.code-block.border-radius`