### PR TITLE
style: change todo badge-data tokens

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -1810,18 +1810,6 @@
     }
   },
   "components/badge-data": {
-    "utrecht": {
-      "badge-data": {
-        "text-transform": {
-          "$type": "textCase",
-          "$value": "None"
-        },
-        "letter-spacing": {
-          "$type": "letterSpacing",
-          "$value": "None"
-        }
-      }
-    },
     "todo": {
       "badge-data": {
         "background-color": {
@@ -1836,10 +1824,6 @@
           "$type": "color",
           "$value": "{utrecht.document.color}"
         },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
         "font-size": {
           "$type": "fontSizes",
           "$value": "{utrecht.document.font-size}"
@@ -1852,41 +1836,25 @@
           "$type": "fontWeights",
           "$value": "{voorbeeld.document.strong.font-weight}"
         },
-        "max-block-size": {
-          "$type": "sizing",
+        "padding-block": {
+          "$type": "spacing",
           "$value": "None"
         },
-        "max-inline-size": {
-          "$type": "sizing",
-          "$value": "None"
+        "padding-inline": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.ant}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "min-inline-size": {
           "$type": "sizing",
-          "$value": "{voorbeeld.size.3xs}"
+          "$value": "{voorbeeld.size.sm}"
         },
         "min-block-size": {
           "$type": "sizing",
-          "$value": "{voorbeeld.size.2xs}"
-        },
-        "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.flea}"
-        },
-        "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.flea}"
-        },
-        "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.ant}"
-        },
-        "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.ant}"
-        },
-        "text-decoration": {
-          "$type": "textDecoration",
-          "$value": "None"
+          "$value": "{voorbeeld.size.xs}"
         }
       }
     }


### PR DESCRIPTION
This component is entirely made up of todo tokens derived from the Badge component tokens of Utrecht

Removed the following tokens because they no longer exist in the Badge tokens.json file of Utrecht:

- `todo.badge-data.max-block-size`
- `todo.badge-data.max-inline-size`
- `todo.badge-data.padding-block-end`
- `todo.badge-data.padding-block-start`
- `todo.badge-data.padding-inline-end`
- `todo.badge-data.padding-inline-start`
- `todo.badge-data.text-decoration`

Also removed these tokens because they are discouraged from being used:
 
- `utrecht.badge-data.text-transform`
- `utrecht.badge-data.letter-spacing`


Added the following tokens: 

- `todo.badge-data.padding-block`
- `todo.badge-data.padding-inline`

Changed the value of the following tokens:

- `todo.badge-data.min-inline-size`
- `todo.badge-data.min-block-size`