### PR TITLE
style: add candidate tokens for code block

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3117,6 +3117,42 @@
           "$value": "{voorbeeld.space.inline.mouse}"
         }
       }
+    },
+    "nl": {
+      "code-block": {
+        "padding-block": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.block.mouse}"
+        },
+        "padding-inline": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.mouse}"
+        },
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.gray.100}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{voorbeeld.code.font-family}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
+        },
+        "border-radius": {
+          "$type": "borderRadius",
+          "$value": "{voorbeeld.border-radius.sm}"
+        }
+      }
     }
   },
   "components/color-sample": {


### PR DESCRIPTION
Added candidate tokens for Code Block.

Removed the following tokens:

- `nl.code-block.padding-block-start`
- `nl.code-block.padding-block-end`
- `nl.code-block.padding-inline-start`
- `nl.code-block.padding-inline-end`

Added the following tokens:

- `nl.code-block.padding-block`
- `nl.code-block.padding-inline`
- `nl.code-block.border-radius`