### PR TITLE
style: add candidate tokens for data badge

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3247,6 +3247,14 @@
         "font-family": {
           "$type": "fontFamilies",
           "$value": "{utrecht.document.font-family}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "transparent"
+        },
+        "border-width": {
+          "$type": "borderWidth",
+          "$value": "{voorbeeld.border-width.sm}"
         }
       }
     }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3201,6 +3201,56 @@
       }
     }
   },
+  "components/data-badge": {
+    "nl": {
+      "data-badge": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.violet.100}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        },
+        "border-radius": {
+          "$type": "borderRadius",
+          "$value": "{voorbeeld.border-radius.sm}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.document.strong.font-weight}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
+        },
+        "min-block-size": {
+          "$type": "sizing",
+          "$value": "{voorbeeld.size.xs}"
+        },
+        "min-inline-size": {
+          "$type": "sizing",
+          "$value": "{voorbeeld.size.sm}"
+        },
+        "padding-block": {
+          "$type": "spacing",
+          "$value": "None"
+        },
+        "padding-inline": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.inline.ant}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
+        }
+      }
+    }
+  },
   "components/drawer": {
     "todo": {
       "drawer": {
@@ -6817,6 +6867,7 @@
       "components/code",
       "components/code-block",
       "components/color-sample",
+      "components/data-badge",
       "components/drawer",
       "components/form-field",
       "components/form-field-checkbox-option",


### PR DESCRIPTION
Added candidate tokens for Data Badge. 

Didn't use the following tokens from the Badge component:

- `nl.data-badge.text-transform`
- `nl.data-badge.letter-spacing`

Added the following tokens:

- `nl.data-badge.min-block-size`
- `nl.data-badge.min-inline-size`
- `nl.data-badge.font-family` 
- `nl.data-badge.border-color`
- `nl.data-badge.border-width`