### PR TITLE
chore: rename spacing and sizing tokens to dimension in voorbeeld tokens

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -526,248 +526,248 @@
       "space": {
         "inline": {
           "flea": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "2px"
           },
           "ant": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "4px"
           },
           "beetle": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "8px"
           },
           "snail": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "12px"
           },
           "mouse": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "16px"
           },
           "rat": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "20px"
           },
           "rabbit": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "24px"
           },
           "cat": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "28px"
           },
           "dog": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "32px"
           },
           "pig": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "48px"
           }
         },
         "block": {
           "flea": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "2px"
           },
           "ant": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "4px"
           },
           "beetle": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "8px"
           },
           "snail": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "12px"
           },
           "mouse": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "16px"
           },
           "rat": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "20px"
           },
           "rabbit": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "24px"
           },
           "cat": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "32px"
           },
           "dog": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "48px"
           },
           "pig": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "64px"
           }
         },
         "text": {
           "flea": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "1px",
             "$description": "0.125ch"
           },
           "ant": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "2px",
             "$description": "0.25ch"
           },
           "beetle": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "4px",
             "$description": "0.5ch"
           },
           "snail": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "6px",
             "$description": "0.75ch"
           },
           "mouse": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "8px",
             "$description": "1ch"
           },
           "rat": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "12px",
             "$description": "1.5ch"
           },
           "rabbit": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "14px",
             "$description": "1.75ch"
           },
           "cat": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "16px",
             "$description": "2ch"
           },
           "dog": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "24px",
             "$description": "3ch"
           }
         },
         "column": {
           "flea": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "1px"
           },
           "ant": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "2px"
           },
           "beetle": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "4px"
           },
           "snail": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "8px"
           },
           "mouse": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "12px"
           },
           "rat": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "16px"
           },
           "rabbit": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "20px"
           },
           "cat": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "24px"
           },
           "dog": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "28px"
           },
           "pig": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "32px"
           },
           "tiger": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "48px"
           },
           "horse": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "64px"
           },
           "elephant": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "96px"
           },
           "giraffe": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "160px"
           }
         },
         "row": {
           "flea": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "1px"
           },
           "ant": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "2px"
           },
           "beetle": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "4px"
           },
           "snail": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "8px"
           },
           "mouse": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "12px"
           },
           "rat": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "16px"
           },
           "rabbit": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "20px"
           },
           "cat": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "24px"
           },
           "dog": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "28px"
           },
           "pig": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "32px"
           },
           "tiger": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "48px"
           },
           "horse": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "64px"
           },
           "elephant": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "96px"
           },
           "giraffe": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "160px"
           }
         }
@@ -806,72 +806,72 @@
       },
       "size": {
         "5xs": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "2px"
         },
         "4xs": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "4px"
         },
         "3xs": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "8px"
         },
         "2xs": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "16px"
         },
         "xs": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "24px"
         },
         "sm": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "32px"
         },
         "md": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "48px"
         },
         "lg": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "64px"
         },
         "xl": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "96px"
         },
         "2xl": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "160px"
         },
         "icon": {
           "sm": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "16px"
           },
           "md": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "24px"
           },
           "lg": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "24px"
           },
           "xl": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "24px"
           },
           "2xl": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "32px"
           },
           "3xl": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "40px"
           },
           "4xl": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "48px"
           }
         }
@@ -1063,23 +1063,23 @@
           "$value": "{voorbeeld.typography.line-height.md}"
         },
         "max-inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "400px"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.snail}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.snail}"
         }
       },
@@ -1117,7 +1117,7 @@
       },
       "pointer-target": {
         "min-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{voorbeeld.size.md}"
         }
       },
@@ -1266,13 +1266,13 @@
       "icon": {
         "functional": {
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.size.icon.md}"
           }
         },
         "toptask": {
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.size.icon.4xl}"
           }
         }
@@ -1370,47 +1370,47 @@
             "$value": "{voorbeeld.border-width.sm}"
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           }
         },
         "button": {
           "gap": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.text.mouse}"
           },
           "icon": {
             "size": {
-              "$type": "sizing",
+              "$type": "dimension",
               "$value": "{voorbeeld.icon.functional.size}"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
           "background-color": {
@@ -1553,34 +1553,34 @@
           "$value": "{utrecht.document.color}"
         },
         "column-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.column.snail}"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.rat}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.mouse}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.mouse}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.mouse}"
         },
         "content": {
           "row-gap": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.row.rat}"
           }
         },
         "message": {
           "row-gap": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.row.snail}"
           }
         },
@@ -1642,11 +1642,11 @@
         },
         "icon": {
           "inset-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.flea}"
           },
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.icon.functional.size}"
           },
           "color": {
@@ -1715,12 +1715,12 @@
           "$value": "{voorbeeld.border-radius.round}"
         },
         "size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.pointer-target.min-size}"
         },
         "icon": {
           "icon-size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.icon.functional.size}"
           }
         },
@@ -1816,8 +1816,8 @@
           "$type": "textCase",
           "$value": "None"
         },
-        "letter-spacing": {
-          "$type": "letterSpacing",
+        "letter-dimension": {
+          "$type": "letterdimension",
           "$value": "None"
         }
       }
@@ -1853,35 +1853,35 @@
           "$value": "{voorbeeld.document.strong.font-weight}"
         },
         "max-block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "None"
         },
         "max-inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "None"
         },
         "min-inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{voorbeeld.size.3xs}"
         },
         "min-block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{voorbeeld.size.2xs}"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.flea}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.flea}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.ant}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.ant}"
         },
         "text-decoration": {
@@ -1899,19 +1899,19 @@
           "$value": "transparent"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "0px"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "0px"
         },
         "attribution": {
@@ -1939,7 +1939,7 @@
     "todo": {
       "blockquote": {
         "row-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.row.snail}"
         },
         "attribution": {
@@ -1987,28 +1987,28 @@
         "link": {
           "icon": {
             "size": {
-              "$type": "sizing",
+              "$type": "dimension",
               "$value": "{voorbeeld.icon.functional.size}"
             },
             "column-gap": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "{voorbeeld.space.text.beetle}"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           },
           "color": {
@@ -2062,7 +2062,7 @@
         },
         "separator": {
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.size.2xs}"
           },
           "color": {
@@ -2071,7 +2071,7 @@
           }
         },
         "column-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.column.snail}"
         },
         "font-family": {
@@ -2091,7 +2091,7 @@
           "$value": "{utrecht.document.line-height}"
         },
         "min-block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.pointer-target.min-size}"
         },
         "font-family": {
@@ -2100,19 +2100,19 @@
         },
         "item": {
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.beetle}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.beetle}"
           }
         },
@@ -2179,7 +2179,7 @@
           },
           "icon": {
             "size": {
-              "$type": "sizing",
+              "$type": "dimension",
               "$value": "{voorbeeld.size.2xs}"
             }
           }
@@ -2216,7 +2216,7 @@
         },
         "icon": {
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.icon.functional.size}"
           }
         },
@@ -2237,19 +2237,19 @@
           "$value": "{utrecht.document.line-height}"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.mouse}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.mouse}"
         },
         "disabled": {
@@ -2309,15 +2309,15 @@
           }
         },
         "min-block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.pointer-target.min-size}"
         },
         "min-inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.pointer-target.min-size}"
         },
         "column-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.text.beetle}"
         },
         "primary-action": {
@@ -2577,19 +2577,19 @@
           "$value": "transparent"
         },
         "column-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.column.snail}"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "0px"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "0px"
         },
         "row-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.row.snail}"
         }
       }
@@ -2621,20 +2621,20 @@
           }
         },
         "row-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.row.mouse}"
         },
         "padding-block": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.rat}"
         },
         "padding-inline": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.rabbit}"
         },
         "icon": {
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.icon.functional.size}"
           },
           "color": {
@@ -2677,11 +2677,11 @@
           }
         },
         "min-block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "192px"
         },
         "min-inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "328px"
         },
         "decoration": {
@@ -2775,12 +2775,12 @@
           "$value": "{utrecht.form-control.border-width}"
         },
         "size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{voorbeeld.size.xs}"
         },
         "icon": {
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.icon.functional.size}"
           }
         },
@@ -3037,15 +3037,15 @@
     "todo": {
       "checkbox-group": {
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.beetle}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.beetle}"
         },
         "row-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.row.rat}"
         }
       }
@@ -3101,19 +3101,19 @@
           "$value": "{utrecht.document.line-height}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.mouse}"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.mouse}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.mouse}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.mouse}"
         }
       }
@@ -3151,11 +3151,11 @@
           }
         },
         "block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{voorbeeld.size.sm}"
         },
         "inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{voorbeeld.size.sm}"
         }
       }
@@ -3163,11 +3163,11 @@
     "nl": {
       "color-sample": {
         "block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{voorbeeld.size.sm}"
         },
         "inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{voorbeeld.size.sm}"
         },
         "border-radius": {
@@ -3232,23 +3232,23 @@
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.beetle}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.beetle}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.beetle}"
           },
           "column-gap": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.column.snail}"
           },
           "border-color": {
@@ -3270,19 +3270,19 @@
             "$value": "{voorbeeld.border-width.sm}"
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.mouse}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.mouse}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
           "border-color": {
@@ -3300,15 +3300,15 @@
         },
         "content": {
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-inline": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           }
         },
@@ -3337,11 +3337,11 @@
           "$value": "{voorbeeld.border-width.sm}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.mouse}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.mouse}"
         },
         "background-color": {
@@ -3361,32 +3361,32 @@
           "$value": "0px"
         },
         "max-block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "800px"
         },
         "max-inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "1440px"
         },
         "min-inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "312px"
         },
         "min-block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.pointer-target.min-size}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.rabbit}"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.rabbit}"
         },
         "backdrop": {
           "min-size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{utrecht.pointer-target.min-size}"
           }
         }
@@ -3406,7 +3406,7 @@
             "$value": "{voorbeeld.border-width.md}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           }
         }
@@ -3417,7 +3417,7 @@
     "todo": {
       "form-field-checkbox-option": {
         "column-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.column.snail}"
         }
       }
@@ -3469,19 +3469,19 @@
           "$value": "{utrecht.document.font-weight}"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "0px"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "0px"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "0px"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "0px"
         }
       }
@@ -3490,12 +3490,12 @@
       "form-field-error-message": {
         "icon": {
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.icon.functional.size}"
           }
         },
         "column-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.text.mouse}"
         }
       }
@@ -3563,7 +3563,7 @@
     "todo": {
       "form-field-radio-option": {
         "column-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.column.snail}"
         }
       }
@@ -3709,19 +3709,19 @@
     "todo": {
       "icon-only-button": {
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.snail}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.snail}"
         }
       }
@@ -3735,7 +3735,7 @@
           "$value": "{voorbeeld.interaction.color}"
         },
         "column-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.text.beetle}"
         },
         "text-decoration": {
@@ -3756,7 +3756,7 @@
         },
         "icon": {
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.icon.functional.size}"
           }
         },
@@ -3812,12 +3812,12 @@
       "link": {
         "icon": {
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.icon.functional.size}"
           }
         },
         "column-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.text.beetle}"
         },
         "color": {
@@ -3893,16 +3893,16 @@
     "utrecht": {
       "link-list": {
         "row-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.row.snail}"
         },
         "icon": {
           "inset-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           },
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.icon.functional.size}"
           }
         }
@@ -3912,7 +3912,7 @@
       "link-list": {
         "item": {
           "column-gap": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.beetle}"
           },
           "text-decoration": {
@@ -3980,19 +3980,19 @@
         },
         "header": {
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.beetle}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.beetle}"
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.beetle}"
           },
           "background-color": {
@@ -4026,7 +4026,7 @@
             "$value": "{voorbeeld.line.border-color}"
           },
           "column-gap": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.column.snail}"
           },
           "border-width": {
@@ -4048,19 +4048,19 @@
         },
         "footer": {
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.mouse}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.mouse}"
           },
           "background-color": {
@@ -4078,15 +4078,15 @@
         },
         "content": {
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.rabbit}"
           },
           "padding-inline": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           }
         },
@@ -4105,11 +4105,11 @@
           "$value": "{voorbeeld.typography.font-size.sm}"
         },
         "min-block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{voorbeeld.size.xs}"
         },
         "min-inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{voorbeeld.size.xs}"
         },
         "border-radius": {
@@ -4129,11 +4129,11 @@
           "$value": "{utrecht.document.color}"
         },
         "padding-inline": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.ant}"
         },
         "padding-block": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.ant}"
         },
         "font-weight": {
@@ -4163,20 +4163,20 @@
           "$value": "{utrecht.document.line-height}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.rabbit}"
         },
         "item": {
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.beetle}"
           },
           "margin-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.ant}"
           },
           "margin-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.ant}"
           }
         }
@@ -4193,28 +4193,28 @@
           },
           "icon": {
             "margin-inline": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "{voorbeeld.space.text.beetle}"
             },
             "size": {
-              "$type": "sizing",
+              "$type": "dimension",
               "$value": "{voorbeeld.icon.functional.size}"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           },
           "background-color": {
@@ -4292,11 +4292,11 @@
             "$value": "{utrecht.document.font-weight}"
           },
           "min-block-size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{utrecht.pointer-target.min-size}"
           },
           "min-inline-size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{utrecht.pointer-target.min-size}"
           },
           "disabled": {
@@ -4350,19 +4350,19 @@
             "$value": "0px"
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.snail}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.snail}"
           },
           "focus": {
@@ -4432,11 +4432,11 @@
             "$value": "{voorbeeld.interaction.color}"
           },
           "min-block-size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{utrecht.pointer-target.min-size}"
           },
           "min-inline-size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{utrecht.pointer-target.min-size}"
           }
         },
@@ -4454,19 +4454,19 @@
         },
         "ellipses": {
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.ant}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.ant}"
           },
           "color": {
@@ -4637,12 +4637,12 @@
           "$value": "{utrecht.form-control.border-width}"
         },
         "size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{voorbeeld.size.xs}"
         },
         "icon": {
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.size.3xs}"
           }
         },
@@ -4811,15 +4811,15 @@
     "todo": {
       "radio-group": {
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.beetle}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.beetle}"
         },
         "row-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.row.rat}"
         }
       }
@@ -4865,27 +4865,27 @@
           "$value": "{utrecht.document.font-weight}"
         },
         "max-inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.max-inline-size}"
         },
         "min-block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.pointer-target.min-size}"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.padding-block-end}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.padding-block-start}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.padding-inline-end}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.padding-inline-start}"
         },
         "disabled": {
@@ -4944,7 +4944,7 @@
         },
         "icon": {
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.icon.functional.size}"
           }
         },
@@ -4983,15 +4983,15 @@
           "$value": "{voorbeeld.line.border-color}"
         },
         "block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{voorbeeld.size.4xs}"
         },
         "margin-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "margin-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         }
       }
@@ -5001,11 +5001,11 @@
     "denhaag": {
       "sidenav": {
         "min-width": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "240px"
         },
         "row-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.row.cat}"
         },
         "item": {
@@ -5032,15 +5032,15 @@
             "$value": "{voorbeeld.interaction.color}"
           },
           "column-gap": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.text.mouse}"
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "text-decoration": {
@@ -5068,15 +5068,15 @@
         },
         "list": {
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           }
         }
@@ -5119,7 +5119,7 @@
           },
           "icon": {
             "size": {
-              "$type": "sizing",
+              "$type": "dimension",
               "$value": "{voorbeeld.icon.functional.size}"
             }
           }
@@ -5139,27 +5139,27 @@
           "$value": "{voorbeeld.document.inverse.color}"
         },
         "min-block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.pointer-target.min-size}"
         },
         "min-inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.pointer-target.min-size}"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.mouse}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.mouse}"
         },
         "text-decoration": {
@@ -5233,11 +5233,11 @@
           "$value": "{voorbeeld.border-radius.sm}"
         },
         "padding-inline": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.ant}"
         },
         "padding-block": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.flea}"
         },
         "informative": {
@@ -5325,36 +5325,36 @@
           },
           "row": {
             "padding-block-end": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "{voorbeeld.space.block.snail}"
             },
             "padding-block-start": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "{voorbeeld.space.block.snail}"
             },
             "padding-inline-end": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "0px"
             },
             "padding-inline-start": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "0px"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.ant}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           }
         },
@@ -5365,36 +5365,36 @@
           },
           "row": {
             "padding-block-end": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "{voorbeeld.space.block.snail}"
             },
             "padding-block-start": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "{voorbeeld.space.block.snail}"
             },
             "padding-inline-end": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "{voorbeeld.space.inline.mouse}"
             },
             "padding-inline-start": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "0px"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.ant}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           }
         },
@@ -5423,36 +5423,36 @@
         "item-action": {
           "row": {
             "padding-block-end": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "{voorbeeld.space.block.snail}"
             },
             "padding-block-start": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "{voorbeeld.space.block.snail}"
             },
             "padding-inline-end": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "0px"
             },
             "padding-inline-start": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "{voorbeeld.space.inline.mouse}"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "0px"
           }
         }
@@ -5526,15 +5526,15 @@
             "$value": "{voorbeeld.border-radius.round}"
           },
           "padding-block": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.ant}"
           },
           "padding-inline": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.ant}"
           },
           "inline-size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "5rem"
           },
           "border-width": {
@@ -5560,7 +5560,7 @@
             }
           },
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.icon.functional.size}"
           }
         },
@@ -5594,11 +5594,11 @@
             }
           },
           "min-inline-size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.size.sm}"
           },
           "min-block-size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.size.sm}"
           },
           "box-shadow": {
@@ -5654,25 +5654,25 @@
             "$value": "{utrecht.heading.font-weight}"
           },
           "margin-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.rabbit}"
           }
         },
         "cell": {
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
           "padding-inline-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           }
         },
@@ -5774,12 +5774,12 @@
             }
           },
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.size.xs}"
           },
           "icon": {
             "size": {
-              "$type": "sizing",
+              "$type": "dimension",
               "$value": "{voorbeeld.size.icon.sm}"
             }
           },
@@ -5820,20 +5820,20 @@
         },
         "item": {
           "column-gap": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.column.mouse}"
           },
           "margin-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.ant}"
           },
           "margin-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.ant}"
           }
         },
         "row-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.row.rat}"
         }
       }
@@ -5879,27 +5879,27 @@
           "$value": "{utrecht.document.line-height}"
         },
         "max-inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.max-inline-size}"
         },
         "min-block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.pointer-target.min-size}"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.padding-block-end}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.padding-block-start}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.padding-inline-end}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.padding-inline-start}"
         },
         "placeholder": {
@@ -6037,27 +6037,27 @@
           "$value": "{utrecht.form-control.line-height}"
         },
         "max-inline-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.max-inline-size}"
         },
         "min-block-size": {
-          "$type": "sizing",
+          "$type": "dimension",
           "$value": "{utrecht.pointer-target.min-size}"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.padding-block-end}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.padding-block-start}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.padding-inline-end}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{utrecht.form-control.padding-inline-start}"
         },
         "placeholder": {
@@ -6159,23 +6159,23 @@
     "todo": {
       "toolbar-button": {
         "column-gap": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.text.beetle}"
         },
         "padding-block-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-block-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.block.snail}"
         },
         "padding-inline-end": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.beetle}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.beetle}"
         }
       }
@@ -6186,22 +6186,22 @@
       "progress-list": {
         "step-marker": {
           "size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.size.sm}"
           },
           "nested": {
             "size": {
-              "$type": "sizing",
+              "$type": "dimension",
               "$value": "{voorbeeld.size.2xs}"
             },
             "figma": {
               "inset-block-start": {
-                "$type": "spacing",
+                "$type": "dimension",
                 "$value": "{voorbeeld.space.block.ant}"
               }
             },
             "padding-inline-start": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "{voorbeeld.space.inline.beetle}"
             }
           },
@@ -6300,13 +6300,13 @@
             "$value": "{voorbeeld.border-width.sm}"
           },
           "icon-size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{voorbeeld.icon.functional.size}"
           }
         },
         "connector": {
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.mouse}"
           },
           "checked": {
@@ -6340,11 +6340,11 @@
         },
         "step-heading": {
           "padding-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.ant}"
           },
           "padding-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.rat}"
           },
           "checked": {
@@ -6397,11 +6397,11 @@
         "button": {
           "icon": {
             "size": {
-              "$type": "sizing",
+              "$type": "dimension",
               "$value": "{voorbeeld.icon.functional.size}"
             },
             "margin-inline": {
-              "$type": "spacing",
+              "$type": "dimension",
               "$value": "{voorbeeld.space.text.beetle}"
             },
             "checked": {
@@ -6502,11 +6502,11 @@
             }
           },
           "min-inline-size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{utrecht.pointer-target.min-size}"
           },
           "min-block-size": {
-            "$type": "sizing",
+            "$type": "dimension",
             "$value": "{utrecht.pointer-target.min-size}"
           },
           "checked": {
@@ -6728,31 +6728,31 @@
         },
         "step-header": {
           "column-gap": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.column.rat}"
           }
         },
         "step-meta": {
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.pig}"
           }
         },
         "sub-step": {
           "margin-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.rabbit}"
           }
         },
         "step-body": {
           "row-gap": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.row.snail}"
           }
         },
         "sub-step-header": {
           "column-gap": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.column.cat}"
           }
         }
@@ -6771,20 +6771,20 @@
           "$value": "{utrecht.document.line-height}"
         },
         "padding-inline-start": {
-          "$type": "spacing",
+          "$type": "dimension",
           "$value": "{voorbeeld.space.inline.rabbit}"
         },
         "item": {
           "padding-inline-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.inline.beetle}"
           },
           "margin-block-end": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.ant}"
           },
           "margin-block-start": {
-            "$type": "spacing",
+            "$type": "dimension",
             "$value": "{voorbeeld.space.block.ant}"
           }
         },


### PR DESCRIPTION
Renamed all 'spacing' and 'sizing' tokens to 'dimension' in the example tokens to align with the W3C DTCG specification, which recommends dimension as the standard token type for size-related values.

This change ensures consistency with the specification and improves clarity in the design token definitions without altering functionality.