### PR TITLE
fix: correct 'transformGroups' to 'transformGroup' in SD config

### DIFF
--- a/.changeset/nora-use-tokens-studio-transforms.md
+++ b/.changeset/nora-use-tokens-studio-transforms.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-community/nora-design-tokens": minor
+---
+
+De `tokens-studio` transforms worden nu toegepast. Hiedoor worden composite tokens goed omgezet naar variabelen.

--- a/proprietary/nora-design-tokens/style-dictionary.config.mjs
+++ b/proprietary/nora-design-tokens/style-dictionary.config.mjs
@@ -24,6 +24,7 @@ const build = async () => {
   const sd = new StyleDictionary({
     ...createConfig({
       selector: themeSelector,
+      useTokensStudioTransformGroup: true,
     }),
     preprocessors: ['tokens-studio', 'dtcg-delegate'],
     source: ['figma/**/*.tokens.json'],

--- a/style-dictionary-config.js
+++ b/style-dictionary-config.js
@@ -12,7 +12,7 @@ const createConfig = ({
 
   const legacyPlatforms = {
     legacyJson: {
-      transformGroups: 'tokens-studio',
+      transformGroup: 'tokens-studio',
       transforms: ['name/camel', 'attribute/cti'],
       buildPath: 'dist/',
       files: [
@@ -23,7 +23,7 @@ const createConfig = ({
       ],
     },
     legacyCss: {
-      transformGroups: 'tokens-studio',
+      transformGroup: 'tokens-studio',
       transforms: ['name/kebab'],
       buildPath: 'dist/',
       files: [
@@ -38,7 +38,7 @@ const createConfig = ({
       ],
     },
     legacyLess: {
-      transformGroups: 'tokens-studio',
+      transformGroup: 'tokens-studio',
       transforms: ['name/kebab'],
       buildPath: 'dist/',
       files: [
@@ -52,7 +52,7 @@ const createConfig = ({
       ],
     },
     legacyScss: {
-      transformGroups: 'tokens-studio',
+      transformGroup: 'tokens-studio',
       transforms: ['name/kebab'],
       buildPath: 'dist/',
       files: [
@@ -66,7 +66,7 @@ const createConfig = ({
       ],
     },
     legacyJs: {
-      transformGroups: 'tokens-studio',
+      transformGroup: 'tokens-studio',
       transforms: ['name/camel'],
       buildPath: 'dist/',
       files: [
@@ -90,7 +90,7 @@ const createConfig = ({
     platforms: {
       ...(backwardsCompatible ? legacyPlatforms : {}),
       js: {
-        transformGroups: 'tokens-studio',
+        transformGroup: 'tokens-studio',
         transforms: ['name/camel'],
         buildPath: 'dist/',
         files: [
@@ -105,7 +105,7 @@ const createConfig = ({
         ],
       },
       tokenTree: {
-        transformGroups: 'tokens-studio',
+        transformGroup: 'tokens-studio',
         transforms: ['name/camel'],
         buildPath: 'dist/',
         files: [
@@ -116,7 +116,7 @@ const createConfig = ({
         ],
       },
       json: {
-        transformGroups: 'tokens-studio',
+        transformGroup: 'tokens-studio',
         transforms: ['name/camel'],
         buildPath: 'dist/',
         files: [
@@ -135,7 +135,7 @@ const createConfig = ({
         ],
       },
       css: {
-        transformGroups: 'tokens-studio',
+        transformGroup: 'tokens-studio',
         transforms: ['name/kebab'],
         buildPath: 'dist/',
         files: [
@@ -158,7 +158,7 @@ const createConfig = ({
         ],
       },
       scss: {
-        transformGroups: 'tokens-studio',
+        transformGroup: 'tokens-studio',
         transforms: ['name/kebab'],
         buildPath: 'dist/',
         files: [
@@ -187,7 +187,7 @@ const createConfig = ({
         ],
       },
       less: {
-        transformGroups: 'tokens-studio',
+        transformGroup: 'tokens-studio',
         transforms: ['name/kebab'],
         buildPath: 'dist/',
         files: [

--- a/style-dictionary-config.js
+++ b/style-dictionary-config.js
@@ -6,10 +6,11 @@ const createConfig = ({
   backwardsCompatible = false,
   selector,
   source = ['src/**/tokens.json', 'src/**/*.tokens.json'],
+  useTokensStudioTransformGroup = false,
 }) => {
   const prefix = selector.replace(/^\.(.+)-theme/, '$1');
   const themeName = `${prefix}-theme`;
-  const transformGroup = backwardsCompatible ? '' : 'tokens-studio';
+  const transformGroup = useTokensStudioTransformGroup ? 'tokens-studio' : '';
 
   const legacyPlatforms = {
     legacyJson: {

--- a/style-dictionary-config.js
+++ b/style-dictionary-config.js
@@ -9,10 +9,11 @@ const createConfig = ({
 }) => {
   const prefix = selector.replace(/^\.(.+)-theme/, '$1');
   const themeName = `${prefix}-theme`;
+  const transformGroup = backwardsCompatible ? '' : 'tokens-studio';
 
   const legacyPlatforms = {
     legacyJson: {
-      transformGroup: 'tokens-studio',
+      transformGroup: transformGroup,
       transforms: ['name/camel', 'attribute/cti'],
       buildPath: 'dist/',
       files: [
@@ -23,7 +24,7 @@ const createConfig = ({
       ],
     },
     legacyCss: {
-      transformGroup: 'tokens-studio',
+      transformGroup: transformGroup,
       transforms: ['name/kebab'],
       buildPath: 'dist/',
       files: [
@@ -38,7 +39,7 @@ const createConfig = ({
       ],
     },
     legacyLess: {
-      transformGroup: 'tokens-studio',
+      transformGroup: transformGroup,
       transforms: ['name/kebab'],
       buildPath: 'dist/',
       files: [
@@ -52,7 +53,7 @@ const createConfig = ({
       ],
     },
     legacyScss: {
-      transformGroup: 'tokens-studio',
+      transformGroup: transformGroup,
       transforms: ['name/kebab'],
       buildPath: 'dist/',
       files: [
@@ -66,7 +67,7 @@ const createConfig = ({
       ],
     },
     legacyJs: {
-      transformGroup: 'tokens-studio',
+      transformGroup: transformGroup,
       transforms: ['name/camel'],
       buildPath: 'dist/',
       files: [
@@ -90,7 +91,7 @@ const createConfig = ({
     platforms: {
       ...(backwardsCompatible ? legacyPlatforms : {}),
       js: {
-        transformGroup: 'tokens-studio',
+        transformGroup: transformGroup,
         transforms: ['name/camel'],
         buildPath: 'dist/',
         files: [
@@ -105,7 +106,7 @@ const createConfig = ({
         ],
       },
       tokenTree: {
-        transformGroup: 'tokens-studio',
+        transformGroup: transformGroup,
         transforms: ['name/camel'],
         buildPath: 'dist/',
         files: [
@@ -116,7 +117,7 @@ const createConfig = ({
         ],
       },
       json: {
-        transformGroup: 'tokens-studio',
+        transformGroup: transformGroup,
         transforms: ['name/camel'],
         buildPath: 'dist/',
         files: [
@@ -135,7 +136,7 @@ const createConfig = ({
         ],
       },
       css: {
-        transformGroup: 'tokens-studio',
+        transformGroup: transformGroup,
         transforms: ['name/kebab'],
         buildPath: 'dist/',
         files: [
@@ -158,7 +159,7 @@ const createConfig = ({
         ],
       },
       scss: {
-        transformGroup: 'tokens-studio',
+        transformGroup: transformGroup,
         transforms: ['name/kebab'],
         buildPath: 'dist/',
         files: [
@@ -187,7 +188,7 @@ const createConfig = ({
         ],
       },
       less: {
-        transformGroup: 'tokens-studio',
+        transformGroup: transformGroup,
         transforms: ['name/kebab'],
         buildPath: 'dist/',
         files: [


### PR DESCRIPTION
Je kunt nu met de flag `useTokensStudioTransformGroup` aangeven of de tokens-studio transforms toegepast moeten worden op de verschillende platforms. Hiermee gaan de tokens-studio transforms werken, zoals:

* Transform colors to rgba() format
* Transform shadow "type" property "innerShadow" to "inset"
* Zie voor meer info: https://github.com/Tokens-studio/sd-transforms?tab=readme-ov-file#style-dictionary-transforms-for-tokens-studio

Daarnaast worden composite tokens automatisch naar de juiste shorthand value omgeschreven.