### PR TITLE
style: add candidate tokens for icon

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3841,6 +3841,20 @@
       }
     }
   },
+  "components/icon": {
+    "nl": {
+      "icon": {
+        "size": {
+          "$type": "sizing",
+          "$value": "{voorbeeld.size.xs}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        }
+      }
+    }
+  },
   "components/icon-only-button": {
     "todo": {
       "icon-only-button": {
@@ -6962,6 +6976,7 @@
       "components/form-field-radio-option",
       "components/heading",
       "components/heading-group",
+      "components/icon",
       "components/icon-only-button",
       "components/link",
       "components/link-list",


### PR DESCRIPTION
Didn't use the following tokens:

- `nl.icon.inset-block-start`
- `nl.icon.baseline.inset-block-start`