### PR TITLE
chore: add new known extensions

### DIFF
--- a/.changeset/eleven-suits-nail.md
+++ b/.changeset/eleven-suits-nail.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/tokens-lib": minor
+---
+
+Add new known extensions

--- a/packages/tokens-lib/src/design-tokens.ts
+++ b/packages/tokens-lib/src/design-tokens.ts
@@ -13,6 +13,8 @@ export interface BoxShadowValue {
 }
 
 export interface KnownExtensions {
+  'nl.nldesignsystem.css-property-syntax'?: string | string[];
+  'nl.nldesignsystem.figma-implementation'?: boolean;
   'nl.nldesignsystem.css.property'?: {
     syntax: string;
     inherits: boolean;


### PR DESCRIPTION
`nl.nldesignsystem.css-property-syntax` and
`nl.nldesignsystem.figma-implementation` are two new known extensions