### PR TITLE
docs: release Groningen changes

### DIFF
--- a/.changeset/mighty-beds-carry.md
+++ b/.changeset/mighty-beds-carry.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/groningen-design-tokens": patch
+---
+
+Aanpassingen aan de `color`, `font-size` en `font-weight` van Heading componenten.

--- a/packages/storybook/config/main.ts
+++ b/packages/storybook/config/main.ts
@@ -2,9 +2,9 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: [
-    '../../voorbeeld-design-tokens/documentation/{readme,dashboard,color,design-tokens,typography}.mdx',
+    '../../voorbeeld-design-tokens/documentation/*.mdx',
     '../../voorbeeld-design-tokens/documentation/**/*.stories.{ts,tsx}',
-    '../../../proprietary/*/documentation/{readme,color,dashboard,design-tokens,typography}.mdx',
+    '../../../proprietary/*/documentation/*.mdx',
     '../../../proprietary/*/documentation/*.stories.ts',
     '../src/**/*.stories.{ts,tsx}',
   ],

--- a/proprietary/groningen-design-tokens/documentation/changelog.mdx
+++ b/proprietary/groningen-design-tokens/documentation/changelog.mdx
@@ -1,0 +1,7 @@
+import { Meta, Markdown } from "@storybook/blocks";
+import markdown from "../CHANGELOG.md?raw";
+import config from "../src/config.json";
+
+<Meta title="Groningen/CHANGELOG" />
+
+<Markdown>{markdown}</Markdown>


### PR DESCRIPTION
2 dingen:

- de package voor Groningen was niet gepubliceerd, ook al waren er tokens gewijzigd. Hierbij alsnog een changeset
- om het makkelijk te maken voor leveranciers van Groningen om te weten wat er is gewijzigd, heb ik [de changelog nu in Storybook gepubliceerd](https://themes-git-docs-groningen-changelog-nl-design-system.vercel.app/?path=/docs/groningen-changelog--docs)