### PR TITLE
style: use `rem` for typography tokens in voorbeeld theme

### DIFF
--- a/.changeset/beige-camels-think.md
+++ b/.changeset/beige-camels-think.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": patch
+---
+
+Use `rem` font sizes in typography tokens for line-height and font-size, to support user preferences for increased line-heights and font-sizes.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -5,31 +5,31 @@
         "font-size": {
           "sm": {
             "$type": "fontSizes",
-            "$value": "14px"
+            "$value": "0.875rem"
           },
           "md": {
             "$type": "fontSizes",
-            "$value": "16px"
+            "$value": "1rem"
           },
           "lg": {
             "$type": "fontSizes",
-            "$value": "20px"
+            "$value": "1.25rem"
           },
           "xl": {
             "$type": "fontSizes",
-            "$value": "24px"
+            "$value": "1.5rem"
           },
           "2xl": {
             "$type": "fontSizes",
-            "$value": "32px"
+            "$value": "2rem"
           },
           "3xl": {
             "$type": "fontSizes",
-            "$value": "40px"
+            "$value": "2.5rem"
           },
           "4xl": {
             "$type": "fontSizes",
-            "$value": "48px"
+            "$value": "3rem"
           }
         },
         "line-height": {


### PR DESCRIPTION
This is supposed to be temporary. When we have implemented the `px` to `rem` converter we can use px in design tokens JSON and ship `rem` to CSS files in `dist/`.

This makes sure we support WCAG for:
- https://nldesignsystem.nl/wcag/1.4.4
- https://nldesignsystem.nl/wcag/1.4.12