### PR TITLE
Link fix open stad/ groningen

### DIFF
--- a/.changeset/home-dip-sit.md
+++ b/.changeset/home-dip-sit.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/groningen-design-tokens": patch
+---
+
+Waardes van focus tokens aangepast.

--- a/proprietary/groningen-design-tokens/figma/figma.tokens.json
+++ b/proprietary/groningen-design-tokens/figma/figma.tokens.json
@@ -2943,11 +2943,11 @@
         "focus": {
           "background-color": {
             "type": "color",
-            "value": "{groningen.focus.background-color}"
+            "value": "{groningen.color.white}"
           },
           "color": {
             "type": "color",
-            "value": "{groningen.focus.color}"
+            "value": "{groningen.interaction.color}"
           },
           "text-decoration": {
             "value": "none",


### PR DESCRIPTION
open stad maakt geen gebruik van visited, wel van focus - zorgt nu voor een error wanneer iemand terug gaat naar pagina. Witte voorgrond tekst wordt dan overgenomen. Waarbij dan er een wit 'gat' valt in de pagina. Want we hanteren een witte achtergrond. 