### PR TITLE
feat: enable tokens studio transform group for voorbeeld thema

### DIFF
--- a/.changeset/hungry-pandas-refuse.md
+++ b/.changeset/hungry-pandas-refuse.md
@@ -1,0 +1,7 @@
+---
+"@nl-design-system-community/purmerend-design-tokens": patch
+"@nl-design-system-unstable/voorbeeld-design-tokens": patch
+"@nl-design-system-unstable/basis-design-tokens": patch
+---
+
+Convert percentages to unitless line-height values in the theme output.

--- a/packages/theme-toolkit/src/style-dictionary.test.ts
+++ b/packages/theme-toolkit/src/style-dictionary.test.ts
@@ -196,7 +196,7 @@ const testDirectory = (distPath: string) => {
           });
 
           it('contains a variable assignment', () => {
-            expect(content).toContain('"utrechtButtonColor": "#0A2750"');
+            expect(content).toContain('"utrechtButtonColor": "#0a2750"');
           });
         });
       });
@@ -264,7 +264,7 @@ const testDirectory = (distPath: string) => {
           });
 
           it('contains a property assignment', () => {
-            expect(content).toContain('"utrechtButtonColor": "#0A2750"');
+            expect(content).toContain('"utrechtButtonColor": "#0a2750"');
           });
         });
       });
@@ -296,7 +296,7 @@ const testDirectory = (distPath: string) => {
           });
 
           it.skip('contains a property assignment', () => {
-            expect(content).toContain('"value": "#0A2750"');
+            expect(content).toContain('"value": "#0a2750"');
           });
         });
       });

--- a/packages/tokens-lib/src/style-dictionary.test.ts
+++ b/packages/tokens-lib/src/style-dictionary.test.ts
@@ -196,7 +196,7 @@ const testDirectory = (distPath: string) => {
           });
 
           it('contains a variable assignment', () => {
-            expect(content).toContain('"utrechtButtonColor": "#0A2750"');
+            expect(content).toContain('"utrechtButtonColor": "#0a2750"');
           });
         });
       });
@@ -264,7 +264,7 @@ const testDirectory = (distPath: string) => {
           });
 
           it('contains a property assignment', () => {
-            expect(content).toContain('"utrechtButtonColor": "#0A2750"');
+            expect(content).toContain('"utrechtButtonColor": "#0a2750"');
           });
         });
       });
@@ -296,7 +296,7 @@ const testDirectory = (distPath: string) => {
           });
 
           it.skip('contains a property assignment', () => {
-            expect(content).toContain('"value": "#0A2750"');
+            expect(content).toContain('"value": "#0a2750"');
           });
         });
       });

--- a/style-dictionary-config.js
+++ b/style-dictionary-config.js
@@ -8,11 +8,11 @@ const createConfig = ({
   source = ['src/**/tokens.json', 'src/**/*.tokens.json'],
   buildPath = 'dist/',
   className = '',
-  useTokensStudioTransformGroup = false,
+  useTokensStudioTransformGroup = true,
 }) => {
   const prefix = selector ? selector.replace(/^\.(.+)-theme/, '$1') : '';
   let themeName = className || (prefix ? `${prefix}-theme` : 'theme');
-  const transformGroup = useTokensStudioTransformGroup ? 'tokens-studio' : '';
+  const transformGroup = useTokensStudioTransformGroup && !backwardsCompatible ? 'tokens-studio' : '';
 
   const legacyPlatforms = {
     legacyJson: {


### PR DESCRIPTION
# Result 
This fixes the units but note that it does also transform the format of a few other tokens. Scroll down for more. Three test results had to have their expected output (a color hex) changed to lower case instead of upper case due to this. See the last commit.

## Line heights
### Diff
```diff
-  --voorbeeld-typography-line-height-lg: 200%;
+  --voorbeeld-typography-line-height-lg: 2;
```

## Colors with transparent or alpha
### Diff
```diff
-  --utrecht-accordion-button-active-border-color: transparent;
-  --voorbeeld-color-dark-alpha-100: #0000001a;
+  --utrecht-accordion-button-active-border-color: rgba(0, 0, 0, 0);
+  --voorbeeld-color-dark-alpha-100: rgba(0, 0, 0, 0.1);
```

## Font family notation
### Diff
```diff
-  --voorbeeld-typography-font-family-code: Fira Code, Tahoma, Verdana, sans-serif;
+  --voorbeeld-typography-font-family-code: 'Fira Code', Tahoma, Verdana, sans-serif;
```

