### PR TITLE
feat: add button tokens theme builder

### DIFF
--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -71,7 +71,38 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     name: 'Utrecht Default Button',
     render: () => <Button>Default</Button>,
     detectTokens: {
-      allOf: ['utrecht.button.color', 'utrecht.button.background-color'],
+      anyOf: [
+        'utrecht.button.color',
+        'utrecht.button.background-color',
+        'utrecht.button.border-color',
+        'utrecht.button.border-radius',
+        'utrecht.button.border-width',
+        'utrecht.button.column-gap',
+        'utrecht.button.font-family',
+        'utrecht.button.font-size',
+        'utrecht.button.font-weight',
+        'utrecht.button.inline-size',
+        'utrecht.button.line-height',
+        'utrecht.button.min-block-size',
+        'utrecht.button.min-inline-size',
+        'utrecht.button.padding-block-start',
+        'utrecht.button.padding-block-end',
+        'utrecht.button.padding-inline-start',
+        'utrecht.button.padding-inline-end',
+        'utrecht.button.text-transform',
+        'utrecht.button.text-transform',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--icon',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Default Button: Icon',
+    state: true,
+    render: () => <Button className="utrecht-button--icon">Default</Button>,
+    detectTokens: {
+      anyOf: ['utrecht.button.icon.size'],
     },
   },
   {
@@ -82,7 +113,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     state: true,
     render: () => <Button className="utrecht-button--active">Default</Button>,
     detectTokens: {
-      allOf: ['utrecht.button.active.color', 'utrecht.button.active.background-color'],
+      anyOf: [
+        'utrecht.button.active.color',
+        'utrecht.button.active.background-color',
+        'utrecht.button.active.border-color',
+      ],
     },
   },
   {
@@ -93,7 +128,12 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     state: true,
     render: () => <Button className="utrecht-button--hover">Default</Button>,
     detectTokens: {
-      allOf: ['utrecht.button.hover.background-color', 'utrecht.button.hover.color'],
+      anyOf: [
+        'utrecht.button.hover.background-color',
+        'utrecht.button.hover.color',
+        'utrecht.button.hover.border-color',
+        'utrecht.button.hover.scale',
+      ],
     },
   },
   {
@@ -104,7 +144,42 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     state: true,
     render: () => <Button className="utrecht-button--focus">Default</Button>,
     detectTokens: {
-      allOf: ['utrecht.button.focus.background-color', 'utrecht.button.focus.color'],
+      anyOf: [
+        'utrecht.button.focus.color',
+        'utrecht.button.focus.background-color',
+        'utrecht.button.focus.border-color',
+        'utrecht.button.focus.scale',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--disabled',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Default Button: Disabled',
+    state: true,
+    render: () => <Button className="utrecht-button--disabled">Default</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.disabled.color',
+        'utrecht.button.disabled.background-color',
+        'utrecht.button.disabled.border-color',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--pressed',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Default Button: Pressed',
+    state: true,
+    render: () => <Button className="utrecht-button--pressed">Default</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.pressed.color',
+        'utrecht.button.pressed.background-color',
+        'utrecht.button.pressed.border-color',
+      ],
     },
   },
   {
@@ -139,7 +214,15 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     state: true,
     render: () => <Button appearance="primary-action-button">Primary action</Button>,
     detectTokens: {
-      allOf: ['utrecht.button.primary-action.color', 'utrecht.button.primary-action.background-color'],
+      anyOf: [
+        'utrecht.button.primary-action.color',
+        'utrecht.button.primary-action.background-color',
+        'utrecht.button.primary-action.border-color',
+        'utrecht.button.primary-action.border-width',
+        'utrecht.button.primary-action.font-size',
+        'utrecht.button.primary-action.font-weight',
+        'utrecht.button.primary-action.line-height',
+      ],
     },
   },
   {
@@ -167,6 +250,82 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     ),
   },
   {
+    storyId: 'react-utrecht-button--primary-action-active',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Primary Action Button: Active',
+    state: true,
+    render: () => <Button appearance="primary-action-button-active">Primary action</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.primary-action.active.color',
+        'utrecht.button.primary-action.active.background-color',
+        'utrecht.button.primary-action.active.border-color',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--primary-action-disabled',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Primary Action Button: Disabled',
+    state: true,
+    render: () => <Button appearance="primary-action-button-disabled">Primary action</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.primary-action.disabled.color',
+        'utrecht.button.primary-action.disabled.background-color',
+        'utrecht.button.primary-action.disabled.border-color',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--primary-action-hover',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Primary Action Button: Hover',
+    state: true,
+    render: () => <Button appearance="primary-action-button-hover">Primary action</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.primary-action.hover.color',
+        'utrecht.button.primary-action.hover.background-color',
+        'utrecht.button.primary-action.hover.border-color',
+        'utrecht.button.primary-action.hover.scale',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--primary-action-focus',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Primary Action Button: Focus',
+    state: true,
+    render: () => <Button appearance="primary-action-button-focus">Primary action</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.primary-action.focus.color',
+        'utrecht.button.primary-action.focus.background-color',
+        'utrecht.button.primary-action.focus.border-color',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--primary-action-pressed',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Primary Action Button: Pressed',
+    state: true,
+    render: () => <Button appearance="primary-action-button-pressed">Primary action</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.primary-action.pressed.color',
+        'utrecht.button.primary-action.pressed.background-color',
+        'utrecht.button.primary-action.pressed.border-color',
+      ],
+    },
+  },
+  {
     storyId: 'react-utrecht-button--secondary-action-button',
     component: 'utrecht-button',
     group: STORY_GROUPS['BUTTON_DEFAULT'],
@@ -174,7 +333,90 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     state: true,
     render: () => <Button appearance="secondary-action-button">Secondary action</Button>,
     detectTokens: {
-      allOf: ['utrecht.button.secondary-action.color', 'utrecht.button.secondary-action.background-color'],
+      anyOf: [
+        'utrecht.button.secondary-action.color',
+        'utrecht.button.secondary-action.background-color',
+        'utrecht.button.secondary-action.border-color',
+        'utrecht.button.secondary-action.border-width',
+        'utrecht.button.secondary-action.font-size',
+        'utrecht.button.secondary-action.font-weight',
+        'utrecht.button.secondary-action.line-height',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--secondary-action-active',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Secondary Action Button: Active',
+    state: true,
+    render: () => <Button appearance="secondary-action-button-active">Secondary action</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.secondary-action.active.color',
+        'utrecht.button.secondary-action.active.background-color',
+        'utrecht.button.secondary-action.active.border-color',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--secondary-action-disabled',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Secondary Action Button: Disabled',
+    state: true,
+    render: () => <Button appearance="secondary-action-button-disabled">Secondary action</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.secondary-action.disabled.color',
+        'utrecht.button.secondary-action.disabled.background-color',
+        'utrecht.button.secondary-action.disabled.border-color',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--secondary-action-hover',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Secondary Action Button: Hover',
+    state: true,
+    render: () => <Button appearance="secondary-action-button-hover">Secondary action</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.secondary-action.hover.color',
+        'utrecht.button.secondary-action.hover.background-color',
+        'utrecht.button.secondary-action.hover.border-color',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--secondary-action-focus',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Secondary Action Button: Focus',
+    state: true,
+    render: () => <Button appearance="secondary-action-button-focus">Secondary action</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.secondary-action.focus.color',
+        'utrecht.button.secondary-action.focus.background-color',
+        'utrecht.button.secondary-action.focus.border-color',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--secondary-action-pressed',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Secondary Action Button: Pressed',
+    state: true,
+    render: () => <Button appearance="secondary-action-button-pressed">Secondary action</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.secondary-action.pressed.color',
+        'utrecht.button.secondary-action.pressed.background-color',
+        'utrecht.button.secondary-action.pressed.border-color',
+      ],
     },
   },
   {
@@ -209,9 +451,93 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     state: true,
     render: () => <Button appearance="subtle-button">Subtle button</Button>,
     detectTokens: {
-      allOf: ['utrecht.button.subtle-action.color', 'utrecht.button.subtle-action.background-color'],
+      anyOf: [
+        'utrecht.button.subtle.color',
+        'utrecht.button.subtle.background-color',
+        'utrecht.button.subtle.border-color',
+        'utrecht.button.subtle.border-width',
+        'utrecht.button.subtle.font-size',
+        'utrecht.button.subtle.font-weight',
+        'utrecht.button.subtle.line-height',
+      ],
     },
   },
+  {
+    storyId: 'react-utrecht-button--subtle-active',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Subtle Button: Active',
+    state: true,
+    render: () => <Button appearance="subtle-button-active">Subtle button</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.subtle.active.color',
+        'utrecht.button.subtle.active.background-color',
+        'utrecht.button.subtle.active.border-color',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--subtle-disabled',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Subtle Button: Disabled',
+    state: true,
+    render: () => <Button appearance="subtle-button-disabled">Subtle button</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.subtle.disabled.color',
+        'utrecht.button.subtle.disabled.background-color',
+        'utrecht.button.subtle.disabled.border-color',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--subtle-hover',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Subtle Button: Hover',
+    state: true,
+    render: () => <Button appearance="subtle-button-hover">Subtle button</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.subtle.hover.color',
+        'utrecht.button.subtle.hover.background-color',
+        'utrecht.button.subtle.hover.border-color',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--subtle-focus',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Subtle Button: Focus',
+    state: true,
+    render: () => <Button appearance="subtle-button-focus">Subtle button</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.subtle.focus.color',
+        'utrecht.button.subtle.focus.background-color',
+        'utrecht.button.subtle.focus.border-color',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-button--subtle-pressed',
+    component: 'utrecht-button',
+    group: STORY_GROUPS['BUTTON_DEFAULT'],
+    name: 'Utrecht Subtle Button: Pressed',
+    state: true,
+    render: () => <Button appearance="subtle-button-pressed">Subtle button</Button>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.button.subtle.pressed.color',
+        'utrecht.button.subtle.pressed.background-color',
+        'utrecht.button.subtle.pressed.border-color',
+      ],
+    },
+  },
+
   {
     storyId: 'react-utrecht-button--subtle-button-danger',
     component: 'utrecht-button',

--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -90,19 +90,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
         'utrecht.button.padding-inline-start',
         'utrecht.button.padding-inline-end',
         'utrecht.button.text-transform',
-        'utrecht.button.text-transform',
       ],
-    },
-  },
-  {
-    storyId: 'react-utrecht-button--icon',
-    component: 'utrecht-button',
-    group: STORY_GROUPS['BUTTON_DEFAULT'],
-    name: 'Utrecht Default Button: Icon',
-    state: true,
-    render: () => <Button className="utrecht-button--icon">Default</Button>,
-    detectTokens: {
-      anyOf: ['utrecht.button.icon.size'],
     },
   },
   {
@@ -158,7 +146,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Default Button: Disabled',
     state: true,
-    render: () => <Button className="utrecht-button--disabled">Default</Button>,
+    render: () => <Button disabled>Default</Button>,
     detectTokens: {
       anyOf: [
         'utrecht.button.disabled.color',
@@ -173,7 +161,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Default Button: Pressed',
     state: true,
-    render: () => <Button className="utrecht-button--pressed">Default</Button>,
+    render: () => <Button pressed>Default</Button>,
     detectTokens: {
       anyOf: [
         'utrecht.button.pressed.color',
@@ -255,7 +243,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Primary Action Button: Active',
     state: true,
-    render: () => <Button appearance="primary-action-button-active">Primary action</Button>,
+    render: () => (
+      <Button appearance="primary-action-button" className="utrecht-button--active">
+        Primary action
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.primary-action.active.color',
@@ -270,7 +262,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Primary Action Button: Disabled',
     state: true,
-    render: () => <Button appearance="primary-action-button-disabled">Primary action</Button>,
+    render: () => (
+      <Button appearance="primary-action-button" disabled>
+        Primary action
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.primary-action.disabled.color',
@@ -285,7 +281,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Primary Action Button: Hover',
     state: true,
-    render: () => <Button appearance="primary-action-button-hover">Primary action</Button>,
+    render: () => (
+      <Button appearance="primary-action-button" className="utrecht-button--hover">
+        Primary action
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.primary-action.hover.color',
@@ -301,7 +301,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Primary Action Button: Focus',
     state: true,
-    render: () => <Button appearance="primary-action-button-focus">Primary action</Button>,
+    render: () => (
+      <Button appearance="primary-action-button" className="utrecht-button--focus utrecht-button--focus-visible">
+        Primary action
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.primary-action.focus.color',
@@ -316,7 +320,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Primary Action Button: Pressed',
     state: true,
-    render: () => <Button appearance="primary-action-button-pressed">Primary action</Button>,
+    render: () => (
+      <Button appearance="primary-action-button" pressed>
+        Primary action
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.primary-action.pressed.color',
@@ -350,7 +358,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Secondary Action Button: Active',
     state: true,
-    render: () => <Button appearance="secondary-action-button-active">Secondary action</Button>,
+    render: () => (
+      <Button appearance="secondary-action-button" className="utrecht-button--active">
+        Secondary action
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.secondary-action.active.color',
@@ -365,7 +377,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Secondary Action Button: Disabled',
     state: true,
-    render: () => <Button appearance="secondary-action-button-disabled">Secondary action</Button>,
+    render: () => (
+      <Button appearance="secondary-action-button" disabled>
+        Secondary action
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.secondary-action.disabled.color',
@@ -380,7 +396,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Secondary Action Button: Hover',
     state: true,
-    render: () => <Button appearance="secondary-action-button-hover">Secondary action</Button>,
+    render: () => (
+      <Button appearance="secondary-action-button" className="utrecht-button--hover">
+        Secondary action
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.secondary-action.hover.color',
@@ -395,7 +415,14 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Secondary Action Button: Focus',
     state: true,
-    render: () => <Button appearance="secondary-action-button-focus">Secondary action</Button>,
+    render: () => (
+      <Button
+        appearance="secondary-action-button-focus"
+        className="utrecht-button--focus utrecht-button--focus-visible"
+      >
+        Secondary action
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.secondary-action.focus.color',
@@ -410,7 +437,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Secondary Action Button: Pressed',
     state: true,
-    render: () => <Button appearance="secondary-action-button-pressed">Secondary action</Button>,
+    render: () => (
+      <Button appearance="secondary-action-button" pressed>
+        Secondary action
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.secondary-action.pressed.color',
@@ -468,7 +499,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Subtle Button: Active',
     state: true,
-    render: () => <Button appearance="subtle-button-active">Subtle button</Button>,
+    render: () => (
+      <Button appearance="subtle-button" className="utrecht-button--active">
+        Subtle button
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.subtle.active.color',
@@ -483,7 +518,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Subtle Button: Disabled',
     state: true,
-    render: () => <Button appearance="subtle-button-disabled">Subtle button</Button>,
+    render: () => (
+      <Button appearance="subtle-button" disabled>
+        Subtle button
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.subtle.disabled.color',
@@ -498,7 +537,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Subtle Button: Hover',
     state: true,
-    render: () => <Button appearance="subtle-button-hover">Subtle button</Button>,
+    render: () => (
+      <Button appearance="subtle-button" className="utrecht-button--hover">
+        Subtle button
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.subtle.hover.color',
@@ -513,7 +556,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Subtle Button: Focus',
     state: true,
-    render: () => <Button appearance="subtle-button-focus">Subtle button</Button>,
+    render: () => (
+      <Button appearance="subtle-button" className="utrecht-button--focus utrecht-button--focus-visible">
+        Subtle button
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.subtle.focus.color',
@@ -528,7 +575,11 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BUTTON_DEFAULT'],
     name: 'Utrecht Subtle Button: Pressed',
     state: true,
-    render: () => <Button appearance="subtle-button-pressed">Subtle button</Button>,
+    render: () => (
+      <Button appearance="subtle-button" pressed>
+        Subtle button
+      </Button>
+    ),
     detectTokens: {
       anyOf: [
         'utrecht.button.subtle.pressed.color',


### PR DESCRIPTION
**Pull Request**
In deze pull request heb ik button tokens toegevoegd aan de theme builder:

**Button component**
- [x] `button-default`
- [x] `button-icon`
- [x] `button-active`
- [x] `button-hover`
- [x] `button-focus`
- [x] `button-disabled`
- [x] `button-pressed`

**Button Primary Action component**
- [x] `button-default`
- [x] `button-active`
- [x] `button-hover`
- [x] `button-focus`
- [x] `button-disabled`
- [x] `button-pressed`

**Button Secondary Action component**
- [x] `button-default`
- [x] `button-active`
- [x] `button-hover`
- [x] `button-focus`
- [x] `button-disabled`
- [x] `button-pressed`

**Button Subtle component**
- [x] `button-default`
- [x] `button-active`
- [x] `button-hover`
- [x] `button-focus`
- [x] `button-disabled`
- [x] `button-pressed`

Hoe weet ik welke tokens ik moet gebruiken voor elke button-variant? Mijn bron is het [Storybook](https://nl-design-system.github.io/utrecht/storybook/?path=/docs/html_html-button--docs) van Gemeente Utrecht, waar je onderaan de pagina alle gebruikte en bestaande tokens voor een specifieke component en de verschillende staten van die component kunt vinden.