### PR TITLE
feat: additional tokens for skip-link component

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -6278,11 +6278,11 @@
         },
         "text-decoration-thickness": {
           "$type": "other",
-          "$value": "auto"
+          "$value": "1px"
         },
         "text-underline-offset": {
           "$type": "other",
-          "$value": "auto"
+          "$value": "1px"
         },
         "focus-visible": {
           "background-color": {

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -6252,6 +6252,14 @@
           "$type": "color",
           "$value": "{voorbeeld.document.inverse.color}"
         },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
+        },
         "padding-block": {
           "$type": "spacing",
           "$value": "{voorbeeld.space.block.snail}"
@@ -6268,9 +6276,13 @@
           "$type": "sizing",
           "$value": "{utrecht.pointer-target.min-size}"
         },
-        "text-decoration": {
-          "$type": "textDecoration",
-          "$value": "underline"
+        "text-decoration-thickness": {
+          "$type": "other",
+          "$value": "auto"
+        },
+        "text-underline-offset": {
+          "$type": "other",
+          "$value": "auto"
         },
         "focus-visible": {
           "background-color": {
@@ -6280,10 +6292,6 @@
           "color": {
             "$type": "color",
             "$value": "{utrecht.focus.color}"
-          },
-          "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
           }
         }
       }


### PR DESCRIPTION
Removed: `text-decotation`

Added:
- `text-decoration-thickness`
- `text-underline-offset`
- `font-size`
- `line-height`