### PR TITLE
chore: changed candidate link tokens

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4670,7 +4670,7 @@
           "$type": "color",
           "$value": "{voorbeeld.interaction.color}"
         },
-        "text-decoration": {
+        "text-decoration-line": {
           "$type": "textDecoration",
           "$value": "underline"
         },
@@ -4691,7 +4691,7 @@
             "$type": "color",
             "$value": "{voorbeeld.interaction.active.color}"
           },
-          "text-decoration": {
+          "text-decoration-line": {
             "$type": "textDecoration",
             "$value": "None"
           },
@@ -4709,7 +4709,7 @@
             "$type": "color",
             "$value": "{utrecht.focus.color}"
           },
-          "text-decoration": {
+          "text-decoration-line": {
             "$type": "textDecoration",
             "$value": "None"
           },
@@ -4723,7 +4723,7 @@
             "$type": "color",
             "$value": "{voorbeeld.interaction.hover.color}"
           },
-          "text-decoration": {
+          "text-decoration-line": {
             "$type": "textDecoration",
             "$value": "None"
           },
@@ -4736,6 +4736,16 @@
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.color.gray.500}"
+          },
+          "cursor": {
+            "$type": "other",
+            "$value": "disabled"
+          }
+        },
+        "current": {
+          "cursor": {
+            "$type": "other",
+            "$value": "default"
           }
         }
       }


### PR DESCRIPTION
Added the following tokens:

- `nl.link.placeholder.cursor`
- `nl.link.current.cursor`

And changed `*.text-decoration` to `*.text-decoration-line`.