### PR TITLE
feat: add link tokens to theme builder

### DIFF
--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -2069,6 +2069,21 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     },
   },
   {
+    storyId: 'react-utrecht-link--placeholder',
+    group: STORY_GROUPS['LINK'],
+    name: 'Utrecht Link: Placeholder',
+    state: true,
+    inline: true,
+    render: () => (
+      <Link href="https://example.com" target="_new" placeholder>
+        The Quick Brown Fox Jumps Over The Lazy Dog
+      </Link>
+    ),
+    detectTokens: {
+      anyOf: ['utrecht.link.placeholder.color', 'utrecht.link.placeholder.font-weight'],
+    },
+  },
+  {
     storyId: 'react-utrecht-link--focus',
     group: STORY_GROUPS['LINK'],
     name: 'Utrecht Link: Focus',

--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -2110,7 +2110,12 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     state: true,
     inline: true,
     render: () => (
-      <Link href="https://example.com" target="_new" external className="utrecht-link--focus-visible">
+      <Link
+        href="https://example.com"
+        target="_new"
+        external
+        className="utrecht-link--focus utrecht-link--focus-visible"
+      >
         The Quick Brown Fox Jumps Over The Lazy Dog
       </Link>
     ),

--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -2031,7 +2031,6 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
         'utrecht.link.text-decoration',
         'utrecht.link.text-decoration-thickness',
         'utrecht.link.text-underline-offset',
-        'utrecht.link.icon.size',
       ],
     },
   },

--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -2075,7 +2075,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     state: true,
     inline: true,
     render: () => (
-      <Link href="https://example.com" target="_new" placeholder>
+      <Link href="https://example.com" target="_new" placeholder className="utrecht-link--placeholder">
         The Quick Brown Fox Jumps Over The Lazy Dog
       </Link>
     ),

--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -2075,7 +2075,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     state: true,
     inline: true,
     render: () => (
-      <Link href="https://example.com" target="_new" placeholder className="utrecht-link--placeholder">
+      <Link href="https://example.com" target="_new" placeholder>
         The Quick Brown Fox Jumps Over The Lazy Dog
       </Link>
     ),

--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -2030,7 +2030,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
         'utrecht.link.color',
         'utrecht.link.text-decoration',
         'utrecht.link.text-decoration-thickness',
-        'utrecht.link.underline-offset',
+        'utrecht.link.text-underline-offset',
         'utrecht.link.icon.size',
       ],
     },

--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -2026,7 +2026,27 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
       </Link>
     ),
     detectTokens: {
-      anyOf: ['utrecht.link.color', 'utrecht.link.text-decoration', 'utrecht.link.text-decoration-thickness'],
+      anyOf: [
+        'utrecht.link.color',
+        'utrecht.link.text-decoration',
+        'utrecht.link.text-decoration-thickness',
+        'utrecht.link.underline-offset',
+        'utrecht.link.icon.size',
+      ],
+    },
+  },
+  {
+    storyId: 'react-utrecht-link--active',
+    group: STORY_GROUPS['LINK'],
+    name: 'Utrecht Link: Active',
+    inline: true,
+    render: () => (
+      <Link href="https://example.com" target="_new" external className="utrecht-link--active">
+        The Quick Brown Fox Jumps Over The Lazy Dog
+      </Link>
+    ),
+    detectTokens: {
+      anyOf: ['utrecht.link.active.color'],
     },
   },
   {
@@ -2062,6 +2082,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     detectTokens: {
       anyOf: [
         'utrecht.link.focus.color',
+        'utrecht.link.focus.background-color',
         'utrecht.link.focus.text-decoration',
         'utrecht.link.focus.text-decoration-thickness',
       ],
@@ -2078,6 +2099,9 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
         The Quick Brown Fox Jumps Over The Lazy Dog
       </Link>
     ),
+    detectTokens: {
+      anyOf: ['utrecht.link.focus-visible.text-decoration', 'utrecht.link.focus-visible.text-decoration-thickness'],
+    },
   },
   {
     storyId: 'react-utrecht-link--visited',
@@ -2090,6 +2114,9 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
         The Quick Brown Fox Jumps Over The Lazy Dog
       </Link>
     ),
+    detectTokens: {
+      anyOf: ['utrecht.link.visited.color'],
+    },
   },
   {
     storyId: 'react-utrecht-document--default',


### PR DESCRIPTION
**Pull Request**
In deze pull request heb ik link tokens toegevoegd aan de theme-builder:

<img width="550" alt="Screenshot 2025-01-09 at 13 53 34" src="https://github.com/user-attachments/assets/20c400f9-539d-4b2b-99cd-8a7f900f169a" />

- [x] `link-default`
- [x] `link-focus`
- [x] `link-focus-visible`
- [x] `link-hover`
- [x] `link-placeholder`
- [x] `link-active`
- [x] `link-visited`
- [x] `link-icon`

Hoe weet ik welke tokens ik moet gebruiken voor elke link-variant? Mijn bron is het [Storybook](https://nl-design-system.github.io/utrecht/storybook/?path=/docs/react_react-link--docs) van Gemeente Utrecht, waar je onderaan de pagina alle gebruikte en bestaande tokens voor een specifieke component en de verschillende staten van die component kunt vinden.