### PR TITLE
feat: add separator tokens

### DIFF
--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -1481,6 +1481,14 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     component: 'utrecht-separator',
     name: 'Utrecht Separator',
     render: () => <Separator />,
+    detectTokens: {
+      anyOf: [
+        'utrecht.separator.color',
+        'utrecht.separator.block-size',
+        'utrecht.separator.margin-block-end',
+        'utrecht.separator.margin-block-start',
+      ],
+    },
   },
   {
     storyId: 'react-utrecht-page-footer--default',


### PR DESCRIPTION
**Pull Request Separator**

<img width="550" alt="Screenshot 2024-12-31 at 13 10 40" src="https://github.com/user-attachments/assets/9651d928-f07d-40f9-b1ea-a7a3fc1b94df" />

In deze PR heb ik `separator` tokens toegevoegd aan de Theme Builder in het Purmerend-thema.

- [x]  `Separator`

 Hoe bepaal ik welke tokens ik moet gebruiken voor elke saparator-variant? In de [documentatie](https://nl-design-system.github.io/utrecht/storybook-react/?path=/docs/react-separator--docs) van Utrecht vind je onderaan de pagina een overzicht van alle gebruikte tokens voor een specifieke component, inclusief de verschillende staten van die component. Dit maakt het gemakkelijk om de juiste tokens te identificeren.