### PR TITLE
feat: add data-badge tokens

### DIFF
--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -2009,6 +2009,21 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['BADGES'],
     name: 'Utrecht Data Badge',
     render: () => <DataBadge>Category 1</DataBadge>,
+    detectTokens: {
+      anyOf: [
+        'utrecht.data-badge.color',
+        'utrecht.data-badge.border-radius',
+        'utrecht.data-badge.border-width',
+        'utrecht.data-badge.background-color',
+        'utrecht.data-badge.font-size',
+        'utrecht.data-badge.font-weight',
+        'utrecht.data-badge.line-height',
+        'utrecht.data-badge.min-block-size',
+        'utrecht.data-badge.min-inline-size',
+        'utrecht.data-badge.padding-block',
+        'utrecht.data-badge.padding-inline',
+      ],
+    },
   },
   {
     storyId: 'react-utrecht-blockquote--default',


### PR DESCRIPTION
Pull Request
In deze pull request heb ik DataBadge tokens toegevoegd aan de theme-builder:

- [ ] ` Data-badge`

Hoe weet ik welke tokens ik moet gebruiken voor elke databadge-variant? Mijn bron is het [Storybook](https://nl-design-system.github.io/utrecht/storybook/?path=/docs/css_css-data-badge--docs) van Gemeente Utrecht, waar je onderaan de pagina alle gebruikte en bestaande tokens voor een specifieke component en de verschillende staten van die component kunt vinden.