### PR TITLE
feat: add document tokens

### DIFF
--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -2096,7 +2096,14 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     name: 'Utrecht Document',
     render: () => <Document>The Quick Brown Fox Jumps Over The Lazy Dog</Document>,
     detectTokens: {
-      anyOf: ['utrecht.document.color', 'utrecht.document.background-color', 'utrecht.document.font-size'],
+      anyOf: [
+        'utrecht.document.color',
+        'utrecht.document.background-color',
+        'utrecht.document.font-size',
+        'utrecht.document.font-family',
+        'utrecht.document.font-weight',
+        'utrecht.document.line-height',
+      ],
     },
   },
   {


### PR DESCRIPTION
**Pull Request Document**

<img width="550" alt="Screenshot 2024-12-31 at 12 53 12" src="https://github.com/user-attachments/assets/60487d2d-377a-49a7-9d5b-7660db46acf6" />

In deze PR heb ik `document` tokens toegevoegd aan de Theme Builder in het Purmerend-thema.

- [x] `document-default`

Hoe bepaal ik welke tokens ik moet gebruiken voor elke document-variant? In de [documentatie](https://nl-design-system.github.io/utrecht/storybook-react/?path=/docs/react-document--docs) van Utrecht vind je onderaan de pagina een overzicht van alle gebruikte tokens voor een specifieke component, inclusief de verschillende staten van die component. Dit maakt het gemakkelijk om de juiste tokens te identificeren.

