### PR TITLE
feat: add select tokens

### DIFF
--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -1928,6 +1928,27 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
         <SelectOption value="3">Option 3</SelectOption>
       </Select>
     ),
+    detectTokens: {
+      anyOf: [
+        'utrecht.select.background-color',
+        'utrecht.select.image',
+        'utrecht.select.border-block-end-width',
+        'utrecht.select.border-bottom-width',
+        'utrecht.select.border-color',
+        'utrecht.select.border-radius',
+        'utrecht.select.color',
+        'utrecht.select.font-family',
+        'utrecht.select.font-size',
+        'utrecht.select.font-weight',
+        'utrecht.select.line-height',
+        'utrecht.select.min-block-size',
+        'utrecht.select.max-inline-size',
+        'utrecht.select.padding-block-end',
+        'utrecht.select.padding-block-start',
+        'utrecht.select.padding-inline-end',
+        'utrecht.select.padding-inline-start',
+      ],
+    },
   },
   {
     storyId: 'react-utrecht-select--disabled',
@@ -1942,6 +1963,13 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
         <SelectOption value="3">Option 3</SelectOption>
       </Select>
     ),
+    detectTokens: {
+      anyOf: [
+        'utrecht.select.disabled.background-color',
+        'utrecht.select.disabled.border-color',
+        'utrecht.select.disabled.color',
+      ],
+    },
   },
   {
     storyId: 'react-utrecht-select--invalid',
@@ -1956,6 +1984,14 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
         <SelectOption value="3">Option 3</SelectOption>
       </Select>
     ),
+    detectTokens: {
+      anyOf: [
+        'utrecht.select.invalid.background-color',
+        'utrecht.select.invalid.border-block-end-width',
+        'utrecht.select.invalid.color',
+        'utrecht.select.invalid.border-width',
+      ],
+    },
   },
   {
     storyId: 'react-utrecht-select--required',
@@ -1983,6 +2019,13 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
         <SelectOption value="3">Option 3</SelectOption>
       </Select>
     ),
+    detectTokens: {
+      anyOf: [
+        'utrecht.select.focus.background-color',
+        'utrecht.select.focus.border-color',
+        'utrecht.select.focus.color',
+      ],
+    },
   },
   {
     storyId: 'react-utrecht-select--focus-visible',

--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -1931,7 +1931,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     detectTokens: {
       anyOf: [
         'utrecht.select.background-color',
-        'utrecht.select.image',
+        'utrecht.select.background-image',
         'utrecht.select.border-block-end-width',
         'utrecht.select.border-bottom-width',
         'utrecht.select.border-color',


### PR DESCRIPTION

<img width="550" alt="Screenshot 2025-01-03 at 13 58 37" src="https://github.com/user-attachments/assets/0fa6d5af-7f4d-4aaa-9761-ebfeb6f90f4f" />

In deze PR heb ik `select` tokens toegevoegd aan de Theme Builder in het Purmerend-thema.

- [x] `select-default` 
- [x] `select-disabled`
- [x] `select-invalid`
- [ ] `select-required`
- [ ] `select-hover`
- [x] `select-focus`
- [ ] `select-focus-visible`

Hoe bepaal ik welke tokens ik moet gebruiken voor elke select-variant? In de [documentatie](https://nl-design-system.github.io/utrecht/storybook/?path=/docs/html_html-select--docs) van Utrecht vind je onderaan de pagina een overzicht van alle gebruikte tokens voor een specifieke component, inclusief de verschillende staten van die component. Dit maakt het gemakkelijk om de juiste tokens te identificeren.