### PR TITLE
fix: removed unnecessary marks

### DIFF
--- a/proprietary/purmerend-design-tokens/figma/color-scheme-dark.tokens.json
+++ b/proprietary/purmerend-design-tokens/figma/color-scheme-dark.tokens.json
@@ -126,7 +126,7 @@
           "fill-1": { "$value": "{purmerend.color.white-1}" },
           "fill-2": { "$value": "{purmerend.color.white-1}" },
           "text-1": { "$value": "{purmerend.color.white-1}" },
-          "text-2": { "$value": "{purmerend.color.white-1}" },
+          "text-2": { "$value": "{purmerend.color.white-1}" }
         },
         "disabled-inverse": {
           "bg-1": { "$value": "{purmerend.color.cyan-6}" },
@@ -140,7 +140,7 @@
           "fill-1": { "$value": "{purmerend.color.white-1}" },
           "fill-2": { "$value": "{purmerend.color.white-1}" },
           "text-1": { "$value": "{purmerend.color.white-1}" },
-          "text-2": { "$value": "{purmerend.color.white-1}" },
+          "text-2": { "$value": "{purmerend.color.white-1}" }
         },
         "primary-inverse": {
           "bg-1": { "$value": "{purmerend.color.cyan-6}" },
@@ -154,7 +154,7 @@
           "fill-1": { "$value": "{purmerend.color.white-1}" },
           "fill-2": { "$value": "{purmerend.color.white-1}" },
           "text-1": { "$value": "{purmerend.color.white-1}" },
-          "text-2": { "$value": "{purmerend.color.white-1}" },
+          "text-2": { "$value": "{purmerend.color.white-1}" }
          
         },
         "secondary-inverse": {

--- a/proprietary/purmerend-design-tokens/figma/figma.tokens.json
+++ b/proprietary/purmerend-design-tokens/figma/figma.tokens.json
@@ -2786,7 +2786,7 @@
           "border-inline-start-color": {
             "$type": "color",
             "$value": "{basis.color.error.border-1}"
-          },
+          }
         }
       }
     }
@@ -3185,7 +3185,7 @@
           }
         }
       }
-    },
+    }
   },
   "$themes": [],
   "$metadata": {


### PR DESCRIPTION
Wanneer je in het Figma-bestand werkt, is het makkelijk om kleine foutjes te maken, zoals extra komma's, typfouten of haakjes. Ik merkte dat er in de main-versie een paar onnodige komma's staan, die een foutmelding veroorzaken boven bij het bestandnaam. Ik heb deze foutjes gevonden en verwijderd.