### PR TITLE
feat: add outline style dashed to purmerend theme

### DIFF
--- a/.changeset/stale-jokes-sell.md
+++ b/.changeset/stale-jokes-sell.md
@@ -1,0 +1,6 @@
+---
+"@nl-design-system-unstable/basis-design-tokens": patch
+"@nl-design-system-community/purmerend-design-tokens": patch
+---
+
+Use `dashed` instead of `dotted` focus ring, because it adheres to WCAG more reliable. Some browsers render circular dots, in that case the 4px outline-width is not sufficient to achieve the minimum focus ring area.

--- a/proprietary/basis-design-tokens/figma/basis.tokens.json
+++ b/proprietary/basis-design-tokens/figma/basis.tokens.json
@@ -1144,7 +1144,7 @@
         },
         "outline-style": {
           "$type": "other",
-          "$value": "dotted"
+          "$value": "dashed"
         },
         "outline-width": {
           "$type": "borderWidth",

--- a/proprietary/purmerend-design-tokens/figma/figma.tokens.json
+++ b/proprietary/purmerend-design-tokens/figma/figma.tokens.json
@@ -2295,7 +2295,13 @@
           "$type": "color",
           "$value": "{purmerend.color.red-17}"
         }
-      }
+      },
+      "focus":{
+        "outline-style": {
+           "$type": "other",
+           "$value": "dashed"
+       }
+     }
     }
   },
   "components/link": {

--- a/proprietary/purmerend-design-tokens/figma/figma.tokens.json
+++ b/proprietary/purmerend-design-tokens/figma/figma.tokens.json
@@ -2295,13 +2295,7 @@
           "$type": "color",
           "$value": "{purmerend.color.red-17}"
         }
-      },
-      "focus":{
-        "outline-style": {
-           "$type": "other",
-           "$value": "dashed"
-       }
-     }
+      }
     }
   },
   "components/link": {


### PR DESCRIPTION
Added focus `outline-style` dashed to Purmerend theme

<img width="600" alt="Screenshot 2025-01-06 at 15 19 42" src="https://github.com/user-attachments/assets/349206c8-dea0-4414-a84c-abb2fc016589" />
