### PR TITLE
feat: add text underline offset to link Purmerend theme

### DIFF
--- a/.changeset/fifty-jars-shave.md
+++ b/.changeset/fifty-jars-shave.md
@@ -1,0 +1,6 @@
+---
+"@nl-design-system-unstable/basis-design-tokens": patch
+"@nl-design-system-community/purmerend-design-tokens": patch
+---
+
+Use thicker underline for links on hover, and move underline slightly away from text.

--- a/proprietary/basis-design-tokens/figma/basis.tokens.json
+++ b/proprietary/basis-design-tokens/figma/basis.tokens.json
@@ -3761,7 +3761,7 @@
           },
           "text-decoration": {
             "$type": "textDecoration",
-            "$value": "{utrecht.link.hover.text-decoration}"
+            "$value": "none"
           },
           "text-decoration-thickness": {
             "$type": "other",

--- a/proprietary/basis-design-tokens/figma/basis.tokens.json
+++ b/proprietary/basis-design-tokens/figma/basis.tokens.json
@@ -3720,7 +3720,7 @@
         },
         "text-underline-offset": {
           "$type": "other",
-          "$value": "{utrecht.link.text-underline-offset}"
+          "$value": "3px"
         },
         "icon": {
           "size": {

--- a/proprietary/basis-design-tokens/figma/basis.tokens.json
+++ b/proprietary/basis-design-tokens/figma/basis.tokens.json
@@ -3720,7 +3720,7 @@
         },
         "text-underline-offset": {
           "$type": "other",
-          "$value": "auto"
+          "$value": "{utrecht.link.text-underline-offset}"
         },
         "icon": {
           "size": {
@@ -3761,11 +3761,11 @@
           },
           "text-decoration": {
             "$type": "textDecoration",
-            "$value": "None"
+            "$value": "{utrecht.link.hover.text-decoration}"
           },
           "text-decoration-thickness": {
             "$type": "other",
-            "$value": "{utrecht.link.text-decoration-thickness}"
+            "$value": "3px"
           }
         },
         "visited": {

--- a/proprietary/purmerend-design-tokens/figma/figma.tokens.json
+++ b/proprietary/purmerend-design-tokens/figma/figma.tokens.json
@@ -2305,10 +2305,6 @@
           "$type": "color",
           "$value": "{basis.color.text.text-1}"
         },
-        "text-underline-offset":{
-          "$type": "other",
-          "$value": "3px"
-        },
         "text-decoration": {
           "$type": "textDecoration",
           "$value": "underline"

--- a/proprietary/purmerend-design-tokens/figma/figma.tokens.json
+++ b/proprietary/purmerend-design-tokens/figma/figma.tokens.json
@@ -2305,6 +2305,10 @@
           "$type": "color",
           "$value": "{basis.color.text.text-1}"
         },
+        "text-underline-offset":{
+          "$type": "other",
+          "$value": "3px"
+        },
         "text-decoration": {
           "$type": "textDecoration",
           "$value": "underline"


### PR DESCRIPTION
**Added `text-underline-offset` to `Link`** 

<img width="600" alt="Screenshot 2025-01-06 at 15 47 43" src="https://github.com/user-attachments/assets/bf1deb07-cd96-4091-b91b-944440085c5e" />

<img width="600" alt="Screenshot 2025-01-06 at 15 48 10" src="https://github.com/user-attachments/assets/43e237ff-1417-4483-8e5b-763287ce05df" />

Volgens de voorbeeld in Gemeente Utrecht is de underline offset 3px. 

In progress ⬇️
- [ ] Er is nog een issue met de underline color (niet meer dark-mode)
- [x] Hover state underline thickness tokens toevoegen
- [x] Gaat het lukken om alles in de Basis thema te zetten ipv Purmerend thema?

**Added `underline-thickness` hover state to `Link`**

<img width="600" alt="Screenshot 2025-01-07 at 11 28 50" src="https://github.com/user-attachments/assets/494420e2-7727-4b06-9ed1-98a1587da122" />

Design token name `utrecht.link.hover.text-decoration-thickness` (3px) geeft aan token reference could not be found, daarom staat het gewoon hardcoded in als `3px`