### PR TITLE
feat: add code block tokens

### DIFF
--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -2188,7 +2188,20 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
 </html>`}</CodeBlock>
     ),
     detectTokens: {
-      allOf: ['utrecht.code-block.font-family'],
+      anyOf: [
+        'utrecht.code-block.font-family',
+        'utrecht.code-block.background-color',
+        'utrecht.code-block.font-size',
+        'utrecht.code-block.line-height',
+        'utrecht.code-block.margin-block-start',
+        'utrecht.code-block.margin-block-end',
+        'utrecht.code-block.margin-inline-start',
+        'utrecht.code-block.margin-inline-end',
+        'utrecht.code-block.padding-block-start',
+        'utrecht.code-block.padding-block-end',
+        'utrecht.code-block.padding-inline-start',
+        'utrecht.code-block.padding-inline-end',
+      ],
     },
   },
   {

--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -2191,6 +2191,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
       anyOf: [
         'utrecht.code-block.font-family',
         'utrecht.code-block.background-color',
+        'utrecht.code-block.color',
         'utrecht.code-block.font-size',
         'utrecht.code-block.line-height',
         'utrecht.code-block.margin-block-start',


### PR DESCRIPTION
**Pull Request Code Block**

<img width="550" alt="Screenshot 2025-01-07 at 14 17 11" src="https://github.com/user-attachments/assets/323d0331-4f6b-4265-adf7-667e4799e821" />

In deze PR heb ik `code-block` tokens toegevoegd aan de Theme Builder in het Purmerend-thema.

- [x]  `code-block-default`

 
Hoe bepaal ik welke tokens ik moet gebruiken voor elke code-block-variant? In de [documentatie](https://nl-design-system.github.io/utrecht/storybook/?path=/docs/css_css-code-block--docs) van Utrecht vind je onderaan de pagina een overzicht van alle gebruikte tokens voor een specifieke component, inclusief de verschillende staten van die component. Dit maakt het gemakkelijk om de juiste tokens te identificeren.