### PR TITLE
feat: add code tokens

### DIFF
--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -2169,7 +2169,13 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     name: 'Utrecht Code',
     render: () => <Code>{'<input type="url" value="https://example.fi/">'}</Code>,
     detectTokens: {
-      allOf: ['utrecht.code.font-family'],
+      anyOf: [
+        'utrecht.code.color',
+        'utrecht.code.background-color',
+        'utrecht.code.font-size',
+        'utrecht.code.font-family',
+        'utrecht.code.line-height',
+      ],
     },
   },
   {


### PR DESCRIPTION
**Pull Request Code**

<img width="550" alt="Screenshot 2025-01-07 at 14 28 13" src="https://github.com/user-attachments/assets/e4a2a2af-9a1a-49c5-80f4-5214d115ed52" />

In deze PR heb ik `code` tokens toegevoegd aan de Theme Builder in het Purmerend-thema.

- [x]  `code-default`

 
Hoe bepaal ik welke tokens ik moet gebruiken voor elke code-block-variant? In de [documentatie](https://nl-design-system.github.io/utrecht/storybook-css/?path=/docs/css-code--docs) van Utrecht vind je onderaan de pagina een overzicht van alle gebruikte tokens voor een specifieke component, inclusief de verschillende staten van die component. Dit maakt het gemakkelijk om de juiste tokens te identificeren.