### PR TITLE
fix: avoid too large screenshots in Chromatic

### DIFF
--- a/packages/theme-toolkit/src/ComponentStories.tsx
+++ b/packages/theme-toolkit/src/ComponentStories.tsx
@@ -105,7 +105,14 @@ export const ComponentStories = ({
   const tokensMap = arrayToMap(tokens || []);
 
   return (
-    <div>
+    <div
+      style={{
+        // Do not exceed the limit for screenshots in Chromatic
+        maxInlineSize: '2500px',
+        maxBlockSize: '20000px',
+        overflowBlock: 'hidden',
+      }}
+    >
       {Object.entries(groupedStories).map(([group, stories]) => {
         const isGrouped = group !== UNGROUPED && stories.length > 1;
         return (


### PR DESCRIPTION
I'm trying to fix #921, but this approach doesn't seem successful yet.