### PR TITLE
border width had een groningen name ipv een utrecht naam, daarom gaat…

### DIFF
--- a/proprietary/groningen-design-tokens/figma/figma.tokens.json
+++ b/proprietary/groningen-design-tokens/figma/figma.tokens.json
@@ -1921,11 +1921,7 @@
         "font-family": {
           "value": "{groningen.document.font-family}",
           "type": "fontFamilies"
-        }
-      }
-    },
-    "groningen": {
-      "button": {
+        },
         "border-width": {
           "type": "borderWidth",
           "value": "{groningen.border-width.1px}"


### PR DESCRIPTION
… er nu iets fout bij implementatie van nl ds bij open stad (geen border getoond)