### PR TITLE
style: restore simplified tokens for Task List component

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4,521 +4,521 @@
       "typography": {
         "font-size": {
           "sm": {
-            "$type": "fontSizes",
-            "$value": "0.875rem"
+            "value": "0.875rem",
+            "type": "fontSizes"
           },
           "md": {
-            "$type": "fontSizes",
-            "$value": "1rem"
+            "value": "1rem",
+            "type": "fontSizes"
           },
           "lg": {
-            "$type": "fontSizes",
-            "$value": "1.25rem"
+            "value": "1.25rem",
+            "type": "fontSizes"
           },
           "xl": {
-            "$type": "fontSizes",
-            "$value": "1.5rem"
+            "value": "1.5rem",
+            "type": "fontSizes"
           },
           "2xl": {
-            "$type": "fontSizes",
-            "$value": "2rem"
+            "value": "2rem",
+            "type": "fontSizes"
           },
           "3xl": {
-            "$type": "fontSizes",
-            "$value": "2.5rem"
+            "value": "2.5rem",
+            "type": "fontSizes"
           },
           "4xl": {
-            "$type": "fontSizes",
-            "$value": "3rem"
+            "value": "3rem",
+            "type": "fontSizes"
           }
         },
         "line-height": {
           "xs": {
-            "$type": "lineHeights",
-            "$value": "100%"
+            "value": "100%",
+            "type": "lineHeights"
           },
           "sm": {
-            "$type": "lineHeights",
-            "$value": "125%"
+            "value": "125%",
+            "type": "lineHeights"
           },
           "md": {
-            "$type": "lineHeights",
-            "$value": "150%"
+            "value": "150%",
+            "type": "lineHeights"
           },
           "lg": {
-            "$type": "lineHeights",
-            "$value": "200%"
+            "value": "200%",
+            "type": "lineHeights"
           }
         },
         "font-weight": {
           "normal": {
-            "$type": "fontWeights",
-            "$value": "Regular"
+            "value": "Regular",
+            "type": "fontWeights"
           },
           "bold": {
-            "$type": "fontWeights",
-            "$value": "Bold"
+            "value": "Bold",
+            "type": "fontWeights"
           }
         },
         "font-family": {
           "primary": {
-            "$type": "fontFamilies",
-            "$value": "Source Serif Pro, Tahoma, Verdana, sans-serif"
+            "value": "Source Serif Pro, Tahoma, Verdana, sans-serif",
+            "type": "fontFamilies"
           },
           "secondary": {
-            "$type": "fontFamilies",
-            "$value": "Fira Sans, Tahoma, Verdana, sans-serif"
+            "value": "Fira Sans, Tahoma, Verdana, sans-serif",
+            "type": "fontFamilies"
           },
           "code": {
-            "$type": "fontFamilies",
-            "$value": "Fira Code, Monaco, monospace"
+            "value": "Fira Code, Monaco, monospace",
+            "type": "fontFamilies"
           }
         }
       },
       "color": {
         "white": {
-          "$type": "color",
-          "$value": "#ffffff"
+          "value": "#ffffff",
+          "type": "color"
         },
         "black": {
-          "$type": "color",
-          "$value": "#000000"
+          "value": "#000000",
+          "type": "color"
         },
         "violet": {
           "50": {
-            "$type": "color",
-            "$value": "#FAF8FF"
+            "value": "#FAF8FF",
+            "type": "color"
           },
           "100": {
-            "$type": "color",
-            "$value": "#F5F2FF"
+            "value": "#F5F2FF",
+            "type": "color"
           },
           "200": {
-            "$type": "color",
-            "$value": "#EBE3FF"
+            "value": "#EBE3FF",
+            "type": "color"
           },
           "300": {
-            "$type": "color",
-            "$value": "#DBCDFF"
+            "value": "#DBCDFF",
+            "type": "color"
           },
           "400": {
-            "$type": "color",
-            "$value": "#AF91FF"
+            "value": "#AF91FF",
+            "type": "color"
           },
           "500": {
-            "$type": "color",
-            "$value": "#966EFF"
+            "value": "#966EFF",
+            "type": "color"
           },
           "600": {
-            "$type": "color",
-            "$value": "#7744FF"
+            "value": "#7744FF",
+            "type": "color"
           },
           "700": {
-            "$type": "color",
-            "$value": "#5315F6"
+            "value": "#5315F6",
+            "type": "color"
           },
           "800": {
-            "$type": "color",
-            "$value": "#3F10BC"
+            "value": "#3F10BC",
+            "type": "color"
           },
           "900": {
-            "$type": "color",
-            "$value": "#290B7A"
+            "value": "#290B7A",
+            "type": "color"
           },
           "950": {
-            "$type": "color",
-            "$value": "#1A074C"
+            "value": "#1A074C",
+            "type": "color"
           }
         },
         "gray": {
           "50": {
-            "$type": "color",
-            "$value": "#F9F9FA"
+            "value": "#F9F9FA",
+            "type": "color"
           },
           "100": {
-            "$type": "color",
-            "$value": "#F2F4F6"
+            "value": "#F2F4F6",
+            "type": "color"
           },
           "200": {
-            "$type": "color",
-            "$value": "#E4E7EC"
+            "value": "#E4E7EC",
+            "type": "color"
           },
           "300": {
-            "$type": "color",
-            "$value": "#CFD5DD"
+            "value": "#CFD5DD",
+            "type": "color"
           },
           "400": {
-            "$type": "color",
-            "$value": "#98A4B6"
+            "value": "#98A4B6",
+            "type": "color"
           },
           "500": {
-            "$type": "color",
-            "$value": "#7A8AA0"
+            "value": "#7A8AA0",
+            "type": "color"
           },
           "600": {
-            "$type": "color",
-            "$value": "#5B6E8A"
+            "value": "#5B6E8A",
+            "type": "color"
           },
           "700": {
-            "$type": "color",
-            "$value": "#3F5676"
+            "value": "#3F5676",
+            "type": "color"
           },
           "800": {
-            "$type": "color",
-            "$value": "#274065"
+            "value": "#274065",
+            "type": "color"
           },
           "900": {
-            "$type": "color",
-            "$value": "#0A2750"
+            "value": "#0A2750",
+            "type": "color"
           },
           "950": {
-            "$type": "color",
-            "$value": "#001737"
+            "value": "#001737",
+            "type": "color"
           }
         },
         "pink": {
           "50": {
-            "$type": "color",
-            "$value": "#FDF8FA"
+            "value": "#FDF8FA",
+            "type": "color"
           },
           "100": {
-            "$type": "color",
-            "$value": "#FCF1F6"
+            "value": "#FCF1F6",
+            "type": "color"
           },
           "200": {
-            "$type": "color",
-            "$value": "#F8E1EB"
+            "value": "#F8E1EB",
+            "type": "color"
           },
           "300": {
-            "$type": "color",
-            "$value": "#F2C9DC"
+            "value": "#F2C9DC",
+            "type": "color"
           },
           "400": {
-            "$type": "color",
-            "$value": "#E287B0"
+            "value": "#E287B0",
+            "type": "color"
           },
           "500": {
-            "$type": "color",
-            "$value": "#D85E95"
+            "value": "#D85E95",
+            "type": "color"
           },
           "600": {
-            "$type": "color",
-            "$value": "#CA2771"
+            "value": "#CA2771",
+            "type": "color"
           },
           "700": {
-            "$type": "color",
-            "$value": "#A60E52"
+            "value": "#A60E52",
+            "type": "color"
           },
           "800": {
-            "$type": "color",
-            "$value": "#7F0B3F"
+            "value": "#7F0B3F",
+            "type": "color"
           },
           "900": {
-            "$type": "color",
-            "$value": "#520729"
+            "value": "#520729",
+            "type": "color"
           },
           "950": {
-            "$type": "color",
-            "$value": "#33041A"
+            "value": "#33041A",
+            "type": "color"
           }
         },
         "red": {
           "50": {
-            "$type": "color",
-            "$value": "#FFF8F8"
+            "value": "#FFF8F8",
+            "type": "color"
           },
           "100": {
-            "$type": "color",
-            "$value": "#FEF0F1"
+            "value": "#FEF0F1",
+            "type": "color"
           },
           "200": {
-            "$type": "color",
-            "$value": "#FEE0E1"
+            "value": "#FEE0E1",
+            "type": "color"
           },
           "300": {
-            "$type": "color",
-            "$value": "#FDC7CA"
+            "value": "#FDC7CA",
+            "type": "color"
           },
           "400": {
-            "$type": "color",
-            "$value": "#F97D83"
+            "value": "#F97D83",
+            "type": "color"
           },
           "500": {
-            "$type": "color",
-            "$value": "#F7464E"
+            "value": "#F7464E",
+            "type": "color"
           },
           "600": {
-            "$type": "color",
-            "$value": "#D2262E"
+            "value": "#D2262E",
+            "type": "color"
           },
           "700": {
-            "$type": "color",
-            "$value": "#A41E24"
+            "value": "#A41E24",
+            "type": "color"
           },
           "800": {
-            "$type": "color",
-            "$value": "#7E171C"
+            "value": "#7E171C",
+            "type": "color"
           },
           "900": {
-            "$type": "color",
-            "$value": "#500F12"
+            "value": "#500F12",
+            "type": "color"
           },
           "950": {
-            "$type": "color",
-            "$value": "#31090B"
+            "value": "#31090B",
+            "type": "color"
           }
         },
         "orange": {
           "50": {
-            "$type": "color",
-            "$value": "#FFF8F3"
+            "value": "#FFF8F3",
+            "type": "color"
           },
           "100": {
-            "$type": "color",
-            "$value": "#FFF1E7"
+            "value": "#FFF1E7",
+            "type": "color"
           },
           "200": {
-            "$type": "color",
-            "$value": "#FFE1CB"
+            "value": "#FFE1CB",
+            "type": "color"
           },
           "300": {
-            "$type": "color",
-            "$value": "#FFC9A3"
+            "value": "#FFC9A3",
+            "type": "color"
           },
           "400": {
-            "$type": "color",
-            "$value": "#FF7A2A"
+            "value": "#FF7A2A",
+            "type": "color"
           },
           "500": {
-            "$type": "color",
-            "$value": "#DD6525"
+            "value": "#DD6525",
+            "type": "color"
           },
           "600": {
-            "$type": "color",
-            "$value": "#B2501F"
+            "value": "#B2501F",
+            "type": "color"
           },
           "700": {
-            "$type": "color",
-            "$value": "#8B3E18"
+            "value": "#8B3E18",
+            "type": "color"
           },
           "800": {
-            "$type": "color",
-            "$value": "#6A2E13"
+            "value": "#6A2E13",
+            "type": "color"
           },
           "900": {
-            "$type": "color",
-            "$value": "#431D0D"
+            "value": "#431D0D",
+            "type": "color"
           },
           "950": {
-            "$type": "color",
-            "$value": "#271208"
+            "value": "#271208",
+            "type": "color"
           }
         },
         "yellow": {
           "50": {
-            "$type": "color",
-            "$value": "#FFFADF"
+            "value": "#FFFADF",
+            "type": "color"
           },
           "100": {
-            "$type": "color",
-            "$value": "#FFF5BE"
+            "value": "#FFF5BE",
+            "type": "color"
           },
           "200": {
-            "$type": "color",
-            "$value": "#FFE76B"
+            "value": "#FFE76B",
+            "type": "color"
           },
           "300": {
-            "$type": "color",
-            "$value": "#F9D100"
+            "value": "#F9D100",
+            "type": "color"
           },
           "400": {
-            "$type": "color",
-            "$value": "#C0A100"
+            "value": "#C0A100",
+            "type": "color"
           },
           "500": {
-            "$type": "color",
-            "$value": "#A08700"
+            "value": "#A08700",
+            "type": "color"
           },
           "600": {
-            "$type": "color",
-            "$value": "#806C00"
+            "value": "#806C00",
+            "type": "color"
           },
           "700": {
-            "$type": "color",
-            "$value": "#645400"
+            "value": "#645400",
+            "type": "color"
           },
           "800": {
-            "$type": "color",
-            "$value": "#4B3F00"
+            "value": "#4B3F00",
+            "type": "color"
           },
           "900": {
-            "$type": "color",
-            "$value": "#2F2800"
+            "value": "#2F2800",
+            "type": "color"
           },
           "950": {
-            "$type": "color",
-            "$value": "#1C1800"
+            "value": "#1C1800",
+            "type": "color"
           }
         },
         "green": {
           "50": {
-            "$type": "color",
-            "$value": "#F2FCF4"
+            "value": "#F2FCF4",
+            "type": "color"
           },
           "100": {
-            "$type": "color",
-            "$value": "#E4F9EA"
+            "value": "#E4F9EA",
+            "type": "color"
           },
           "200": {
-            "$type": "color",
-            "$value": "#C5F1D1"
+            "value": "#C5F1D1",
+            "type": "color"
           },
           "300": {
-            "$type": "color",
-            "$value": "#94E6AB"
+            "value": "#94E6AB",
+            "type": "color"
           },
           "400": {
-            "$type": "color",
-            "$value": "#20BC4B"
+            "value": "#20BC4B",
+            "type": "color"
           },
           "500": {
-            "$type": "color",
-            "$value": "#1B9D3F"
+            "value": "#1B9D3F",
+            "type": "color"
           },
           "600": {
-            "$type": "color",
-            "$value": "#167E33"
+            "value": "#167E33",
+            "type": "color"
           },
           "700": {
-            "$type": "color",
-            "$value": "#116227"
+            "value": "#116227",
+            "type": "color"
           },
           "800": {
-            "$type": "color",
-            "$value": "#0D4A1E"
+            "value": "#0D4A1E",
+            "type": "color"
           },
           "900": {
-            "$type": "color",
-            "$value": "#082F13"
+            "value": "#082F13",
+            "type": "color"
           },
           "950": {
-            "$type": "color",
-            "$value": "#051C0B"
+            "value": "#051C0B",
+            "type": "color"
           }
         },
         "sea-green": {
           "50": {
-            "$type": "color",
-            "$value": "#F2FBFA"
+            "value": "#F2FBFA",
+            "type": "color"
           },
           "100": {
-            "$type": "color",
-            "$value": "#E5F7F5"
+            "value": "#E5F7F5",
+            "type": "color"
           },
           "200": {
-            "$type": "color",
-            "$value": "#C6EFE9"
+            "value": "#C6EFE9",
+            "type": "color"
           },
           "300": {
-            "$type": "color",
-            "$value": "#99E2D8"
+            "value": "#99E2D8",
+            "type": "color"
           },
           "400": {
-            "$type": "color",
-            "$value": "#05B7A0"
+            "value": "#05B7A0",
+            "type": "color"
           },
           "500": {
-            "$type": "color",
-            "$value": "#009A85"
+            "value": "#009A85",
+            "type": "color"
           },
           "600": {
-            "$type": "color",
-            "$value": "#007B6B"
+            "value": "#007B6B",
+            "type": "color"
           },
           "700": {
-            "$type": "color",
-            "$value": "#006053"
+            "value": "#006053",
+            "type": "color"
           },
           "800": {
-            "$type": "color",
-            "$value": "#00493F"
+            "value": "#00493F",
+            "type": "color"
           },
           "900": {
-            "$type": "color",
-            "$value": "#002E28"
+            "value": "#002E28",
+            "type": "color"
           },
           "950": {
-            "$type": "color",
-            "$value": "#001C18"
+            "value": "#001C18",
+            "type": "color"
           }
         },
         "blue": {
           "50": {
-            "$type": "color",
-            "$value": "#F4FAFE"
+            "value": "#F4FAFE",
+            "type": "color"
           },
           "100": {
-            "$type": "color",
-            "$value": "#E9F5FD"
+            "value": "#E9F5FD",
+            "type": "color"
           },
           "200": {
-            "$type": "color",
-            "$value": "#D0EBFB"
+            "value": "#D0EBFB",
+            "type": "color"
           },
           "300": {
-            "$type": "color",
-            "$value": "#ABDBF8"
+            "value": "#ABDBF8",
+            "type": "color"
           },
           "400": {
-            "$type": "color",
-            "$value": "#3EACEF"
+            "value": "#3EACEF",
+            "type": "color"
           },
           "500": {
-            "$type": "color",
-            "$value": "#008DE4"
+            "value": "#008DE4",
+            "type": "color"
           },
           "600": {
-            "$type": "color",
-            "$value": "#0071B7"
+            "value": "#0071B7",
+            "type": "color"
           },
           "700": {
-            "$type": "color",
-            "$value": "#00588F"
+            "value": "#00588F",
+            "type": "color"
           },
           "800": {
-            "$type": "color",
-            "$value": "#00436C"
+            "value": "#00436C",
+            "type": "color"
           },
           "900": {
-            "$type": "color",
-            "$value": "#002A44"
+            "value": "#002A44",
+            "type": "color"
           },
           "950": {
-            "$type": "color",
-            "$value": "#001A29"
+            "value": "#001A29",
+            "type": "color"
           }
         },
         "light": {
           "alpha": {
             "50": {
-              "$type": "color",
-              "$value": "#ffffff0d"
+              "value": "#ffffff0d",
+              "type": "color"
             },
             "100": {
-              "$type": "color",
-              "$value": "#ffffff1a"
+              "value": "#ffffff1a",
+              "type": "color"
             }
           }
         },
         "dark": {
           "alpha": {
             "50": {
-              "$type": "color",
-              "$value": "#0000000d"
+              "value": "#0000000d",
+              "type": "color"
             },
             "100": {
-              "$type": "color",
-              "$value": "#0000001a"
+              "value": "#0000001a",
+              "type": "color"
             }
           }
         }
@@ -526,389 +526,389 @@
       "space": {
         "inline": {
           "flea": {
-            "$type": "spacing",
-            "$value": "2px"
+            "value": "2px",
+            "type": "spacing"
           },
           "ant": {
-            "$type": "spacing",
-            "$value": "4px"
+            "value": "4px",
+            "type": "spacing"
           },
           "beetle": {
-            "$type": "spacing",
-            "$value": "8px"
+            "value": "8px",
+            "type": "spacing"
           },
           "snail": {
-            "$type": "spacing",
-            "$value": "12px"
+            "value": "12px",
+            "type": "spacing"
           },
           "mouse": {
-            "$type": "spacing",
-            "$value": "16px"
+            "value": "16px",
+            "type": "spacing"
           },
           "rat": {
-            "$type": "spacing",
-            "$value": "20px"
+            "value": "20px",
+            "type": "spacing"
           },
           "rabbit": {
-            "$type": "spacing",
-            "$value": "24px"
+            "value": "24px",
+            "type": "spacing"
           },
           "cat": {
-            "$type": "spacing",
-            "$value": "28px"
+            "value": "28px",
+            "type": "spacing"
           },
           "dog": {
-            "$type": "spacing",
-            "$value": "32px"
+            "value": "32px",
+            "type": "spacing"
           },
           "pig": {
-            "$type": "spacing",
-            "$value": "48px"
+            "value": "48px",
+            "type": "spacing"
           }
         },
         "block": {
           "flea": {
-            "$type": "spacing",
-            "$value": "2px"
+            "value": "2px",
+            "type": "spacing"
           },
           "ant": {
-            "$type": "spacing",
-            "$value": "4px"
+            "value": "4px",
+            "type": "spacing"
           },
           "beetle": {
-            "$type": "spacing",
-            "$value": "8px"
+            "value": "8px",
+            "type": "spacing"
           },
           "snail": {
-            "$type": "spacing",
-            "$value": "12px"
+            "value": "12px",
+            "type": "spacing"
           },
           "mouse": {
-            "$type": "spacing",
-            "$value": "16px"
+            "value": "16px",
+            "type": "spacing"
           },
           "rat": {
-            "$type": "spacing",
-            "$value": "20px"
+            "value": "20px",
+            "type": "spacing"
           },
           "rabbit": {
-            "$type": "spacing",
-            "$value": "24px"
+            "value": "24px",
+            "type": "spacing"
           },
           "cat": {
-            "$type": "spacing",
-            "$value": "32px"
+            "value": "32px",
+            "type": "spacing"
           },
           "dog": {
-            "$type": "spacing",
-            "$value": "48px"
+            "value": "48px",
+            "type": "spacing"
           },
           "pig": {
-            "$type": "spacing",
-            "$value": "64px"
+            "value": "64px",
+            "type": "spacing"
           }
         },
         "text": {
           "flea": {
-            "$type": "spacing",
-            "$value": "1px",
-            "$description": "0.125ch"
+            "value": "1px",
+            "description": "0.125ch",
+            "type": "spacing"
           },
           "ant": {
-            "$type": "spacing",
-            "$value": "2px",
-            "$description": "0.25ch"
+            "value": "2px",
+            "description": "0.25ch",
+            "type": "spacing"
           },
           "beetle": {
-            "$type": "spacing",
-            "$value": "4px",
-            "$description": "0.5ch"
+            "value": "4px",
+            "description": "0.5ch",
+            "type": "spacing"
           },
           "snail": {
-            "$type": "spacing",
-            "$value": "6px",
-            "$description": "0.75ch"
+            "value": "6px",
+            "description": "0.75ch",
+            "type": "spacing"
           },
           "mouse": {
-            "$type": "spacing",
-            "$value": "8px",
-            "$description": "1ch"
+            "value": "8px",
+            "description": "1ch",
+            "type": "spacing"
           },
           "rat": {
-            "$type": "spacing",
-            "$value": "12px",
-            "$description": "1.5ch"
+            "value": "12px",
+            "description": "1.5ch",
+            "type": "spacing"
           },
           "rabbit": {
-            "$type": "spacing",
-            "$value": "14px",
-            "$description": "1.75ch"
+            "value": "14px",
+            "description": "1.75ch",
+            "type": "spacing"
           },
           "cat": {
-            "$type": "spacing",
-            "$value": "16px",
-            "$description": "2ch"
+            "value": "16px",
+            "description": "2ch",
+            "type": "spacing"
           },
           "dog": {
-            "$type": "spacing",
-            "$value": "24px",
-            "$description": "3ch"
+            "value": "24px",
+            "description": "3ch",
+            "type": "spacing"
           }
         },
         "column": {
           "flea": {
-            "$type": "spacing",
-            "$value": "1px"
+            "value": "1px",
+            "type": "spacing"
           },
           "ant": {
-            "$type": "spacing",
-            "$value": "2px"
+            "value": "2px",
+            "type": "spacing"
           },
           "beetle": {
-            "$type": "spacing",
-            "$value": "4px"
+            "value": "4px",
+            "type": "spacing"
           },
           "snail": {
-            "$type": "spacing",
-            "$value": "8px"
+            "value": "8px",
+            "type": "spacing"
           },
           "mouse": {
-            "$type": "spacing",
-            "$value": "12px"
+            "value": "12px",
+            "type": "spacing"
           },
           "rat": {
-            "$type": "spacing",
-            "$value": "16px"
+            "value": "16px",
+            "type": "spacing"
           },
           "rabbit": {
-            "$type": "spacing",
-            "$value": "20px"
+            "value": "20px",
+            "type": "spacing"
           },
           "cat": {
-            "$type": "spacing",
-            "$value": "24px"
+            "value": "24px",
+            "type": "spacing"
           },
           "dog": {
-            "$type": "spacing",
-            "$value": "28px"
+            "value": "28px",
+            "type": "spacing"
           },
           "pig": {
-            "$type": "spacing",
-            "$value": "32px"
+            "value": "32px",
+            "type": "spacing"
           },
           "tiger": {
-            "$type": "spacing",
-            "$value": "48px"
+            "value": "48px",
+            "type": "spacing"
           },
           "horse": {
-            "$type": "spacing",
-            "$value": "64px"
+            "value": "64px",
+            "type": "spacing"
           },
           "elephant": {
-            "$type": "spacing",
-            "$value": "96px"
+            "value": "96px",
+            "type": "spacing"
           },
           "giraffe": {
-            "$type": "spacing",
-            "$value": "160px"
+            "value": "160px",
+            "type": "spacing"
           }
         },
         "row": {
           "flea": {
-            "$type": "spacing",
-            "$value": "1px"
+            "value": "1px",
+            "type": "spacing"
           },
           "ant": {
-            "$type": "spacing",
-            "$value": "2px"
+            "value": "2px",
+            "type": "spacing"
           },
           "beetle": {
-            "$type": "spacing",
-            "$value": "4px"
+            "value": "4px",
+            "type": "spacing"
           },
           "snail": {
-            "$type": "spacing",
-            "$value": "8px"
+            "value": "8px",
+            "type": "spacing"
           },
           "mouse": {
-            "$type": "spacing",
-            "$value": "12px"
+            "value": "12px",
+            "type": "spacing"
           },
           "rat": {
-            "$type": "spacing",
-            "$value": "16px"
+            "value": "16px",
+            "type": "spacing"
           },
           "rabbit": {
-            "$type": "spacing",
-            "$value": "20px"
+            "value": "20px",
+            "type": "spacing"
           },
           "cat": {
-            "$type": "spacing",
-            "$value": "24px"
+            "value": "24px",
+            "type": "spacing"
           },
           "dog": {
-            "$type": "spacing",
-            "$value": "28px"
+            "value": "28px",
+            "type": "spacing"
           },
           "pig": {
-            "$type": "spacing",
-            "$value": "32px"
+            "value": "32px",
+            "type": "spacing"
           },
           "tiger": {
-            "$type": "spacing",
-            "$value": "48px"
+            "value": "48px",
+            "type": "spacing"
           },
           "horse": {
-            "$type": "spacing",
-            "$value": "64px"
+            "value": "64px",
+            "type": "spacing"
           },
           "elephant": {
-            "$type": "spacing",
-            "$value": "96px"
+            "value": "96px",
+            "type": "spacing"
           },
           "giraffe": {
-            "$type": "spacing",
-            "$value": "160px"
+            "value": "160px",
+            "type": "spacing"
           }
         }
       },
       "border-radius": {
         "sm": {
-          "$type": "borderRadius",
-          "$value": "4px"
+          "value": "4px",
+          "type": "borderRadius"
         },
         "md": {
-          "$type": "borderRadius",
-          "$value": "8px"
+          "value": "8px",
+          "type": "borderRadius"
         },
         "lg": {
-          "$type": "borderRadius",
-          "$value": "16px"
+          "value": "16px",
+          "type": "borderRadius"
         },
         "round": {
-          "$type": "borderRadius",
-          "$value": "999px"
+          "value": "999px",
+          "type": "borderRadius"
         }
       },
       "border-width": {
         "sm": {
-          "$type": "borderWidth",
-          "$value": "1px"
+          "value": "1px",
+          "type": "borderWidth"
         },
         "md": {
-          "$type": "borderWidth",
-          "$value": "2px"
+          "value": "2px",
+          "type": "borderWidth"
         },
         "lg": {
-          "$type": "borderWidth",
-          "$value": "4px"
+          "value": "4px",
+          "type": "borderWidth"
         }
       },
       "size": {
         "5xs": {
-          "$type": "sizing",
-          "$value": "2px"
+          "value": "2px",
+          "type": "sizing"
         },
         "4xs": {
-          "$type": "sizing",
-          "$value": "4px"
+          "value": "4px",
+          "type": "sizing"
         },
         "3xs": {
-          "$type": "sizing",
-          "$value": "8px"
+          "value": "8px",
+          "type": "sizing"
         },
         "2xs": {
-          "$type": "sizing",
-          "$value": "16px"
+          "value": "16px",
+          "type": "sizing"
         },
         "xs": {
-          "$type": "sizing",
-          "$value": "24px"
+          "value": "24px",
+          "type": "sizing"
         },
         "sm": {
-          "$type": "sizing",
-          "$value": "32px"
+          "value": "32px",
+          "type": "sizing"
         },
         "md": {
-          "$type": "sizing",
-          "$value": "48px"
+          "value": "48px",
+          "type": "sizing"
         },
         "lg": {
-          "$type": "sizing",
-          "$value": "64px"
+          "value": "64px",
+          "type": "sizing"
         },
         "xl": {
-          "$type": "sizing",
-          "$value": "96px"
+          "value": "96px",
+          "type": "sizing"
         },
         "2xl": {
-          "$type": "sizing",
-          "$value": "160px"
+          "value": "160px",
+          "type": "sizing"
         },
         "icon": {
           "sm": {
-            "$type": "sizing",
-            "$value": "16px"
+            "value": "16px",
+            "type": "sizing"
           },
           "md": {
-            "$type": "sizing",
-            "$value": "24px"
+            "value": "24px",
+            "type": "sizing"
           },
           "lg": {
-            "$type": "sizing",
-            "$value": "24px"
+            "value": "24px",
+            "type": "sizing"
           },
           "xl": {
-            "$type": "sizing",
-            "$value": "24px"
+            "value": "24px",
+            "type": "sizing"
           },
           "2xl": {
-            "$type": "sizing",
-            "$value": "32px"
+            "value": "32px",
+            "type": "sizing"
           },
           "3xl": {
-            "$type": "sizing",
-            "$value": "40px"
+            "value": "40px",
+            "type": "sizing"
           },
           "4xl": {
-            "$type": "sizing",
-            "$value": "48px"
+            "value": "48px",
+            "type": "sizing"
           }
         }
       },
       "box-shadow": {
         "sm": {
-          "$type": "boxShadow",
-          "$value": {
+          "value": {
             "x": "0",
             "y": "2",
             "blur": "6",
             "spread": "0",
             "color": "{voorbeeld.color.dark.alpha.100}",
             "type": "dropShadow"
-          }
+          },
+          "type": "boxShadow"
         },
         "md": {
-          "$type": "boxShadow",
-          "$value": {
+          "value": {
             "x": "0",
             "y": "8",
             "blur": "16",
             "spread": "0",
             "color": "{voorbeeld.color.dark.alpha.100}",
             "type": "dropShadow"
-          }
+          },
+          "type": "boxShadow"
         },
         "lg": {
-          "$type": "boxShadow",
-          "$value": {
+          "value": {
             "x": "0",
             "y": "16",
             "blur": "48",
             "spread": "0",
             "color": "{voorbeeld.color.dark.alpha.100}",
             "type": "dropShadow"
-          }
+          },
+          "type": "boxShadow"
         }
       }
     }
@@ -917,223 +917,223 @@
     "utrecht": {
       "document": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.white}"
+          "value": "{voorbeeld.color.white}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.900}"
+          "value": "{voorbeeld.color.gray.900}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{voorbeeld.typography.font-family.secondary}"
+          "value": "{voorbeeld.typography.font-family.secondary}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.md}"
+          "value": "{voorbeeld.typography.font-size.md}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.typography.font-weight.normal}"
+          "value": "{voorbeeld.typography.font-weight.normal}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{voorbeeld.typography.line-height.md}"
+          "value": "{voorbeeld.typography.line-height.md}",
+          "type": "lineHeights"
         }
       },
       "heading": {
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{voorbeeld.typography.font-family.primary}"
+          "value": "{voorbeeld.typography.font-family.primary}",
+          "type": "fontFamilies"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.typography.font-weight.bold}"
+          "value": "{voorbeeld.typography.font-weight.bold}",
+          "type": "fontWeights"
         },
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.900}"
+          "value": "{voorbeeld.color.gray.900}",
+          "type": "color"
         }
       },
       "form-control": {
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.typography.font-weight.normal}"
+          "value": "{voorbeeld.typography.font-weight.normal}",
+          "type": "fontWeights"
         },
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.white}"
+          "value": "{voorbeeld.color.white}",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.500}"
+          "value": "{voorbeeld.color.gray.500}",
+          "type": "color"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.950}"
+          "value": "{voorbeeld.color.gray.950}",
+          "type": "color"
         },
         "disabled": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.50}"
+            "value": "{voorbeeld.color.gray.50}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
           }
         },
         "focus": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.black}"
+            "value": "{voorbeeld.color.black}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.black}"
+            "value": "{voorbeeld.color.black}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
           }
         },
         "invalid": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.negative.border-color}"
+            "value": "{voorbeeld.feedback.negative.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.negative.color}"
+            "value": "{voorbeeld.feedback.negative.color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
           }
         },
         "read-only": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.50}"
+            "value": "{voorbeeld.color.gray.50}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.950}"
+            "value": "{voorbeeld.color.gray.950}",
+            "type": "color"
           }
         },
         "placeholder": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.600}"
+            "value": "{voorbeeld.color.gray.600}",
+            "type": "color"
           }
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "0px"
+          "value": "0px",
+          "type": "borderRadius"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{voorbeeld.typography.font-family.secondary}"
+          "value": "{voorbeeld.typography.font-family.secondary}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.md}"
+          "value": "{voorbeeld.typography.font-size.md}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{voorbeeld.typography.line-height.md}"
+          "value": "{voorbeeld.typography.line-height.md}",
+          "type": "lineHeights"
         },
         "max-inline-size": {
-          "$type": "sizing",
-          "$value": "400px"
+          "value": "400px",
+          "type": "sizing"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "value": "{voorbeeld.space.inline.snail}",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "value": "{voorbeeld.space.inline.snail}",
+          "type": "spacing"
         }
       },
       "focus": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.yellow.200}"
+          "value": "{voorbeeld.color.yellow.200}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.black}"
+          "value": "{voorbeeld.color.black}",
+          "type": "color"
         },
         "outline-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.violet.700}"
+          "value": "{voorbeeld.color.violet.700}",
+          "type": "color"
         },
         "inverse": {
           "outline-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
           }
         },
         "outline-offset": {
-          "$type": "other",
-          "$value": "0"
+          "value": "0",
+          "type": "other"
         },
         "outline-style": {
-          "$type": "other",
-          "$value": "dotted"
+          "value": "dotted",
+          "type": "other"
         },
         "outline-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.md}"
+          "value": "{voorbeeld.border-width.md}",
+          "type": "borderWidth"
         }
       },
       "pointer-target": {
         "min-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.md}"
+          "value": "{voorbeeld.size.md}",
+          "type": "sizing"
         }
       },
       "feedback": {
         "warning": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.yellow.100}"
+            "value": "{voorbeeld.color.yellow.100}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.yellow.600}"
+            "value": "{voorbeeld.color.yellow.600}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.yellow.600}"
+            "value": "{voorbeeld.color.yellow.600}",
+            "type": "color"
           }
         }
       }
@@ -1141,218 +1141,218 @@
     "voorbeeld": {
       "root": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.50}"
+          "value": "{voorbeeld.color.gray.50}",
+          "type": "color"
         }
       },
       "container": {
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.300}"
+          "value": "{voorbeeld.color.gray.300}",
+          "type": "color"
         }
       },
       "line": {
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.300}"
+          "value": "{voorbeeld.color.gray.300}",
+          "type": "color"
         }
       },
       "form-control": {
         "active": {
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
           },
           "accent-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.active.color}"
+            "value": "{voorbeeld.interaction.active.color}",
+            "type": "color"
           },
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.100}"
+            "value": "{voorbeeld.color.gray.100}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.950}"
+            "value": "{voorbeeld.color.gray.950}",
+            "type": "color"
           }
         },
         "hover": {
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
           },
           "accent-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.hover.color}"
+            "value": "{voorbeeld.interaction.hover.color}",
+            "type": "color"
           },
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.50}"
+            "value": "{voorbeeld.color.gray.50}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.950}"
+            "value": "{voorbeeld.color.gray.950}",
+            "type": "color"
           }
         },
         "accent-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.interaction.color}"
+          "value": "{voorbeeld.interaction.color}",
+          "type": "color"
         },
         "disabled": {
           "accent-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
           }
         }
       },
       "document": {
         "inverse": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.950}"
+            "value": "{voorbeeld.color.gray.950}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
           }
         },
         "subtle": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.600}"
+            "value": "{voorbeeld.color.gray.600}",
+            "type": "color"
           }
         },
         "strong": {
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.typography.font-weight.bold}"
+            "value": "{voorbeeld.typography.font-weight.bold}",
+            "type": "fontWeights"
           }
         }
       },
       "interaction": {
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.violet.700}"
+          "value": "{voorbeeld.color.violet.700}",
+          "type": "color"
         },
         "active": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.violet.900}"
+            "value": "{voorbeeld.color.violet.900}",
+            "type": "color"
           }
         },
         "hover": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.violet.800}"
+            "value": "{voorbeeld.color.violet.800}",
+            "type": "color"
           }
         }
       },
       "icon": {
         "functional": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.size.icon.md}"
+            "value": "{voorbeeld.size.icon.md}",
+            "type": "sizing"
           }
         },
         "toptask": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.size.icon.4xl}"
+            "value": "{voorbeeld.size.icon.4xl}",
+            "type": "sizing"
           }
         }
       },
       "feedback": {
         "informative": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.blue.100}"
+            "value": "{voorbeeld.color.blue.100}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.blue.600}"
+            "value": "{voorbeeld.color.blue.600}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.blue.600}"
+            "value": "{voorbeeld.color.blue.600}",
+            "type": "color"
           }
         },
         "negative": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.red.100}"
+            "value": "{voorbeeld.color.red.100}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.red.600}"
+            "value": "{voorbeeld.color.red.600}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.red.600}"
+            "value": "{voorbeeld.color.red.600}",
+            "type": "color"
           }
         },
         "positive": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.green.100}"
+            "value": "{voorbeeld.color.green.100}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.green.600}"
+            "value": "{voorbeeld.color.green.600}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.green.600}"
+            "value": "{voorbeeld.color.green.600}",
+            "type": "color"
           }
         }
       },
       "space": {
         "relation": {
           "kind": {
-            "$type": "dimension",
-            "$value": "0px"
+            "value": "0px",
+            "type": "dimension"
           },
           "besties": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.row.snail}"
+            "value": "{voorbeeld.space.row.snail}",
+            "type": "dimension"
           },
           "vrienden": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.row.rat}"
+            "value": "{voorbeeld.space.row.rat}",
+            "type": "dimension"
           },
           "bekenden": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.row.cat}"
+            "value": "{voorbeeld.space.row.cat}",
+            "type": "dimension"
           },
           "onbekenden": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.row.pig}"
+            "value": "{voorbeeld.space.row.pig}",
+            "type": "dimension"
           },
           "onbemind": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.row.horse}"
+            "value": "{voorbeeld.space.row.horse}",
+            "type": "dimension"
           }
         }
       },
       "code": {
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{voorbeeld.typography.font-family.code}"
+          "value": "{voorbeeld.typography.font-family.code}",
+          "type": "fontFamilies"
         }
       }
     }
@@ -1362,118 +1362,118 @@
       "accordion": {
         "panel": {
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.rabbit}"
+            "value": "{voorbeeld.space.block.rabbit}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.rabbit}"
+            "value": "{voorbeeld.space.block.rabbit}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           }
         },
         "button": {
           "gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.text.mouse}"
+            "value": "{voorbeeld.space.text.mouse}",
+            "type": "spacing"
           },
           "icon": {
             "size": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.icon.functional.size}"
+              "value": "{voorbeeld.icon.functional.size}",
+              "type": "sizing"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.50}"
+            "value": "{voorbeeld.color.gray.50}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           },
           "hover": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.100}"
+              "value": "{voorbeeld.color.gray.100}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             }
           },
           "focus": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.background-color}"
+              "value": "{utrecht.focus.background-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "value": "{utrecht.focus.color}",
+              "type": "color"
             }
           },
           "active": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.200}"
+              "value": "{voorbeeld.color.gray.200}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}",
+              "type": "color"
             }
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           },
           "border-radius": {
-            "$type": "borderRadius",
-            "$value": "0px"
+            "value": "0px",
+            "type": "borderRadius"
           }
         }
       }
@@ -1481,49 +1481,49 @@
     "todo": {
       "accordion": {
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "0px"
+          "value": "0px",
+          "type": "borderRadius"
         },
         "section": {
           "border-block-end-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           }
         },
         "button": {
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           },
           "expanded": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.50}"
+              "value": "{voorbeeld.color.gray.50}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.color}"
+              "value": "{voorbeeld.interaction.color}",
+              "type": "color"
             }
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           }
         }
       }
@@ -1533,167 +1533,167 @@
     "denhaag": {
       "action": {
         "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.document.background-color}"
+          "value": "{utrecht.document.background-color}",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.line.border-color}"
+          "value": "{voorbeeld.line.border-color}",
+          "type": "color"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.line.border-width}"
+          "value": "{voorbeeld.line.border-width}",
+          "type": "borderWidth"
         },
         "border-style": {
-          "$type": "other",
-          "$value": "solid"
+          "value": "solid",
+          "type": "other"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "font-familiy": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
+          "value": "{voorbeeld.document.strong.font-weight}",
+          "type": "fontWeights"
         },
         "gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.row.snail}"
+          "value": "{voorbeeld.space.row.snail}",
+          "type": "spacing"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.mouse}"
+          "value": "{voorbeeld.space.block.mouse}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.mouse}"
+          "value": "{voorbeeld.space.block.mouse}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "lg": {
           "gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.column.rat}"
+            "value": "{voorbeeld.space.column.rat}",
+            "type": "spacing"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.mouse}"
+            "value": "{voorbeeld.space.block.mouse}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.mouse}"
+            "value": "{voorbeeld.space.block.mouse}",
+            "type": "spacing"
           }
         },
         "date": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           },
           "gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.row.snail}"
+            "value": "{voorbeeld.space.row.snail}",
+            "type": "spacing"
           },
           "warning": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.negative.color}"
+              "value": "{voorbeeld.feedback.negative.color}",
+              "type": "color"
             },
             "gap": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.row.snail}"
+              "value": "{voorbeeld.space.row.snail}",
+              "type": "spacing"
             },
             "font-weight": {
-              "$type": "fontWeights",
-              "$value": "{voorbeeld.document.strong.font-weight}"
+              "value": "{voorbeeld.document.strong.font-weight}",
+              "type": "fontWeights"
             }
           }
         },
         "content": {
           "bold": {
             "font-weight": {
-              "$type": "fontWeights",
-              "$value": "{voorbeeld.document.strong.font-weight}"
+              "value": "{voorbeeld.document.strong.font-weight}",
+              "type": "fontWeights"
             }
           }
         },
         "details": {
           "gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.row.snail}"
+            "value": "{voorbeeld.space.row.snail}",
+            "type": "spacing"
           },
           "lg": {
             "gap": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.column.rat}"
+              "value": "{voorbeeld.space.column.rat}",
+              "type": "spacing"
             }
           }
         },
         "link": {
           "icon": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.color}"
+              "value": "{voorbeeld.interaction.color}",
+              "type": "color"
             },
             "width": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.icon.functional.size}"
+              "value": "{voorbeeld.icon.functional.size}",
+              "type": "sizing"
             }
           }
         },
         "single": {
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "hover": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.100}"
+              "value": "{voorbeeld.color.gray.100}",
+              "type": "color"
             }
           },
           "details": {
             "gap": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.row.snail}"
+              "value": "{voorbeeld.space.row.snail}",
+              "type": "spacing"
             },
             "lg": {
               "gap": {
-                "$type": "spacing",
-                "$value": "{voorbeeld.space.column.snail}"
+                "value": "{voorbeeld.space.column.snail}",
+                "type": "spacing"
               }
             }
           }
@@ -1701,12 +1701,12 @@
         "warning": {
           "icon": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.negative.color}"
+              "value": "{voorbeeld.feedback.negative.color}",
+              "type": "color"
             },
             "width": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.icon.functional.size}"
+              "value": "{voorbeeld.icon.functional.size}",
+              "type": "sizing"
             }
           }
         }
@@ -1717,148 +1717,148 @@
     "utrecht": {
       "alert": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.feedback.informative.background-color}"
+          "value": "{voorbeeld.feedback.informative.background-color}",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.feedback.informative.border-color}"
+          "value": "{voorbeeld.feedback.informative.border-color}",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "0px"
+          "value": "0px",
+          "type": "borderRadius"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.md}"
+          "value": "{voorbeeld.border-width.md}",
+          "type": "borderWidth"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "column-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.column.snail}"
+          "value": "{voorbeeld.space.column.snail}",
+          "type": "spacing"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.rat}"
+          "value": "{voorbeeld.space.block.rat}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.mouse}"
+          "value": "{voorbeeld.space.block.mouse}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "content": {
           "row-gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.row.rat}"
+            "value": "{voorbeeld.space.row.rat}",
+            "type": "spacing"
           }
         },
         "message": {
           "row-gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.row.snail}"
+            "value": "{voorbeeld.space.row.snail}",
+            "type": "spacing"
           }
         },
         "info": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.informative.background-color}"
+            "value": "{voorbeeld.feedback.informative.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.informative.border-color}"
+            "value": "{voorbeeld.feedback.informative.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           }
         },
         "error": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.negative.background-color}"
+            "value": "{voorbeeld.feedback.negative.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.negative.border-color}"
+            "value": "{voorbeeld.feedback.negative.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           }
         },
         "ok": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.positive.background-color}"
+            "value": "{voorbeeld.feedback.positive.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.positive.border-color}"
+            "value": "{voorbeeld.feedback.positive.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           }
         },
         "warning": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.feedback.warning.background-color}"
+            "value": "{utrecht.feedback.warning.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.feedback.warning.border-color}"
+            "value": "{utrecht.feedback.warning.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           }
         },
         "icon": {
           "inset-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.flea}"
+            "value": "{voorbeeld.space.block.flea}",
+            "type": "spacing"
           },
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.informative.color}"
+            "value": "{voorbeeld.feedback.informative.color}",
+            "type": "color"
           },
           "info": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.informative.color}"
+              "value": "{voorbeeld.feedback.informative.color}",
+              "type": "color"
             }
           },
           "error": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.negative.color}"
+              "value": "{voorbeeld.feedback.negative.color}",
+              "type": "color"
             }
           },
           "ok": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.positive.color}"
+              "value": "{voorbeeld.feedback.positive.color}",
+              "type": "color"
             }
           },
           "warning": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.feedback.warning.color}"
+              "value": "{utrecht.feedback.warning.color}",
+              "type": "color"
             }
           }
         }
@@ -1868,20 +1868,20 @@
       "alert": {
         "heading": {
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.heading.font-family}"
+            "value": "{utrecht.heading.font-family}",
+            "type": "fontFamilies"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.heading.font-weight}"
+            "value": "{utrecht.heading.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.sm}"
+            "value": "{voorbeeld.typography.line-height.sm}",
+            "type": "lineHeights"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.xl}"
+            "value": "{voorbeeld.typography.font-size.xl}",
+            "type": "fontSizes"
           }
         }
       }
@@ -1891,69 +1891,69 @@
     "todo": {
       "avatar": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.interaction.color}"
+          "value": "{voorbeeld.interaction.color}",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{voorbeeld.border-radius.round}"
+          "value": "{voorbeeld.border-radius.round}",
+          "type": "borderRadius"
         },
         "size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "icon": {
           "icon-size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           }
         },
         "border-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "value": "transparent",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.white}"
+          "value": "{voorbeeld.color.white}",
+          "type": "color"
         },
         "text": {
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           },
           "text-transform": {
-            "$type": "textCase",
-            "$value": "uppercase"
+            "value": "uppercase",
+            "type": "textCase"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           }
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "hover": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.hover.color}"
+            "value": "{voorbeeld.interaction.hover.color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
           }
         }
       }
@@ -1963,31 +1963,31 @@
     "utrecht": {
       "backdrop": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.black}"
+          "value": "{voorbeeld.color.black}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.white}"
+          "value": "{voorbeeld.color.white}",
+          "type": "color"
         },
         "opacity": {
-          "$type": "opacity",
-          "$value": "0.2"
+          "value": "0.2",
+          "type": "opacity"
         },
         "reduced-transparency": {
           "opacity": {
-            "$type": "opacity",
-            "$value": "0.98"
+            "value": "0.98",
+            "type": "opacity"
           }
         },
         "z-index": {
-          "$type": "other",
-          "$value": "auto"
+          "value": "auto",
+          "type": "other"
         },
         "fade-in": {
           "animation-duration": {
-            "$type": "other",
-            "$value": "0.4s"
+            "value": "0.4s",
+            "type": "other"
           }
         }
       }
@@ -1997,43 +1997,43 @@
     "utrecht": {
       "blockquote": {
         "background-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "value": "transparent",
+          "type": "color"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "0px"
+          "value": "0px",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "0px"
+          "value": "0px",
+          "type": "spacing"
         },
         "attribution": {
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.sm}"
+            "value": "{voorbeeld.typography.font-size.sm}",
+            "type": "fontSizes"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.document.subtle.color}"
+            "value": "{voorbeeld.document.subtle.color}",
+            "type": "color"
           }
         },
         "content": {
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.xl}"
+            "value": "{voorbeeld.typography.font-size.xl}",
+            "type": "fontSizes"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           }
         }
       }
@@ -2041,35 +2041,35 @@
     "todo": {
       "blockquote": {
         "row-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.row.snail}"
+          "value": "{voorbeeld.space.row.snail}",
+          "type": "spacing"
         },
         "attribution": {
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.md}"
+            "value": "{voorbeeld.typography.line-height.md}",
+            "type": "lineHeights"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           }
         },
         "content": {
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.heading.font-family}"
+            "value": "{utrecht.heading.font-family}",
+            "type": "fontFamilies"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.sm}"
+            "value": "{voorbeeld.typography.line-height.sm}",
+            "type": "lineHeights"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           }
         }
       }
@@ -2079,216 +2079,216 @@
     "todo": {
       "breadcrumb-nav": {
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "link": {
           "icon": {
             "size": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.icon.functional.size}"
+              "value": "{voorbeeld.icon.functional.size}",
+              "type": "sizing"
             },
             "column-gap": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.text.beetle}"
+              "value": "{voorbeeld.space.text.beetle}",
+              "type": "spacing"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           },
           "active": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}",
+              "type": "color"
             },
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
+              "value": "None",
+              "type": "textDecoration"
             }
           },
           "focus": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.background-color}"
+              "value": "{utrecht.focus.background-color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "value": "{utrecht.focus.color}",
+              "type": "color"
             },
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
+              "value": "None",
+              "type": "textDecoration"
             }
           },
           "hover": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             },
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
+              "value": "None",
+              "type": "textDecoration"
             }
           },
           "current": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.document.subtle.color}"
+              "value": "{voorbeeld.document.subtle.color}",
+              "type": "color"
             }
           },
           "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "underline"
+            "value": "underline",
+            "type": "textDecoration"
           }
         },
         "separator": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.size.2xs}"
+            "value": "{voorbeeld.size.2xs}",
+            "type": "sizing"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.document.subtle.color}"
+            "value": "{voorbeeld.document.subtle.color}",
+            "type": "color"
           }
         },
         "column-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.column.snail}"
+          "value": "{voorbeeld.space.column.snail}",
+          "type": "spacing"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
+          "value": "{utrecht.document.font-weight}",
+          "type": "fontWeights"
         }
       }
     },
     "utrecht": {
       "breadcrumb-nav": {
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "item": {
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.beetle}"
+            "value": "{voorbeeld.space.inline.beetle}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.beetle}"
+            "value": "{voorbeeld.space.inline.beetle}",
+            "type": "spacing"
           }
         },
         "link": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           },
           "focus": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.background-color}"
+              "value": "{utrecht.focus.background-color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "value": "{utrecht.focus.color}",
+              "type": "color"
             },
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
+              "value": "None",
+              "type": "textDecoration"
             }
           },
           "hover": {
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
+              "value": "None",
+              "type": "textDecoration"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             }
           },
           "disabled": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.500}"
+              "value": "{voorbeeld.color.gray.500}",
+              "type": "color"
             }
           },
           "current": {
             "font-weight": {
-              "$type": "fontWeights",
-              "$value": "{utrecht.document.font-weight}"
+              "value": "{utrecht.document.font-weight}",
+              "type": "fontWeights"
             }
           },
           "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "underline"
+            "value": "underline",
+            "type": "textDecoration"
           },
           "active": {
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
+              "value": "None",
+              "type": "textDecoration"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}",
+              "type": "color"
             }
           }
         },
         "separator": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.document.subtle.color}"
+            "value": "{voorbeeld.document.subtle.color}",
+            "type": "color"
           },
           "icon": {
             "size": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.size.2xs}"
+              "value": "{voorbeeld.size.2xs}",
+              "type": "sizing"
             }
           }
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         }
       }
     }
@@ -2297,375 +2297,375 @@
     "utrecht": {
       "button": {
         "background-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "value": "transparent",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.900}"
+          "value": "{voorbeeld.color.gray.900}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.900}"
+          "value": "{voorbeeld.color.gray.900}",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{voorbeeld.border-radius.md}"
+          "value": "{voorbeeld.border-radius.md}",
+          "type": "borderRadius"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "icon": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           }
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
+          "value": "{voorbeeld.document.strong.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "disabled": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.50}"
+            "value": "{voorbeeld.color.gray.50}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
           }
         },
         "focus": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.background-color}"
+            "value": "{utrecht.focus.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.color}"
+            "value": "{utrecht.focus.color}",
+            "type": "color"
           }
         },
         "hover": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.50}"
+            "value": "{voorbeeld.color.gray.50}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.hover.color}"
+            "value": "{voorbeeld.interaction.hover.color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.hover.color}"
+            "value": "{voorbeeld.interaction.hover.color}",
+            "type": "color"
           }
         },
         "active": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.100}"
+            "value": "{voorbeeld.color.gray.100}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.active.color}"
+            "value": "{voorbeeld.interaction.active.color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.active.color}"
+            "value": "{voorbeeld.interaction.active.color}",
+            "type": "color"
           }
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "min-inline-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "column-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.text.beetle}"
+          "value": "{voorbeeld.space.text.beetle}",
+          "type": "spacing"
         },
         "primary-action": {
           "hover": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             }
           },
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
           },
           "disabled": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.50}"
+              "value": "{voorbeeld.color.gray.50}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.500}"
+              "value": "{voorbeeld.color.gray.500}",
+              "type": "color"
             }
           },
           "focus": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.background-color}"
+              "value": "{utrecht.focus.background-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "value": "{utrecht.focus.color}",
+              "type": "color"
             }
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           },
           "active": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             }
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           }
         },
         "secondary-action": {
           "hover": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.50}"
+              "value": "{voorbeeld.color.gray.50}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             }
           },
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           },
           "disabled": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.50}"
+              "value": "{voorbeeld.color.gray.50}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.500}"
+              "value": "{voorbeeld.color.gray.500}",
+              "type": "color"
             }
           },
           "focus": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.background-color}"
+              "value": "{utrecht.focus.background-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "value": "{utrecht.focus.color}",
+              "type": "color"
             }
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           },
           "active": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.100}"
+              "value": "{voorbeeld.color.gray.100}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}",
+              "type": "color"
             }
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           }
         },
         "subtle": {
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           },
           "hover": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.dark.alpha.50}"
+              "value": "{voorbeeld.color.dark.alpha.50}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             }
           },
           "background-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           },
           "disabled": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.50}"
+              "value": "{voorbeeld.color.gray.50}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.500}"
+              "value": "{voorbeeld.color.gray.500}",
+              "type": "color"
             }
           },
           "focus": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.background-color}"
+              "value": "{utrecht.focus.background-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "value": "{utrecht.focus.color}",
+              "type": "color"
             }
           },
           "active": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.dark.alpha.100}"
+              "value": "{voorbeeld.color.dark.alpha.100}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}",
+              "type": "color"
             }
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           }
         }
       }
@@ -2675,24 +2675,24 @@
     "utrecht": {
       "button-group": {
         "background-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "value": "transparent",
+          "type": "color"
         },
         "column-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.column.snail}"
+          "value": "{voorbeeld.space.column.snail}",
+          "type": "spacing"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "0px"
+          "value": "0px",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "0px"
+          "value": "0px",
+          "type": "spacing"
         },
         "row-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.row.snail}"
+          "value": "{voorbeeld.space.row.snail}",
+          "type": "spacing"
         }
       }
     }
@@ -2702,157 +2702,157 @@
       "case-card": {
         "heading": {
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.sm}"
+            "value": "{voorbeeld.typography.line-height.sm}",
+            "type": "lineHeights"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.xl}"
+            "value": "{voorbeeld.typography.font-size.xl}",
+            "type": "fontSizes"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.heading.font-family}"
+            "value": "{utrecht.heading.font-family}",
+            "type": "fontFamilies"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.heading.font-weight}"
+            "value": "{utrecht.heading.font-weight}",
+            "type": "fontWeights"
           }
         },
         "row-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.row.mouse}"
+          "value": "{voorbeeld.space.row.mouse}",
+          "type": "spacing"
         },
         "padding-block": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.rat}"
+          "value": "{voorbeeld.space.block.rat}",
+          "type": "spacing"
         },
         "padding-inline": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.rabbit}"
+          "value": "{voorbeeld.space.inline.rabbit}",
+          "type": "spacing"
         },
         "icon": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           }
         },
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.violet.200}"
+          "value": "{voorbeeld.color.violet.200}",
+          "type": "color"
         },
         "read-only": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.100}"
+            "value": "{voorbeeld.color.gray.100}",
+            "type": "color"
           },
           "hover": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.200}"
+              "value": "{voorbeeld.color.gray.200}",
+              "type": "color"
             }
           },
           "active": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.300}"
+              "value": "{voorbeeld.color.gray.300}",
+              "type": "color"
             }
           }
         },
         "hover": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.violet.300}"
+            "value": "{voorbeeld.color.violet.300}",
+            "type": "color"
           }
         },
         "active": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.violet.400}"
+            "value": "{voorbeeld.color.violet.400}",
+            "type": "color"
           }
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "192px"
+          "value": "192px",
+          "type": "sizing"
         },
         "min-inline-size": {
-          "$type": "sizing",
-          "$value": "328px"
+          "value": "328px",
+          "type": "sizing"
         },
         "decoration": {
           "paper": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.document.background-color}"
+              "value": "{utrecht.document.background-color}",
+              "type": "color"
             }
           },
           "folder": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.violet.300}"
+              "value": "{voorbeeld.color.violet.300}",
+              "type": "color"
             },
             "read-only": {
               "background-color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.gray.200}"
+                "value": "{voorbeeld.color.gray.200}",
+                "type": "color"
               },
               "hover": {
                 "background-color": {
-                  "$type": "color",
-                  "$value": "{voorbeeld.color.gray.300}"
+                  "value": "{voorbeeld.color.gray.300}",
+                  "type": "color"
                 }
               },
               "active": {
                 "background-color": {
-                  "$type": "color",
-                  "$value": "{voorbeeld.color.gray.400}"
+                  "value": "{voorbeeld.color.gray.400}",
+                  "type": "color"
                 }
               }
             },
             "active": {
               "background-color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.violet.500}"
+                "value": "{voorbeeld.color.violet.500}",
+                "type": "color"
               }
             },
             "hover": {
               "background-color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.violet.400}"
+                "value": "{voorbeeld.color.violet.400}",
+                "type": "color"
               }
             },
             "focus": {
               "background-color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.yellow.300}"
+                "value": "{voorbeeld.color.yellow.300}",
+                "type": "color"
               }
             }
           }
         },
         "focus": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.background-color}"
+            "value": "{utrecht.focus.background-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.color}"
+            "value": "{utrecht.focus.color}",
+            "type": "color"
           }
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{voorbeeld.border-radius.sm}"
+          "value": "{voorbeeld.border-radius.sm}",
+          "type": "borderRadius"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         }
       }
     }
@@ -2861,131 +2861,131 @@
     "utrecht": {
       "checkbox": {
         "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.background-color}"
+          "value": "{utrecht.form-control.background-color}",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.border-color}"
+          "value": "{utrecht.form-control.border-color}",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "0px"
+          "value": "0px",
+          "type": "borderRadius"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{utrecht.form-control.border-width}"
+          "value": "{utrecht.form-control.border-width}",
+          "type": "borderWidth"
         },
         "size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.xs}"
+          "value": "{voorbeeld.size.xs}",
+          "type": "sizing"
         },
         "icon": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           }
         },
         "active": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.active.background-color}"
+            "value": "{voorbeeld.form-control.active.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.active.border-color}"
+            "value": "{voorbeeld.form-control.active.border-color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.active.border-width}"
+            "value": "{voorbeeld.form-control.active.border-width}",
+            "type": "borderWidth"
           }
         },
         "disabled": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.background-color}"
+            "value": "{utrecht.form-control.disabled.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.border-color}"
+            "value": "{utrecht.form-control.disabled.border-color}",
+            "type": "color"
           }
         },
         "hover": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.background-color}"
+            "value": "{voorbeeld.form-control.hover.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.border-color}"
+            "value": "{voorbeeld.form-control.hover.border-color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.hover.border-width}"
+            "value": "{voorbeeld.form-control.hover.border-width}",
+            "type": "borderWidth"
           }
         },
         "focus": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.background-color}"
+            "value": "{utrecht.form-control.focus.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.border-color}"
+            "value": "{utrecht.form-control.focus.border-color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.focus.border-width}"
+            "value": "{utrecht.form-control.focus.border-width}",
+            "type": "borderWidth"
           }
         },
         "invalid": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.background-color}"
+            "value": "{utrecht.form-control.invalid.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.border-color}"
+            "value": "{utrecht.form-control.invalid.border-color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.invalid.border-width}"
+            "value": "{utrecht.form-control.invalid.border-width}",
+            "type": "borderWidth"
           }
         },
         "checked": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.accent-color}"
+            "value": "{voorbeeld.form-control.accent-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.border-width}"
+            "value": "{utrecht.form-control.border-width}",
+            "type": "borderWidth"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
           }
         },
         "indeterminate": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.accent-color}"
+            "value": "{voorbeeld.form-control.accent-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.border-width}"
+            "value": "{utrecht.form-control.border-width}",
+            "type": "borderWidth"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
           }
         }
       }
@@ -2995,140 +2995,140 @@
         "checked": {
           "focus": {
             "border-width": {
-              "$type": "borderWidth",
-              "$value": "{utrecht.form-control.focus.border-width}"
+              "value": "{utrecht.form-control.focus.border-width}",
+              "type": "borderWidth"
             },
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.focus.background-color}"
+              "value": "{utrecht.form-control.focus.background-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.focus.border-color}"
+              "value": "{utrecht.form-control.focus.border-color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.focus.color}"
+              "value": "{utrecht.form-control.focus.color}",
+              "type": "color"
             }
           },
           "hover": {
             "border-width": {
-              "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.hover.border-width}"
+              "value": "{voorbeeld.form-control.hover.border-width}",
+              "type": "borderWidth"
             },
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.form-control.hover.accent-color}"
+              "value": "{voorbeeld.form-control.hover.accent-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             }
           },
           "active": {
             "border-width": {
-              "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.active.border-width}"
+              "value": "{voorbeeld.form-control.active.border-width}",
+              "type": "borderWidth"
             },
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.form-control.active.accent-color}"
+              "value": "{voorbeeld.form-control.active.accent-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             }
           },
           "disabled": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.form-control.disabled.accent-color}"
+              "value": "{voorbeeld.form-control.disabled.accent-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             }
           }
         },
         "indeterminate": {
           "active": {
             "border-width": {
-              "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.active.border-width}"
+              "value": "{voorbeeld.form-control.active.border-width}",
+              "type": "borderWidth"
             },
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.form-control.active.accent-color}"
+              "value": "{voorbeeld.form-control.active.accent-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             }
           },
           "hover": {
             "border-width": {
-              "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.hover.border-width}"
+              "value": "{voorbeeld.form-control.hover.border-width}",
+              "type": "borderWidth"
             },
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.form-control.hover.accent-color}"
+              "value": "{voorbeeld.form-control.hover.accent-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             }
           },
           "focus": {
             "border-width": {
-              "$type": "borderWidth",
-              "$value": "{utrecht.form-control.focus.border-width}"
+              "value": "{utrecht.form-control.focus.border-width}",
+              "type": "borderWidth"
             },
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.focus.background-color}"
+              "value": "{utrecht.form-control.focus.background-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.focus.border-color}"
+              "value": "{utrecht.form-control.focus.border-color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.focus.color}"
+              "value": "{utrecht.form-control.focus.color}",
+              "type": "color"
             }
           },
           "disabled": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.form-control.disabled.accent-color}"
+              "value": "{voorbeeld.form-control.disabled.accent-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             }
           }
         }
@@ -3139,16 +3139,16 @@
     "todo": {
       "checkbox-group": {
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
+          "value": "{voorbeeld.space.block.beetle}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
+          "value": "{voorbeeld.space.block.beetle}",
+          "type": "spacing"
         },
         "row-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.row.rat}"
+          "value": "{voorbeeld.space.row.rat}",
+          "type": "spacing"
         }
       }
     }
@@ -3157,44 +3157,44 @@
     "nl": {
       "code": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.100}"
+          "value": "{voorbeeld.color.gray.100}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{voorbeeld.code.font-family}"
+          "value": "{voorbeeld.code.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         }
       }
     },
     "utrecht": {
       "code": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.100}"
+          "value": "{voorbeeld.color.gray.100}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{voorbeeld.code.font-family}"
+          "value": "{voorbeeld.code.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         }
       }
     }
@@ -3203,76 +3203,76 @@
     "nl": {
       "code-block": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.100}"
+          "value": "{voorbeeld.color.gray.100}",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{voorbeeld.border-radius.sm}"
+          "value": "{voorbeeld.border-radius.sm}",
+          "type": "borderRadius"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{voorbeeld.code.font-family}"
+          "value": "{voorbeeld.code.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "padding-block": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.mouse}"
+          "value": "{voorbeeld.space.block.mouse}",
+          "type": "spacing"
         },
         "padding-inline": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         }
       }
     },
     "utrecht": {
       "code-block": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.gray.100}"
+          "value": "{voorbeeld.color.gray.100}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{voorbeeld.code.font-family}"
+          "value": "{voorbeeld.code.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.mouse}"
+          "value": "{voorbeeld.space.block.mouse}",
+          "type": "spacing"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.mouse}"
+          "value": "{voorbeeld.space.block.mouse}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         }
       }
     }
@@ -3281,68 +3281,68 @@
     "nl": {
       "color-sample": {
         "background-color": {
-          "$type": "color",
-          "$value": "#cccccc"
+          "value": "#cccccc",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "#787878"
+          "value": "#787878",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "0px"
+          "value": "0px",
+          "type": "borderRadius"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "block-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.sm}"
+          "value": "{voorbeeld.size.sm}",
+          "type": "sizing"
         },
         "inline-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.sm}"
+          "value": "{voorbeeld.size.sm}",
+          "type": "sizing"
         }
       }
     },
     "utrecht": {
       "color-sample": {
         "background-color": {
-          "$type": "color",
-          "$value": "{nl.color-sample.background-color}"
+          "value": "{nl.color-sample.background-color}",
+          "type": "color"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{nl.color-sample.border-width}"
+          "value": "{nl.color-sample.border-width}",
+          "type": "borderWidth"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{nl.color-sample.border-color}"
+          "value": "{nl.color-sample.border-color}",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{nl.color-sample.border-radius}"
+          "value": "{nl.color-sample.border-radius}",
+          "type": "borderRadius"
         },
         "dark": {
           "border-color": {
-            "$type": "color",
-            "$value": "{nl.color-sample.border-color}"
+            "value": "{nl.color-sample.border-color}",
+            "type": "color"
           }
         },
         "light": {
           "border-color": {
-            "$type": "color",
-            "$value": "{nl.color-sample.border-color}"
+            "value": "{nl.color-sample.border-color}",
+            "type": "color"
           }
         },
         "block-size": {
-          "$type": "sizing",
-          "$value": "{nl.color-sample.block-size}"
+          "value": "{nl.color-sample.block-size}",
+          "type": "sizing"
         },
         "inline-size": {
-          "$type": "sizing",
-          "$value": "{nl.color-sample.inline-size}"
+          "value": "{nl.color-sample.inline-size}",
+          "type": "sizing"
         }
       }
     }
@@ -3352,141 +3352,141 @@
       "contact-timeline": {
         "step": {
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.cat}"
+            "value": "{voorbeeld.space.block.cat}",
+            "type": "spacing"
           },
           "distance": {
-            "$type": "spacing",
-            "$value": "0"
+            "value": "0",
+            "type": "spacing"
           }
         },
         "step-details": {
           "desktop": {
             "margin-inline-start": {
-              "$type": "spacing",
-              "$value": "240px"
+              "value": "240px",
+              "type": "spacing"
             }
           },
           "mobile": {
             "margin-inline-start": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.inline.dog}"
+              "value": "{voorbeeld.space.inline.dog}",
+              "type": "spacing"
             }
           },
           "file": {
             "margin-block-end": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.block.rabbit}"
+              "value": "{voorbeeld.space.block.rabbit}",
+              "type": "spacing"
             },
             "margin-block-start": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.block.rabbit}"
+              "value": "{voorbeeld.space.block.rabbit}",
+              "type": "spacing"
             },
             "mobile": {
               "margin-block-end": {
-                "$type": "spacing",
-                "$value": "{voorbeeld.space.block.cat}"
+                "value": "{voorbeeld.space.block.cat}",
+                "type": "spacing"
               }
             }
           },
           "sender": {
             "font-size": {
-              "$type": "fontSizes",
-              "$value": "{utrecht.document.font-size}"
+              "value": "{utrecht.document.font-size}",
+              "type": "fontSizes"
             },
             "font-weight": {
-              "$type": "fontWeights",
-              "$value": "{voorbeeld.document.strong.font-weight}"
+              "value": "{voorbeeld.document.strong.font-weight}",
+              "type": "fontWeights"
             },
             "margin-block-start": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.block.mouse}"
+              "value": "{voorbeeld.space.block.mouse}",
+              "type": "spacing"
             }
           }
         },
         "step-header": {
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           },
           "channel": {
             "width": {
-              "$type": "sizing",
-              "$value": "80px"
+              "value": "80px",
+              "type": "sizing"
             }
           },
           "date": {
             "width": {
-              "$type": "sizing",
-              "$value": "96px"
+              "value": "96px",
+              "type": "sizing"
             }
           },
           "toggle": {
             "gap": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.text.beetle}"
+              "value": "{voorbeeld.space.text.beetle}",
+              "type": "spacing"
             },
             "active": {
               "color": {
-                "$type": "color",
-                "$value": "{voorbeeld.interaction.active.color}"
+                "value": "{voorbeeld.interaction.active.color}",
+                "type": "color"
               }
             },
             "focus": {
               "color": {
-                "$type": "color",
-                "$value": "{utrecht.focus.color}"
+                "value": "{utrecht.focus.color}",
+                "type": "color"
               }
             },
             "hover": {
               "color": {
-                "$type": "color",
-                "$value": "{voorbeeld.interaction.hover.color}"
+                "value": "{voorbeeld.interaction.hover.color}",
+                "type": "color"
               }
             }
           }
         },
         "step-marker": {
           "align-items": {
-            "$type": "other",
-            "$value": "flex-start"
+            "value": "flex-start",
+            "type": "other"
           },
           "connector": {
             "bottom": {
-              "$type": "dimension",
-              "$value": "0px"
+              "value": "0px",
+              "type": "dimension"
             },
             "desktop": {
               "margin-inline-start": {
-                "$type": "spacing",
-                "$value": "112px"
+                "value": "112px",
+                "type": "spacing"
               }
             },
             "mobile": {
               "margin-inline-start": {
-                "$type": "spacing",
-                "$value": "0"
+                "value": "0",
+                "type": "spacing"
               }
             }
           }
         },
         "step-meta": {
           "gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.text.mouse}"
+            "value": "{voorbeeld.space.text.mouse}",
+            "type": "spacing"
           },
           "marker": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
+              "value": "{utrecht.document.color}",
+              "type": "color"
             },
             "size": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.size.4xs}"
+              "value": "{voorbeeld.size.4xs}",
+              "type": "sizing"
             }
           }
         }
@@ -3498,8 +3498,8 @@
           "toggle": {
             "focus": {
               "background-color": {
-                "$type": "color",
-                "$value": "{utrecht.focus.background-color}"
+                "value": "{utrecht.focus.background-color}",
+                "type": "color"
               }
             }
           }
@@ -3511,112 +3511,112 @@
     "nl": {
       "data-badge": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.violet.100}"
+          "value": "{voorbeeld.color.violet.100}",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "value": "transparent",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{voorbeeld.border-radius.sm}"
+          "value": "{voorbeeld.border-radius.sm}",
+          "type": "borderRadius"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
+          "value": "{voorbeeld.document.strong.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.xs}"
+          "value": "{voorbeeld.size.xs}",
+          "type": "sizing"
         },
         "min-inline-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.sm}"
+          "value": "{voorbeeld.size.sm}",
+          "type": "sizing"
         },
         "padding-block": {
-          "$type": "spacing",
-          "$value": "None"
+          "value": "None",
+          "type": "spacing"
         },
         "padding-inline": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.ant}"
+          "value": "{voorbeeld.space.inline.ant}",
+          "type": "spacing"
         }
       }
     },
     "utrecht": {
       "data-badge": {
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.xs}"
+          "value": "{voorbeeld.size.xs}",
+          "type": "sizing"
         },
         "min-inline-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.sm}"
+          "value": "{voorbeeld.size.sm}",
+          "type": "sizing"
         },
         "padding-block": {
-          "$type": "spacing",
-          "$value": "None"
+          "value": "None",
+          "type": "spacing"
         },
         "padding-inline": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.ant}"
+          "value": "{voorbeeld.space.inline.ant}",
+          "type": "spacing"
         },
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.violet.100}"
+          "value": "{voorbeeld.color.violet.100}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "value": "transparent",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{voorbeeld.border-radius.sm}"
+          "value": "{voorbeeld.border-radius.sm}",
+          "type": "borderRadius"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
+          "value": "{voorbeeld.document.strong.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         }
       }
     }
@@ -3626,188 +3626,188 @@
       "drawer": {
         "header": {
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           },
           "label": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
+              "value": "{utrecht.document.color}",
+              "type": "color"
             },
             "font-family": {
-              "$type": "fontFamilies",
-              "$value": "{utrecht.document.font-family}"
+              "value": "{utrecht.document.font-family}",
+              "type": "fontFamilies"
             },
             "font-size": {
-              "$type": "fontSizes",
-              "$value": "{utrecht.document.font-size}"
+              "value": "{utrecht.document.font-size}",
+              "type": "fontSizes"
             },
             "font-weight": {
-              "$type": "fontWeights",
-              "$value": "{voorbeeld.document.strong.font-weight}"
+              "value": "{voorbeeld.document.strong.font-weight}",
+              "type": "fontWeights"
             },
             "line-height": {
-              "$type": "lineHeights",
-              "$value": "{utrecht.document.line-height}"
+              "value": "{utrecht.document.line-height}",
+              "type": "lineHeights"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.beetle}"
+            "value": "{voorbeeld.space.block.beetle}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.beetle}"
+            "value": "{voorbeeld.space.block.beetle}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.beetle}"
+            "value": "{voorbeeld.space.inline.beetle}",
+            "type": "spacing"
           },
           "column-gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.column.snail}"
+            "value": "{voorbeeld.space.column.snail}",
+            "type": "spacing"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           },
           "background-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           }
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "0px"
+          "value": "0px",
+          "type": "borderRadius"
         },
         "footer": {
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.mouse}"
+            "value": "{voorbeeld.space.block.mouse}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.mouse}"
+            "value": "{voorbeeld.space.block.mouse}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           },
           "background-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           }
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "content": {
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.rabbit}"
+            "value": "{voorbeeld.space.block.rabbit}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.rabbit}"
+            "value": "{voorbeeld.space.block.rabbit}",
+            "type": "spacing"
           },
           "padding-inline": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           }
         },
         "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.document.background-color}"
+          "value": "{utrecht.document.background-color}",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.container.border-color}"
+          "value": "{voorbeeld.container.border-color}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "box-shadow": {
-          "$type": "boxShadow",
-          "$value": "{voorbeeld.box-shadow.lg}"
+          "value": "{voorbeeld.box-shadow.lg}",
+          "type": "boxShadow"
         }
       }
     },
     "utrecht": {
       "drawer": {
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.document.background-color}"
+          "value": "{utrecht.document.background-color}",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.container.border-color}"
+          "value": "{voorbeeld.container.border-color}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "0px"
+          "value": "0px",
+          "type": "borderRadius"
         },
         "max-block-size": {
-          "$type": "sizing",
-          "$value": "800px"
+          "value": "800px",
+          "type": "sizing"
         },
         "max-inline-size": {
-          "$type": "sizing",
-          "$value": "1440px"
+          "value": "1440px",
+          "type": "sizing"
         },
         "min-inline-size": {
-          "$type": "sizing",
-          "$value": "312px"
+          "value": "312px",
+          "type": "sizing"
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.rabbit}"
+          "value": "{voorbeeld.space.block.rabbit}",
+          "type": "spacing"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.rabbit}"
+          "value": "{voorbeeld.space.block.rabbit}",
+          "type": "spacing"
         },
         "backdrop": {
           "min-size": {
-            "$type": "sizing",
-            "$value": "{utrecht.pointer-target.min-size}"
+            "value": "{utrecht.pointer-target.min-size}",
+            "type": "sizing"
           }
         }
       }
@@ -3817,73 +3817,73 @@
     "denhaag": {
       "file": {
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.container.border-color}"
+          "value": "{voorbeeld.container.border-color}",
+          "type": "color"
         },
         "left": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.100}"
+            "value": "{voorbeeld.color.gray.100}",
+            "type": "color"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           }
         },
         "link": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           },
           "hover": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             }
           },
           "gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.text.beetle}"
+            "value": "{voorbeeld.space.text.beetle}",
+            "type": "spacing"
           },
           "icon": {
             "width": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.icon.functional.size}"
+              "value": "{voorbeeld.icon.functional.size}",
+              "type": "sizing"
             }
           }
         },
         "border-style": {
-          "$type": "other",
-          "$value": "solid"
+          "value": "solid",
+          "type": "other"
         },
         "right": {
           "gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.row.snail}"
+            "value": "{voorbeeld.space.row.snail}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           }
         }
       }
@@ -3894,16 +3894,16 @@
       "form-field": {
         "invalid": {
           "border-inline-start-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.negative.border-color}"
+            "value": "{voorbeeld.feedback.negative.border-color}",
+            "type": "color"
           },
           "border-inline-start-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           }
         }
       }
@@ -3913,8 +3913,8 @@
     "todo": {
       "form-field-checkbox-option": {
         "column-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.column.snail}"
+          "value": "{voorbeeld.space.column.snail}",
+          "type": "spacing"
         }
       }
     }
@@ -3923,20 +3923,20 @@
     "utrecht": {
       "form-field-description": {
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.document.subtle.color}"
+          "value": "{voorbeeld.document.subtle.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         }
       }
     }
@@ -3945,44 +3945,44 @@
     "utrecht": {
       "form-field-error-message": {
         "background-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "value": "transparent",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.feedback.negative.color}"
+          "value": "{voorbeeld.feedback.negative.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
+          "value": "{utrecht.document.font-weight}",
+          "type": "fontWeights"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "0px"
+          "value": "0px",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "0px"
+          "value": "0px",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "0px"
+          "value": "0px",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "0px"
+          "value": "0px",
+          "type": "spacing"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         }
       }
     },
@@ -3990,13 +3990,13 @@
       "form-field-error-message": {
         "icon": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           }
         },
         "column-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.text.mouse}"
+          "value": "{voorbeeld.space.text.mouse}",
+          "type": "spacing"
         }
       }
     }
@@ -4005,24 +4005,24 @@
     "todo": {
       "form-field-label": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
+          "value": "{voorbeeld.document.strong.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         }
       }
     }
@@ -4031,29 +4031,29 @@
     "todo": {
       "form-field-option-label": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.color}"
+          "value": "{utrecht.form-control.color}",
+          "type": "color"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
+          "value": "{utrecht.document.font-weight}",
+          "type": "fontWeights"
         },
         "disabled": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.600}"
+            "value": "{voorbeeld.color.gray.600}",
+            "type": "color"
           }
         }
       }
@@ -4063,8 +4063,8 @@
     "todo": {
       "form-field-radio-option": {
         "column-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.column.snail}"
+          "value": "{voorbeeld.space.column.snail}",
+          "type": "spacing"
         }
       }
     }
@@ -4073,145 +4073,145 @@
     "todo": {
       "form-summary": {
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "item-value": {
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           },
           "row": {
             "padding-block-end": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.block.snail}"
+              "value": "{voorbeeld.space.block.snail}",
+              "type": "spacing"
             },
             "padding-block-start": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.block.snail}"
+              "value": "{voorbeeld.space.block.snail}",
+              "type": "spacing"
             },
             "padding-inline-end": {
-              "$type": "spacing",
-              "$value": "0px"
+              "value": "0px",
+              "type": "spacing"
             },
             "padding-inline-start": {
-              "$type": "spacing",
-              "$value": "0px"
+              "value": "0px",
+              "type": "spacing"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.ant}"
+            "value": "{voorbeeld.space.block.ant}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           }
         },
         "item-key": {
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           },
           "row": {
             "padding-block-end": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.block.snail}"
+              "value": "{voorbeeld.space.block.snail}",
+              "type": "spacing"
             },
             "padding-block-start": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.block.snail}"
+              "value": "{voorbeeld.space.block.snail}",
+              "type": "spacing"
             },
             "padding-inline-end": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.inline.mouse}"
+              "value": "{voorbeeld.space.inline.mouse}",
+              "type": "spacing"
             },
             "padding-inline-start": {
-              "$type": "spacing",
-              "$value": "0px"
+              "value": "0px",
+              "type": "spacing"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.ant}"
+            "value": "{voorbeeld.space.block.ant}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           }
         },
         "item": {
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           }
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "item-action": {
           "row": {
             "padding-block-end": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.block.snail}"
+              "value": "{voorbeeld.space.block.snail}",
+              "type": "spacing"
             },
             "padding-block-start": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.block.snail}"
+              "value": "{voorbeeld.space.block.snail}",
+              "type": "spacing"
             },
             "padding-inline-end": {
-              "$type": "spacing",
-              "$value": "0px"
+              "value": "0px",
+              "type": "spacing"
             },
             "padding-inline-start": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.inline.mouse}"
+              "value": "{voorbeeld.space.inline.mouse}",
+              "type": "spacing"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           }
         }
       }
@@ -4222,134 +4222,134 @@
       "heading": {
         "level-1": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.heading.color}"
+            "value": "{utrecht.heading.color}",
+            "type": "color"
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.heading.font-family}"
+            "value": "{utrecht.heading.font-family}",
+            "type": "fontFamilies"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.3xl}"
+            "value": "{voorbeeld.typography.font-size.3xl}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.heading.font-weight}"
+            "value": "{utrecht.heading.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.sm}"
+            "value": "{voorbeeld.typography.line-height.sm}",
+            "type": "lineHeights"
           }
         },
         "level-2": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.heading.color}"
+            "value": "{utrecht.heading.color}",
+            "type": "color"
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.heading.font-family}"
+            "value": "{utrecht.heading.font-family}",
+            "type": "fontFamilies"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.2xl}"
+            "value": "{voorbeeld.typography.font-size.2xl}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.heading.font-weight}"
+            "value": "{utrecht.heading.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.sm}"
+            "value": "{voorbeeld.typography.line-height.sm}",
+            "type": "lineHeights"
           }
         },
         "level-3": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.heading.color}"
+            "value": "{utrecht.heading.color}",
+            "type": "color"
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.heading.font-family}"
+            "value": "{utrecht.heading.font-family}",
+            "type": "fontFamilies"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.xl}"
+            "value": "{voorbeeld.typography.font-size.xl}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.heading.font-weight}"
+            "value": "{utrecht.heading.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.sm}"
+            "value": "{voorbeeld.typography.line-height.sm}",
+            "type": "lineHeights"
           }
         },
         "level-4": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.heading.color}"
+            "value": "{utrecht.heading.color}",
+            "type": "color"
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.heading.font-family}"
+            "value": "{utrecht.heading.font-family}",
+            "type": "fontFamilies"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.lg}"
+            "value": "{voorbeeld.typography.font-size.lg}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.heading.font-weight}"
+            "value": "{utrecht.heading.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.md}"
+            "value": "{voorbeeld.typography.line-height.md}",
+            "type": "lineHeights"
           }
         },
         "level-5": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.heading.color}"
+            "value": "{utrecht.heading.color}",
+            "type": "color"
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.heading.font-family}"
+            "value": "{utrecht.heading.font-family}",
+            "type": "fontFamilies"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.md}"
+            "value": "{voorbeeld.typography.font-size.md}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.heading.font-weight}"
+            "value": "{utrecht.heading.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.md}"
+            "value": "{voorbeeld.typography.line-height.md}",
+            "type": "lineHeights"
           }
         },
         "level-6": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.heading.color}"
+            "value": "{utrecht.heading.color}",
+            "type": "color"
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.heading.font-family}"
+            "value": "{utrecht.heading.font-family}",
+            "type": "fontFamilies"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.sm}"
+            "value": "{voorbeeld.typography.font-size.sm}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.heading.font-weight}"
+            "value": "{utrecht.heading.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.md}"
+            "value": "{voorbeeld.typography.line-height.md}",
+            "type": "lineHeights"
           }
         }
       }
@@ -4357,80 +4357,80 @@
     "ams": {
       "heading": {
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.heading.font-weight}"
+          "value": "{utrecht.heading.font-weight}",
+          "type": "fontWeights"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.heading.color}"
+          "value": "{utrecht.heading.color}",
+          "type": "color"
         },
         "inverse-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.document.inverse.color}"
+          "value": "{voorbeeld.document.inverse.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.heading.font-family}"
+          "value": "{utrecht.heading.font-family}",
+          "type": "fontFamilies"
         },
         "level": {
           "1": {
             "line-height": {
-              "$type": "lineHeights",
-              "$value": "{voorbeeld.typography.line-height.sm}"
+              "value": "{voorbeeld.typography.line-height.sm}",
+              "type": "lineHeights"
             },
             "font-size": {
-              "$type": "fontSizes",
-              "$value": "{voorbeeld.typography.font-size.3xl}"
+              "value": "{voorbeeld.typography.font-size.3xl}",
+              "type": "fontSizes"
             }
           },
           "2": {
             "line-height": {
-              "$type": "lineHeights",
-              "$value": "{voorbeeld.typography.line-height.sm}"
+              "value": "{voorbeeld.typography.line-height.sm}",
+              "type": "lineHeights"
             },
             "font-size": {
-              "$type": "fontSizes",
-              "$value": "{voorbeeld.typography.font-size.2xl}"
+              "value": "{voorbeeld.typography.font-size.2xl}",
+              "type": "fontSizes"
             }
           },
           "3": {
             "line-height": {
-              "$type": "lineHeights",
-              "$value": "{voorbeeld.typography.line-height.sm}"
+              "value": "{voorbeeld.typography.line-height.sm}",
+              "type": "lineHeights"
             },
             "font-size": {
-              "$type": "fontSizes",
-              "$value": "{voorbeeld.typography.font-size.xl}"
+              "value": "{voorbeeld.typography.font-size.xl}",
+              "type": "fontSizes"
             }
           },
           "4": {
             "line-height": {
-              "$type": "lineHeights",
-              "$value": "{voorbeeld.typography.line-height.md}"
+              "value": "{voorbeeld.typography.line-height.md}",
+              "type": "lineHeights"
             },
             "font-size": {
-              "$type": "fontSizes",
-              "$value": "{voorbeeld.typography.font-size.lg}"
+              "value": "{voorbeeld.typography.font-size.lg}",
+              "type": "fontSizes"
             }
           },
           "5": {
             "line-height": {
-              "$type": "lineHeights",
-              "$value": "{voorbeeld.typography.line-height.md}"
+              "value": "{voorbeeld.typography.line-height.md}",
+              "type": "lineHeights"
             },
             "font-size": {
-              "$type": "fontSizes",
-              "$value": "{voorbeeld.typography.font-size.md}"
+              "value": "{voorbeeld.typography.font-size.md}",
+              "type": "fontSizes"
             }
           },
           "6": {
             "line-height": {
-              "$type": "lineHeights",
-              "$value": "{voorbeeld.typography.line-height.md}"
+              "value": "{voorbeeld.typography.line-height.md}",
+              "type": "lineHeights"
             },
             "font-size": {
-              "$type": "fontSizes",
-              "$value": "{voorbeeld.typography.font-size.sm}"
+              "value": "{voorbeeld.typography.font-size.sm}",
+              "type": "fontSizes"
             }
           }
         }
@@ -4441,48 +4441,48 @@
     "nl": {
       "heading-1": {
         "color": {
-          "$type": "color",
-          "$value": "{nl.heading.level-1.color}"
+          "value": "{nl.heading.level-1.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{nl.heading.level-1.font-family}"
+          "value": "{nl.heading.level-1.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{nl.heading.level-1.font-size}"
+          "value": "{nl.heading.level-1.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{nl.heading.level-1.font-weight}"
+          "value": "{nl.heading.level-1.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{nl.heading.level-1.line-height}"
+          "value": "{nl.heading.level-1.line-height}",
+          "type": "lineHeights"
         }
       }
     },
     "utrecht": {
       "heading-1": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.heading.color}"
+          "value": "{utrecht.heading.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.heading.font-family}"
+          "value": "{utrecht.heading.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.3xl}"
+          "value": "{voorbeeld.typography.font-size.3xl}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.heading.font-weight}"
+          "value": "{utrecht.heading.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{voorbeeld.typography.line-height.sm}"
+          "value": "{voorbeeld.typography.line-height.sm}",
+          "type": "lineHeights"
         }
       }
     }
@@ -4491,48 +4491,48 @@
     "nl": {
       "heading-2": {
         "color": {
-          "$type": "color",
-          "$value": "{nl.heading.level-2.color}"
+          "value": "{nl.heading.level-2.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{nl.heading.level-2.font-family}"
+          "value": "{nl.heading.level-2.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{nl.heading.level-2.font-size}"
+          "value": "{nl.heading.level-2.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{nl.heading.level-2.font-weight}"
+          "value": "{nl.heading.level-2.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{nl.heading.level-2.line-height}"
+          "value": "{nl.heading.level-2.line-height}",
+          "type": "lineHeights"
         }
       }
     },
     "utrecht": {
       "heading-2": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.heading.color}"
+          "value": "{utrecht.heading.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.heading.font-family}"
+          "value": "{utrecht.heading.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.2xl}"
+          "value": "{voorbeeld.typography.font-size.2xl}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.heading.font-weight}"
+          "value": "{utrecht.heading.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{voorbeeld.typography.line-height.sm}"
+          "value": "{voorbeeld.typography.line-height.sm}",
+          "type": "lineHeights"
         }
       }
     }
@@ -4541,48 +4541,48 @@
     "nl": {
       "heading-3": {
         "color": {
-          "$type": "color",
-          "$value": "{nl.heading.level-3.color}"
+          "value": "{nl.heading.level-3.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{nl.heading.level-3.font-family}"
+          "value": "{nl.heading.level-3.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{nl.heading.level-3.font-size}"
+          "value": "{nl.heading.level-3.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{nl.heading.level-3.font-weight}"
+          "value": "{nl.heading.level-3.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{nl.heading.level-3.line-height}"
+          "value": "{nl.heading.level-3.line-height}",
+          "type": "lineHeights"
         }
       }
     },
     "utrecht": {
       "heading-3": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.heading.color}"
+          "value": "{utrecht.heading.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.heading.font-family}"
+          "value": "{utrecht.heading.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.xl}"
+          "value": "{voorbeeld.typography.font-size.xl}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.heading.font-weight}"
+          "value": "{utrecht.heading.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{voorbeeld.typography.line-height.sm}"
+          "value": "{voorbeeld.typography.line-height.sm}",
+          "type": "lineHeights"
         }
       }
     }
@@ -4591,48 +4591,48 @@
     "nl": {
       "heading-4": {
         "color": {
-          "$type": "color",
-          "$value": "{nl.heading.level-4.color}"
+          "value": "{nl.heading.level-4.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{nl.heading.level-4.font-family}"
+          "value": "{nl.heading.level-4.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{nl.heading.level-4.font-size}"
+          "value": "{nl.heading.level-4.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{nl.heading.level-4.font-weight}"
+          "value": "{nl.heading.level-4.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{nl.heading.level-4.line-height}"
+          "value": "{nl.heading.level-4.line-height}",
+          "type": "lineHeights"
         }
       }
     },
     "utrecht": {
       "heading-4": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.heading.color}"
+          "value": "{utrecht.heading.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.heading.font-family}"
+          "value": "{utrecht.heading.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.lg}"
+          "value": "{voorbeeld.typography.font-size.lg}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.heading.font-weight}"
+          "value": "{utrecht.heading.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{voorbeeld.typography.line-height.md}"
+          "value": "{voorbeeld.typography.line-height.md}",
+          "type": "lineHeights"
         }
       }
     }
@@ -4641,48 +4641,48 @@
     "nl": {
       "heading-5": {
         "color": {
-          "$type": "color",
-          "$value": "{nl.heading.level-5.color}"
+          "value": "{nl.heading.level-5.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{nl.heading.level-5.font-family}"
+          "value": "{nl.heading.level-5.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{nl.heading.level-5.font-size}"
+          "value": "{nl.heading.level-5.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{nl.heading.level-5.font-weight}"
+          "value": "{nl.heading.level-5.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{nl.heading.level-5.line-height}"
+          "value": "{nl.heading.level-5.line-height}",
+          "type": "lineHeights"
         }
       }
     },
     "utrecht": {
       "heading-5": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.heading.color}"
+          "value": "{utrecht.heading.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.heading.font-family}"
+          "value": "{utrecht.heading.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.md}"
+          "value": "{voorbeeld.typography.font-size.md}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.heading.font-weight}"
+          "value": "{utrecht.heading.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{voorbeeld.typography.line-height.md}"
+          "value": "{voorbeeld.typography.line-height.md}",
+          "type": "lineHeights"
         }
       }
     }
@@ -4691,48 +4691,48 @@
     "nl": {
       "heading-6": {
         "color": {
-          "$type": "color",
-          "$value": "{nl.heading.level-6.color}"
+          "value": "{nl.heading.level-6.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{nl.heading.level-6.font-family}"
+          "value": "{nl.heading.level-6.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{nl.heading.level-6.font-size}"
+          "value": "{nl.heading.level-6.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{nl.heading.level-6.font-weight}"
+          "value": "{nl.heading.level-6.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{nl.heading.level-6.line-height}"
+          "value": "{nl.heading.level-6.line-height}",
+          "type": "lineHeights"
         }
       }
     },
     "utrecht": {
       "heading-6": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.heading.color}"
+          "value": "{utrecht.heading.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.heading.font-family}"
+          "value": "{utrecht.heading.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.sm}"
+          "value": "{voorbeeld.typography.font-size.sm}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.heading.font-weight}"
+          "value": "{utrecht.heading.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{voorbeeld.typography.line-height.md}"
+          "value": "{voorbeeld.typography.line-height.md}",
+          "type": "lineHeights"
         }
       }
     }
@@ -4742,46 +4742,46 @@
       "heading-group": {
         "pre-heading": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.sm}"
+            "value": "{voorbeeld.typography.font-size.sm}",
+            "type": "fontSizes"
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
           }
         },
         "subheading": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.700}"
+            "value": "{voorbeeld.color.gray.700}",
+            "type": "color"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
           }
         }
       }
@@ -4791,12 +4791,12 @@
     "nl": {
       "icon": {
         "size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.xs}"
+          "value": "{voorbeeld.size.xs}",
+          "type": "sizing"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         }
       }
     }
@@ -4805,20 +4805,20 @@
     "todo": {
       "icon-only-button": {
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "value": "{voorbeeld.space.inline.snail}",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "value": "{voorbeeld.space.inline.snail}",
+          "type": "spacing"
         }
       }
     }
@@ -4827,85 +4827,85 @@
     "nl": {
       "link": {
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.interaction.color}"
+          "value": "{voorbeeld.interaction.color}",
+          "type": "color"
         },
         "text-decoration-line": {
-          "$type": "textDecoration",
-          "$value": "underline"
+          "value": "underline",
+          "type": "textDecoration"
         },
         "text-decoration-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.interaction.color}"
+          "value": "{voorbeeld.interaction.color}",
+          "type": "color"
         },
         "text-decoration-thickness": {
-          "$type": "other",
-          "$value": "auto"
+          "value": "auto",
+          "type": "other"
         },
         "text-underline-offset": {
-          "$type": "other",
-          "$value": "auto"
+          "value": "auto",
+          "type": "other"
         },
         "active": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.active.color}"
+            "value": "{voorbeeld.interaction.active.color}",
+            "type": "color"
           },
           "text-decoration-line": {
-            "$type": "textDecoration",
-            "$value": "None"
+            "value": "None",
+            "type": "textDecoration"
           },
           "text-decoration-thickness": {
-            "$type": "other",
-            "$value": "auto"
+            "value": "auto",
+            "type": "other"
           }
         },
         "focus-visible": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.background-color}"
+            "value": "{utrecht.focus.background-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.color}"
+            "value": "{utrecht.focus.color}",
+            "type": "color"
           },
           "text-decoration-line": {
-            "$type": "textDecoration",
-            "$value": "None"
+            "value": "None",
+            "type": "textDecoration"
           },
           "text-decoration-thickness": {
-            "$type": "other",
-            "$value": "auto"
+            "value": "auto",
+            "type": "other"
           }
         },
         "hover": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.hover.color}"
+            "value": "{voorbeeld.interaction.hover.color}",
+            "type": "color"
           },
           "text-decoration-line": {
-            "$type": "textDecoration",
-            "$value": "None"
+            "value": "None",
+            "type": "textDecoration"
           },
           "text-decoration-thickness": {
-            "$type": "other",
-            "$value": "auto"
+            "value": "auto",
+            "type": "other"
           }
         },
         "disabled": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
           },
           "cursor": {
-            "$type": "other",
-            "$value": "disabled"
+            "value": "disabled",
+            "type": "other"
           }
         },
         "current": {
           "cursor": {
-            "$type": "other",
-            "$value": "default"
+            "value": "default",
+            "type": "other"
           }
         }
       }
@@ -4913,79 +4913,79 @@
     "utrecht": {
       "link": {
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.interaction.color}"
+          "value": "{voorbeeld.interaction.color}",
+          "type": "color"
         },
         "column-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.text.beetle}"
+          "value": "{voorbeeld.space.text.beetle}",
+          "type": "spacing"
         },
         "text-decoration": {
-          "$type": "textDecoration",
-          "$value": "underline"
+          "value": "underline",
+          "type": "textDecoration"
         },
         "text-decoration-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.interaction.color}"
+          "value": "{voorbeeld.interaction.color}",
+          "type": "color"
         },
         "text-decoration-thickness": {
-          "$type": "other",
-          "$value": "auto"
+          "value": "auto",
+          "type": "other"
         },
         "text-underline-offset": {
-          "$type": "other",
-          "$value": "auto"
+          "value": "auto",
+          "type": "other"
         },
         "icon": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           }
         },
         "active": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.active.color}"
+            "value": "{voorbeeld.interaction.active.color}",
+            "type": "color"
           }
         },
         "focus": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.background-color}"
+            "value": "{utrecht.focus.background-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.color}"
+            "value": "{utrecht.focus.color}",
+            "type": "color"
           }
         },
         "focus-visible": {
           "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
+            "value": "None",
+            "type": "textDecoration"
           },
           "text-decoration-thickness": {
-            "$type": "other",
-            "$value": "auto"
+            "value": "auto",
+            "type": "other"
           }
         },
         "hover": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.hover.color}"
+            "value": "{voorbeeld.interaction.hover.color}",
+            "type": "color"
           },
           "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
+            "value": "None",
+            "type": "textDecoration"
           },
           "text-decoration-thickness": {
-            "$type": "other",
-            "$value": "auto"
+            "value": "auto",
+            "type": "other"
           }
         },
         "visited": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           }
         }
       }
@@ -4995,17 +4995,17 @@
     "utrecht": {
       "link-list": {
         "row-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.row.snail}"
+          "value": "{voorbeeld.space.row.snail}",
+          "type": "spacing"
         },
         "icon": {
           "inset-block-start": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           },
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           }
         }
       }
@@ -5014,29 +5014,29 @@
       "link-list": {
         "item": {
           "column-gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.beetle}"
+            "value": "{voorbeeld.space.block.beetle}",
+            "type": "spacing"
           },
           "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
+            "value": "None",
+            "type": "textDecoration"
           },
           "active": {
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "underline"
+              "value": "underline",
+              "type": "textDecoration"
             }
           },
           "focus": {
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "none"
+              "value": "none",
+              "type": "textDecoration"
             }
           },
           "hover": {
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "underline"
+              "value": "underline",
+              "type": "textDecoration"
             }
           }
         }
@@ -5048,101 +5048,101 @@
       "login-link": {
         "active": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.100}"
+            "value": "{voorbeeld.color.gray.100}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.active.color}"
+            "value": "{voorbeeld.interaction.active.color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.active.color}"
+            "value": "{voorbeeld.interaction.active.color}",
+            "type": "color"
           }
         },
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.white}"
+          "value": "{voorbeeld.color.white}",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.interaction.color}"
+          "value": "{voorbeeld.interaction.color}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.interaction.color}"
+          "value": "{voorbeeld.interaction.color}",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{voorbeeld.border-radius.md}"
+          "value": "{voorbeeld.border-radius.md}",
+          "type": "borderRadius"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "hover": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.50}"
+            "value": "{voorbeeld.color.gray.50}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.hover.color}"
+            "value": "{voorbeeld.interaction.hover.color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.hover.color}"
+            "value": "{voorbeeld.interaction.hover.color}",
+            "type": "color"
           }
         },
         "icon": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.toptask.size}"
+            "value": "{voorbeeld.icon.toptask.size}",
+            "type": "sizing"
           }
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
+          "value": "{voorbeeld.space.block.beetle}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
+          "value": "{voorbeeld.space.block.beetle}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.beetle}"
+          "value": "{voorbeeld.space.inline.beetle}",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.beetle}"
+          "value": "{voorbeeld.space.inline.beetle}",
+          "type": "spacing"
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "min-inline-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "column-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.snail}"
+          "value": "{voorbeeld.space.inline.snail}",
+          "type": "spacing"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
+          "value": "{voorbeeld.document.strong.font-weight}",
+          "type": "fontWeights"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         }
       }
     },
@@ -5150,16 +5150,16 @@
       "login-link": {
         "focus-visible": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.background-color}"
+            "value": "{utrecht.focus.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.color}"
+            "value": "{utrecht.focus.color}",
+            "type": "color"
           }
         }
       }
@@ -5169,24 +5169,24 @@
     "nl": {
       "mark": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.document.inverse.background-color}"
+          "value": "{voorbeeld.document.inverse.background-color}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.document.inverse.color}"
+          "value": "{voorbeeld.document.inverse.color}",
+          "type": "color"
         }
       }
     },
     "utrecht": {
       "mark": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.yellow.100}"
+          "value": "{voorbeeld.color.yellow.100}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         }
       }
     }
@@ -5195,128 +5195,128 @@
     "todo": {
       "modal-dialog": {
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{voorbeeld.border-radius.lg}"
+          "value": "{voorbeeld.border-radius.lg}",
+          "type": "borderRadius"
         },
         "box-shadow": {
-          "$type": "boxShadow",
-          "$value": "{voorbeeld.box-shadow.lg}"
+          "value": "{voorbeeld.box-shadow.lg}",
+          "type": "boxShadow"
         },
         "header": {
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.beetle}"
+            "value": "{voorbeeld.space.block.beetle}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.beetle}"
+            "value": "{voorbeeld.space.inline.beetle}",
+            "type": "spacing"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.beetle}"
+            "value": "{voorbeeld.space.block.beetle}",
+            "type": "spacing"
           },
           "background-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "label": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
+              "value": "{utrecht.document.color}",
+              "type": "color"
             },
             "font-family": {
-              "$type": "fontFamilies",
-              "$value": "{utrecht.document.font-family}"
+              "value": "{utrecht.document.font-family}",
+              "type": "fontFamilies"
             },
             "font-weight": {
-              "$type": "fontWeights",
-              "$value": "{voorbeeld.document.strong.font-weight}"
+              "value": "{voorbeeld.document.strong.font-weight}",
+              "type": "fontWeights"
             },
             "font-size": {
-              "$type": "fontSizes",
-              "$value": "{utrecht.document.font-size}"
+              "value": "{utrecht.document.font-size}",
+              "type": "fontSizes"
             },
             "line-height": {
-              "$type": "lineHeights",
-              "$value": "{utrecht.document.line-height}"
+              "value": "{utrecht.document.line-height}",
+              "type": "lineHeights"
             }
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           },
           "column-gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.column.snail}"
+            "value": "{voorbeeld.space.column.snail}",
+            "type": "spacing"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           }
         },
         "border-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "value": "transparent",
+          "type": "color"
         },
         "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.document.background-color}"
+          "value": "{utrecht.document.background-color}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "footer": {
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.mouse}"
+            "value": "{voorbeeld.space.block.mouse}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.mouse}"
+            "value": "{voorbeeld.space.block.mouse}",
+            "type": "spacing"
           },
           "background-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           }
         },
         "content": {
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.rabbit}"
+            "value": "{voorbeeld.space.block.rabbit}",
+            "type": "spacing"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.rabbit}"
+            "value": "{voorbeeld.space.block.rabbit}",
+            "type": "spacing"
           },
           "padding-inline": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           }
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         }
       }
     }
@@ -5325,104 +5325,104 @@
     "nl": {
       "number-badge": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.violet.100}"
+          "value": "{voorbeeld.color.violet.100}",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "value": "transparent",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{voorbeeld.border-radius.round}"
+          "value": "{voorbeeld.border-radius.round}",
+          "type": "borderRadius"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
+          "value": "{voorbeeld.document.strong.font-weight}",
+          "type": "fontWeights"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.sm}"
+          "value": "{voorbeeld.typography.font-size.sm}",
+          "type": "fontSizes"
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.xs}"
+          "value": "{voorbeeld.size.xs}",
+          "type": "sizing"
         },
         "min-inline-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.xs}"
+          "value": "{voorbeeld.size.xs}",
+          "type": "sizing"
         },
         "padding-block": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.ant}"
+          "value": "{voorbeeld.space.block.ant}",
+          "type": "spacing"
         },
         "padding-inline": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.ant}"
+          "value": "{voorbeeld.space.inline.ant}",
+          "type": "spacing"
         }
       }
     },
     "utrecht": {
       "number-badge": {
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.sm}"
+          "value": "{voorbeeld.typography.font-size.sm}",
+          "type": "fontSizes"
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.xs}"
+          "value": "{voorbeeld.size.xs}",
+          "type": "sizing"
         },
         "min-inline-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.xs}"
+          "value": "{voorbeeld.size.xs}",
+          "type": "sizing"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{voorbeeld.border-radius.round}"
+          "value": "{voorbeeld.border-radius.round}",
+          "type": "borderRadius"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.violet.100}"
+          "value": "{voorbeeld.color.violet.100}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "padding-inline": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.ant}"
+          "value": "{voorbeeld.space.inline.ant}",
+          "type": "spacing"
         },
         "padding-block": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.ant}"
+          "value": "{voorbeeld.space.block.ant}",
+          "type": "spacing"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
+          "value": "{voorbeeld.document.strong.font-weight}",
+          "type": "fontWeights"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "value": "transparent",
+          "type": "color"
         }
       }
     }
@@ -5431,29 +5431,29 @@
     "utrecht": {
       "ordered-list": {
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.rabbit}"
+          "value": "{voorbeeld.space.inline.rabbit}",
+          "type": "spacing"
         },
         "item": {
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.beetle}"
+            "value": "{voorbeeld.space.inline.beetle}",
+            "type": "spacing"
           },
           "margin-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.ant}"
+            "value": "{voorbeeld.space.block.ant}",
+            "type": "spacing"
           },
           "margin-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.ant}"
+            "value": "{voorbeeld.space.block.ant}",
+            "type": "spacing"
           }
         }
       }
@@ -5464,304 +5464,304 @@
       "pagination": {
         "relative-link": {
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           },
           "icon": {
             "margin-inline": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.text.beetle}"
+              "value": "{voorbeeld.space.text.beetle}",
+              "type": "spacing"
             },
             "size": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.icon.functional.size}"
+              "value": "{voorbeeld.icon.functional.size}",
+              "type": "sizing"
             }
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           },
           "background-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           },
           "active": {
             "background-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}",
+              "type": "color"
             },
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "underline"
+              "value": "underline",
+              "type": "textDecoration"
             }
           },
           "focus": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.background-color}"
+              "value": "{utrecht.focus.background-color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "value": "{utrecht.focus.color}",
+              "type": "color"
             },
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
+              "value": "None",
+              "type": "textDecoration"
             }
           },
           "hover": {
             "background-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             },
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "underline"
+              "value": "underline",
+              "type": "textDecoration"
             }
           },
           "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
+            "value": "None",
+            "type": "textDecoration"
           },
           "border-radius": {
-            "$type": "borderRadius",
-            "$value": "0px"
+            "value": "0px",
+            "type": "borderRadius"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           },
           "min-block-size": {
-            "$type": "sizing",
-            "$value": "{utrecht.pointer-target.min-size}"
+            "value": "{utrecht.pointer-target.min-size}",
+            "type": "sizing"
           },
           "min-inline-size": {
-            "$type": "sizing",
-            "$value": "{utrecht.pointer-target.min-size}"
+            "value": "{utrecht.pointer-target.min-size}",
+            "type": "sizing"
           },
           "disabled": {
             "background-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.500}"
+              "value": "{voorbeeld.color.gray.500}",
+              "type": "color"
             }
           }
         },
         "page-link": {
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           },
           "current": {
             "font-weight": {
-              "$type": "fontWeights",
-              "$value": "{voorbeeld.document.strong.font-weight}"
+              "value": "{voorbeeld.document.strong.font-weight}",
+              "type": "fontWeights"
             },
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
+              "value": "None",
+              "type": "textDecoration"
             },
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.100}"
+              "value": "{voorbeeld.color.gray.100}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
+              "value": "{utrecht.document.color}",
+              "type": "color"
             }
           },
           "border-radius": {
-            "$type": "borderRadius",
-            "$value": "0px"
+            "value": "0px",
+            "type": "borderRadius"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.snail}"
+            "value": "{voorbeeld.space.inline.snail}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.snail}"
+            "value": "{voorbeeld.space.inline.snail}",
+            "type": "spacing"
           },
           "focus": {
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
+              "value": "None",
+              "type": "textDecoration"
             },
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.background-color}"
+              "value": "{utrecht.focus.background-color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "value": "{utrecht.focus.color}",
+              "type": "color"
             }
           },
           "hover": {
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "underline"
+              "value": "underline",
+              "type": "textDecoration"
             },
             "background-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             }
           },
           "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
+            "value": "None",
+            "type": "textDecoration"
           },
           "active": {
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "underline"
+              "value": "underline",
+              "type": "textDecoration"
             },
             "background-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}",
+              "type": "color"
             }
           },
           "background-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           },
           "min-block-size": {
-            "$type": "sizing",
-            "$value": "{utrecht.pointer-target.min-size}"
+            "value": "{utrecht.pointer-target.min-size}",
+            "type": "sizing"
           },
           "min-inline-size": {
-            "$type": "sizing",
-            "$value": "{utrecht.pointer-target.min-size}"
+            "value": "{utrecht.pointer-target.min-size}",
+            "type": "sizing"
           }
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "ellipses": {
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.ant}"
+            "value": "{voorbeeld.space.inline.ant}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.ant}"
+            "value": "{voorbeeld.space.inline.ant}",
+            "type": "spacing"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.document.subtle.color}"
+            "value": "{voorbeeld.document.subtle.color}",
+            "type": "color"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           }
         },
         "description": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           }
         }
       }
@@ -5770,159 +5770,159 @@
       "pagination": {
         "relative-link": {
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
+            "value": "None",
+            "type": "textDecoration"
           },
           "border-radius": {
-            "$type": "borderRadius",
-            "$value": "0px"
+            "value": "0px",
+            "type": "borderRadius"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           },
           "background-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           },
           "hover": {
             "background-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             }
           },
           "disabled": {
             "background-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.500}"
+              "value": "{voorbeeld.color.gray.500}",
+              "type": "color"
             }
           },
           "text-transform": {
-            "$type": "textCase",
-            "$value": "None"
+            "value": "None",
+            "type": "textCase"
           }
         },
         "page-link": {
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           },
           "current": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.100}"
+              "value": "{voorbeeld.color.gray.100}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
+              "value": "{utrecht.document.color}",
+              "type": "color"
             }
           },
           "border-radius": {
-            "$type": "borderRadius",
-            "$value": "0px"
+            "value": "0px",
+            "type": "borderRadius"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "hover": {
             "background-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             }
           },
           "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
+            "value": "None",
+            "type": "textDecoration"
           },
           "background-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           }
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         }
       }
     }
@@ -5931,37 +5931,37 @@
     "nl": {
       "paragraph": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
+          "value": "{utrecht.document.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "lead": {
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.lg}"
+            "value": "{voorbeeld.typography.font-size.lg}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           }
         }
       }
@@ -5969,59 +5969,59 @@
     "utrecht": {
       "paragraph": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
+          "value": "{utrecht.document.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "lead": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.lg}"
+            "value": "{voorbeeld.typography.font-size.lg}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           }
         },
         "small": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.sm}"
+            "value": "{voorbeeld.typography.font-size.sm}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           }
         }
       }
@@ -6031,24 +6031,24 @@
     "utrecht": {
       "pre-heading": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.sm}"
+          "value": "{voorbeeld.typography.font-size.sm}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
+          "value": "{voorbeeld.document.strong.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         }
       }
     }
@@ -6058,574 +6058,574 @@
       "progress-list": {
         "step-marker": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.size.sm}"
+            "value": "{voorbeeld.size.sm}",
+            "type": "sizing"
           },
           "nested": {
             "size": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.size.2xs}"
+              "value": "{voorbeeld.size.2xs}",
+              "type": "sizing"
             },
             "figma": {
               "inset-block-start": {
-                "$type": "spacing",
-                "$value": "{voorbeeld.space.block.ant}"
+                "value": "{voorbeeld.space.block.ant}",
+                "type": "spacing"
               }
             },
             "padding-inline-start": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.inline.beetle}"
+              "value": "{voorbeeld.space.inline.beetle}",
+              "type": "spacing"
             }
           },
           "checked": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.positive.color}"
+              "value": "{voorbeeld.feedback.positive.color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             }
           },
           "not-checked": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.document.subtle.color}"
+              "value": "{voorbeeld.document.subtle.color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             }
           },
           "current": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.violet.600}"
+              "value": "{voorbeeld.color.violet.600}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             }
           },
           "warning": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.feedback.warning.color}"
+              "value": "{utrecht.feedback.warning.color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             }
           },
           "error": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.negative.color}"
+              "value": "{voorbeeld.feedback.negative.color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             }
           },
           "border-radius": {
-            "$type": "borderRadius",
-            "$value": "{voorbeeld.border-radius.round}"
+            "value": "{voorbeeld.border-radius.round}",
+            "type": "borderRadius"
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           },
           "icon-size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           }
         },
         "connector": {
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "checked": {
             "border-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.positive.border-color}"
+              "value": "{voorbeeld.feedback.positive.border-color}",
+              "type": "color"
             }
           },
           "not-checked": {
             "border-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.document.subtle.color}"
+              "value": "{voorbeeld.document.subtle.color}",
+              "type": "color"
             }
           },
           "warning": {
             "border-color": {
-              "$type": "color",
-              "$value": "{utrecht.feedback.warning.border-color}"
+              "value": "{utrecht.feedback.warning.border-color}",
+              "type": "color"
             }
           },
           "error": {
             "border-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.negative.border-color}"
+              "value": "{voorbeeld.feedback.negative.border-color}",
+              "type": "color"
             }
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
           }
         },
         "step-heading": {
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.ant}"
+            "value": "{voorbeeld.space.block.ant}",
+            "type": "spacing"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.rat}"
+            "value": "{voorbeeld.space.block.rat}",
+            "type": "spacing"
           },
           "checked": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
+              "value": "{utrecht.document.color}",
+              "type": "color"
             }
           },
           "not-checked": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
+              "value": "{utrecht.document.color}",
+              "type": "color"
             }
           },
           "current": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.violet.600}"
+              "value": "{voorbeeld.color.violet.600}",
+              "type": "color"
             }
           },
           "error": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.negative.color}"
+              "value": "{voorbeeld.feedback.negative.color}",
+              "type": "color"
             }
           },
           "warning": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.feedback.warning.color}"
+              "value": "{utrecht.feedback.warning.color}",
+              "type": "color"
             }
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           }
         },
         "button": {
           "icon": {
             "size": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.icon.functional.size}"
+              "value": "{voorbeeld.icon.functional.size}",
+              "type": "sizing"
             },
             "margin-inline": {
-              "$type": "spacing",
-              "$value": "{voorbeeld.space.text.beetle}"
+              "value": "{voorbeeld.space.text.beetle}",
+              "type": "spacing"
             },
             "checked": {
               "color": {
-                "$type": "color",
-                "$value": "{utrecht.document.color}"
+                "value": "{utrecht.document.color}",
+                "type": "color"
               },
               "hover": {
                 "color": {
-                  "$type": "color",
-                  "$value": "{voorbeeld.interaction.hover.color}"
+                  "value": "{voorbeeld.interaction.hover.color}",
+                  "type": "color"
                 }
               },
               "focus": {
                 "color": {
-                  "$type": "color",
-                  "$value": "{utrecht.focus.color}"
+                  "value": "{utrecht.focus.color}",
+                  "type": "color"
                 }
               },
               "active": {
                 "color": {
-                  "$type": "color",
-                  "$value": "{voorbeeld.interaction.active.color}"
+                  "value": "{voorbeeld.interaction.active.color}",
+                  "type": "color"
                 }
               }
             },
             "current": {
               "color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.violet.600}"
+                "value": "{voorbeeld.color.violet.600}",
+                "type": "color"
               },
               "active": {
                 "color": {
-                  "$type": "color",
-                  "$value": "{voorbeeld.color.violet.800}"
+                  "value": "{voorbeeld.color.violet.800}",
+                  "type": "color"
                 }
               },
               "hover": {
                 "color": {
-                  "$type": "color",
-                  "$value": "{voorbeeld.color.violet.700}"
+                  "value": "{voorbeeld.color.violet.700}",
+                  "type": "color"
                 }
               },
               "focus": {
                 "color": {
-                  "$type": "color",
-                  "$value": "{utrecht.focus.color}"
+                  "value": "{utrecht.focus.color}",
+                  "type": "color"
                 }
               }
             },
             "warning": {
               "color": {
-                "$type": "color",
-                "$value": "{utrecht.feedback.warning.color}"
+                "value": "{utrecht.feedback.warning.color}",
+                "type": "color"
               },
               "active": {
                 "color": {
-                  "$type": "color",
-                  "$value": "{voorbeeld.color.yellow.800}"
+                  "value": "{voorbeeld.color.yellow.800}",
+                  "type": "color"
                 }
               },
               "hover": {
                 "color": {
-                  "$type": "color",
-                  "$value": "{voorbeeld.color.yellow.700}"
+                  "value": "{voorbeeld.color.yellow.700}",
+                  "type": "color"
                 }
               },
               "focus": {
                 "color": {
-                  "$type": "color",
-                  "$value": "{utrecht.focus.color}"
+                  "value": "{utrecht.focus.color}",
+                  "type": "color"
                 }
               }
             },
             "error": {
               "color": {
-                "$type": "color",
-                "$value": "{voorbeeld.feedback.negative.color}"
+                "value": "{voorbeeld.feedback.negative.color}",
+                "type": "color"
               },
               "active": {
                 "color": {
-                  "$type": "color",
-                  "$value": "{voorbeeld.color.red.800}"
+                  "value": "{voorbeeld.color.red.800}",
+                  "type": "color"
                 }
               },
               "hover": {
                 "color": {
-                  "$type": "color",
-                  "$value": "{voorbeeld.color.red.700}"
+                  "value": "{voorbeeld.color.red.700}",
+                  "type": "color"
                 }
               },
               "focus": {
                 "color": {
-                  "$type": "color",
-                  "$value": "{utrecht.focus.color}"
+                  "value": "{utrecht.focus.color}",
+                  "type": "color"
                 }
               }
             }
           },
           "min-inline-size": {
-            "$type": "sizing",
-            "$value": "{utrecht.pointer-target.min-size}"
+            "value": "{utrecht.pointer-target.min-size}",
+            "type": "sizing"
           },
           "min-block-size": {
-            "$type": "sizing",
-            "$value": "{utrecht.pointer-target.min-size}"
+            "value": "{utrecht.pointer-target.min-size}",
+            "type": "sizing"
           },
           "checked": {
             "active": {
               "color": {
-                "$type": "color",
-                "$value": "{voorbeeld.interaction.active.color}"
+                "value": "{voorbeeld.interaction.active.color}",
+                "type": "color"
               },
               "background-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               },
               "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               }
             },
             "hover": {
               "color": {
-                "$type": "color",
-                "$value": "{voorbeeld.interaction.hover.color}"
+                "value": "{voorbeeld.interaction.hover.color}",
+                "type": "color"
               },
               "background-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               },
               "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               }
             },
             "focus": {
               "background-color": {
-                "$type": "color",
-                "$value": "{utrecht.focus.background-color}"
+                "value": "{utrecht.focus.background-color}",
+                "type": "color"
               },
               "color": {
-                "$type": "color",
-                "$value": "{utrecht.focus.color}"
+                "value": "{utrecht.focus.color}",
+                "type": "color"
               },
               "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               }
             },
             "background-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             }
           },
           "current": {
             "active": {
               "color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.violet.800}"
+                "value": "{voorbeeld.color.violet.800}",
+                "type": "color"
               },
               "background-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               },
               "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               }
             },
             "hover": {
               "color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.violet.700}"
+                "value": "{voorbeeld.color.violet.700}",
+                "type": "color"
               },
               "background-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               },
               "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               }
             },
             "focus": {
               "background-color": {
-                "$type": "color",
-                "$value": "{utrecht.focus.background-color}"
+                "value": "{utrecht.focus.background-color}",
+                "type": "color"
               },
               "color": {
-                "$type": "color",
-                "$value": "{utrecht.focus.color}"
+                "value": "{utrecht.focus.color}",
+                "type": "color"
               },
               "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               }
             },
             "background-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             }
           },
           "warning": {
             "active": {
               "color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.yellow.800}"
+                "value": "{voorbeeld.color.yellow.800}",
+                "type": "color"
               },
               "background-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               },
               "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               }
             },
             "hover": {
               "color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.yellow.700}"
+                "value": "{voorbeeld.color.yellow.700}",
+                "type": "color"
               },
               "background-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               },
               "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               }
             },
             "focus": {
               "background-color": {
-                "$type": "color",
-                "$value": "{utrecht.focus.background-color}"
+                "value": "{utrecht.focus.background-color}",
+                "type": "color"
               },
               "color": {
-                "$type": "color",
-                "$value": "{utrecht.focus.color}"
+                "value": "{utrecht.focus.color}",
+                "type": "color"
               },
               "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               }
             },
             "background-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             }
           },
           "error": {
             "active": {
               "color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.red.800}"
+                "value": "{voorbeeld.color.red.800}",
+                "type": "color"
               },
               "background-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               },
               "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               }
             },
             "hover": {
               "color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.red.700}"
+                "value": "{voorbeeld.color.red.700}",
+                "type": "color"
               },
               "background-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               },
               "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               }
             },
             "focus": {
               "background-color": {
-                "$type": "color",
-                "$value": "{utrecht.focus.background-color}"
+                "value": "{utrecht.focus.background-color}",
+                "type": "color"
               },
               "color": {
-                "$type": "color",
-                "$value": "{utrecht.focus.color}"
+                "value": "{utrecht.focus.color}",
+                "type": "color"
               },
               "border-color": {
-                "$type": "color",
-                "$value": "transparent"
+                "value": "transparent",
+                "type": "color"
               }
             },
             "background-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             }
           },
           "border-radius": {
-            "$type": "borderRadius",
-            "$value": "{utrecht.button.border-radius}"
+            "value": "{utrecht.button.border-radius}",
+            "type": "borderRadius"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           }
         },
         "step-header": {
           "column-gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.column.rat}"
+            "value": "{voorbeeld.space.column.rat}",
+            "type": "spacing"
           }
         },
         "step-meta": {
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.pig}"
+            "value": "{voorbeeld.space.inline.pig}",
+            "type": "spacing"
           }
         },
         "sub-step": {
           "margin-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.rabbit}"
+            "value": "{voorbeeld.space.block.rabbit}",
+            "type": "spacing"
           }
         },
         "step-body": {
           "row-gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.row.snail}"
+            "value": "{voorbeeld.space.row.snail}",
+            "type": "spacing"
           }
         },
         "sub-step-header": {
           "column-gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.column.cat}"
+            "value": "{voorbeeld.space.column.cat}",
+            "type": "spacing"
           }
         }
       }
@@ -6633,232 +6633,232 @@
     "denhaag": {
       "process-steps": {
         "font-familiy": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "step-description": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.document.subtle.color}"
+            "value": "{voorbeeld.document.subtle.color}",
+            "type": "color"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           }
         },
         "step-line": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           },
           "stroke-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
           },
           "checked": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.positive.border-color}"
+              "value": "{voorbeeld.feedback.positive.border-color}",
+              "type": "color"
             }
           },
           "warning": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.feedback.warning.border-color}"
+              "value": "{utrecht.feedback.warning.border-color}",
+              "type": "color"
             }
           }
         },
         "step-header": {
           "align-items": {
-            "$type": "other",
-            "$value": "center"
+            "value": "center",
+            "type": "other"
           }
         },
         "step-heading": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           },
           "font-familiy": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.lg}"
+            "value": "{voorbeeld.typography.font-size.lg}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           },
           "current": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.violet.600}"
+              "value": "{voorbeeld.color.violet.600}",
+              "type": "color"
             }
           },
           "checked": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.positive.color}"
+              "value": "{voorbeeld.feedback.positive.color}",
+              "type": "color"
             }
           },
           "not-checked": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
+              "value": "{utrecht.document.color}",
+              "type": "color"
             }
           },
           "warning": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.feedback.warning.color}"
+              "value": "{utrecht.feedback.warning.color}",
+              "type": "color"
             }
           }
         },
         "step-marker": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.document.background-color}"
+            "value": "{utrecht.document.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           },
           "current": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.violet.600}"
+              "value": "{voorbeeld.color.violet.600}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-width": {
-              "$type": "borderWidth",
-              "$value": "{voorbeeld.border-width.md}"
+              "value": "{voorbeeld.border-width.md}",
+              "type": "borderWidth"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.document.inverse.color}"
+              "value": "{voorbeeld.document.inverse.color}",
+              "type": "color"
             }
           },
           "checked": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.positive.color}"
+              "value": "{voorbeeld.feedback.positive.color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-width": {
-              "$type": "borderWidth",
-              "$value": "{voorbeeld.border-width.md}"
+              "value": "{voorbeeld.border-width.md}",
+              "type": "borderWidth"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.document.inverse.color}"
+              "value": "{voorbeeld.document.inverse.color}",
+              "type": "color"
             }
           },
           "warning": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.feedback.warning.color}"
+              "value": "{utrecht.feedback.warning.color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.document.inverse.color}"
+              "value": "{voorbeeld.document.inverse.color}",
+              "type": "color"
             }
           }
         },
         "step-metaddata": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.document.subtle.color}"
+            "value": "{voorbeeld.document.subtle.color}",
+            "type": "color"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           }
         },
         "sub-step-heading": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           },
           "font-familiy": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           }
         },
         "sub-step-marker": {
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           },
           "current": {
             "border-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.violet.600}"
+              "value": "{voorbeeld.color.violet.600}",
+              "type": "color"
             }
           },
           "checked": {
             "border-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.positive.border-color}"
+              "value": "{voorbeeld.feedback.positive.border-color}",
+              "type": "color"
             }
           },
           "warning": {
             "border-color": {
-              "$type": "color",
-              "$value": "{utrecht.feedback.warning.border-color}"
+              "value": "{utrecht.feedback.warning.border-color}",
+              "type": "color"
             }
           },
           "not-checked": {
             "border-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.line.border-color}"
+              "value": "{voorbeeld.line.border-color}",
+              "type": "color"
             }
           }
         }
@@ -6869,186 +6869,186 @@
     "utrecht": {
       "radio-button": {
         "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.background-color}"
+          "value": "{utrecht.form-control.background-color}",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.border-color}"
+          "value": "{utrecht.form-control.border-color}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.radio-button.border-color}"
+          "value": "{utrecht.radio-button.border-color}",
+          "type": "color"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{utrecht.form-control.border-width}"
+          "value": "{utrecht.form-control.border-width}",
+          "type": "borderWidth"
         },
         "size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.xs}"
+          "value": "{voorbeeld.size.xs}",
+          "type": "sizing"
         },
         "icon": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.size.3xs}"
+            "value": "{voorbeeld.size.3xs}",
+            "type": "sizing"
           }
         },
         "active": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.active.background-color}"
+            "value": "{voorbeeld.form-control.active.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.active.border-color}"
+            "value": "{voorbeeld.form-control.active.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.radio-button.active.border-color}"
+            "value": "{utrecht.radio-button.active.border-color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.active.border-width}"
+            "value": "{voorbeeld.form-control.active.border-width}",
+            "type": "borderWidth"
           }
         },
         "focus": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.background-color}"
+            "value": "{utrecht.form-control.focus.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.border-color}"
+            "value": "{utrecht.form-control.focus.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.radio-button.focus.border-color}"
+            "value": "{utrecht.radio-button.focus.border-color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.focus.border-width}"
+            "value": "{utrecht.form-control.focus.border-width}",
+            "type": "borderWidth"
           }
         },
         "hover": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.background-color}"
+            "value": "{voorbeeld.form-control.hover.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.border-color}"
+            "value": "{voorbeeld.form-control.hover.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.radio-button.hover.border-color}"
+            "value": "{utrecht.radio-button.hover.border-color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.form-control.hover.border-width}"
+            "value": "{voorbeeld.form-control.hover.border-width}",
+            "type": "borderWidth"
           }
         },
         "invalid": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.background-color}"
+            "value": "{utrecht.form-control.invalid.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.border-color}"
+            "value": "{utrecht.form-control.invalid.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.radio-button.invalid.border-color}"
+            "value": "{utrecht.radio-button.invalid.border-color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.invalid.border-width}"
+            "value": "{utrecht.form-control.invalid.border-width}",
+            "type": "borderWidth"
           }
         },
         "disabled": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.background-color}"
+            "value": "{utrecht.form-control.disabled.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.border-color}"
+            "value": "{utrecht.form-control.disabled.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.radio-button.disabled.border-color}"
+            "value": "{utrecht.radio-button.disabled.border-color}",
+            "type": "color"
           }
         },
         "checked": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.accent-color}"
+            "value": "{voorbeeld.form-control.accent-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.border-width}"
+            "value": "{utrecht.form-control.border-width}",
+            "type": "borderWidth"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
           },
           "active": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.form-control.active.accent-color}"
+              "value": "{voorbeeld.form-control.active.accent-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-width": {
-              "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.active.border-width}"
+              "value": "{voorbeeld.form-control.active.border-width}",
+              "type": "borderWidth"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             }
           },
           "focus": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.focus.background-color}"
+              "value": "{utrecht.form-control.focus.background-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.focus.border-color}"
+              "value": "{utrecht.form-control.focus.border-color}",
+              "type": "color"
             },
             "border-width": {
-              "$type": "borderWidth",
-              "$value": "{utrecht.form-control.focus.border-width}"
+              "value": "{utrecht.form-control.focus.border-width}",
+              "type": "borderWidth"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.focus.color}"
+              "value": "{utrecht.form-control.focus.color}",
+              "type": "color"
             }
           },
           "hover": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.form-control.hover.accent-color}"
+              "value": "{voorbeeld.form-control.hover.accent-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "border-width": {
-              "$type": "borderWidth",
-              "$value": "{voorbeeld.form-control.hover.border-width}"
+              "value": "{voorbeeld.form-control.hover.border-width}",
+              "type": "borderWidth"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             }
           }
         }
@@ -7059,16 +7059,16 @@
         "checked": {
           "disabled": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.form-control.disabled.accent-color}"
+              "value": "{voorbeeld.form-control.disabled.accent-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "transparent"
+              "value": "transparent",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             }
           }
         }
@@ -7079,16 +7079,16 @@
     "todo": {
       "radio-group": {
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
+          "value": "{voorbeeld.space.block.beetle}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.beetle}"
+          "value": "{voorbeeld.space.block.beetle}",
+          "type": "spacing"
         },
         "row-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.row.rat}"
+          "value": "{voorbeeld.space.row.rat}",
+          "type": "spacing"
         }
       }
     }
@@ -7097,127 +7097,127 @@
     "utrecht": {
       "select": {
         "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.background-color}"
+          "value": "{utrecht.form-control.background-color}",
+          "type": "color"
         },
         "border-block-end-width": {
-          "$type": "borderWidth",
-          "$value": "{utrecht.select.border-width}"
+          "value": "{utrecht.select.border-width}",
+          "type": "borderWidth"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.border-color}"
+          "value": "{utrecht.form-control.border-color}",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{utrecht.form-control.border-radius}"
+          "value": "{utrecht.form-control.border-radius}",
+          "type": "borderRadius"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{utrecht.form-control.border-width}"
+          "value": "{utrecht.form-control.border-width}",
+          "type": "borderWidth"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.color}"
+          "value": "{utrecht.form-control.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.form-control.font-family}"
+          "value": "{utrecht.form-control.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.form-control.font-size}"
+          "value": "{utrecht.form-control.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
+          "value": "{utrecht.document.font-weight}",
+          "type": "fontWeights"
         },
         "max-inline-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.form-control.max-inline-size}"
+          "value": "{utrecht.form-control.max-inline-size}",
+          "type": "sizing"
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{utrecht.form-control.padding-block-end}"
+          "value": "{utrecht.form-control.padding-block-end}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{utrecht.form-control.padding-block-start}"
+          "value": "{utrecht.form-control.padding-block-start}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{utrecht.form-control.padding-inline-end}"
+          "value": "{utrecht.form-control.padding-inline-end}",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{utrecht.form-control.padding-inline-start}"
+          "value": "{utrecht.form-control.padding-inline-start}",
+          "type": "spacing"
         },
         "disabled": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.background-color}"
+            "value": "{utrecht.form-control.disabled.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.border-color}"
+            "value": "{utrecht.form-control.disabled.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.color}"
+            "value": "{utrecht.form-control.disabled.color}",
+            "type": "color"
           }
         },
         "focus": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.background-color}"
+            "value": "{utrecht.form-control.focus.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.border-color}"
+            "value": "{utrecht.form-control.focus.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.color}"
+            "value": "{utrecht.form-control.focus.color}",
+            "type": "color"
           }
         },
         "invalid": {
           "border-block-end-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.select.invalid.border-width}"
+            "value": "{utrecht.select.invalid.border-width}",
+            "type": "borderWidth"
           },
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.background-color}"
+            "value": "{utrecht.form-control.invalid.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.border-color}"
+            "value": "{utrecht.form-control.invalid.border-color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.invalid.border-width}"
+            "value": "{utrecht.form-control.invalid.border-width}",
+            "type": "borderWidth"
           }
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.form-control.line-height}"
+          "value": "{utrecht.form-control.line-height}",
+          "type": "lineHeights"
         },
         "hover": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.background-color}"
+            "value": "{voorbeeld.form-control.hover.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.border-color}"
+            "value": "{voorbeeld.form-control.hover.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.color}"
+            "value": "{voorbeeld.form-control.hover.color}",
+            "type": "color"
           }
         }
       }
@@ -7226,8 +7226,8 @@
       "select": {
         "icon": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           }
         }
       }
@@ -7237,24 +7237,24 @@
     "utrecht": {
       "separator": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         },
         "block-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.4xs}"
+          "value": "{voorbeeld.size.4xs}",
+          "type": "sizing"
         }
       }
     },
     "nl": {
       "separator": {
         "block-size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.4xs}"
+          "value": "{voorbeeld.size.4xs}",
+          "type": "sizing"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         }
       }
     }
@@ -7263,83 +7263,83 @@
     "denhaag": {
       "sidenav": {
         "min-width": {
-          "$type": "sizing",
-          "$value": "240px"
+          "value": "240px",
+          "type": "sizing"
         },
         "row-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.row.cat}"
+          "value": "{voorbeeld.space.row.cat}",
+          "type": "spacing"
         },
         "item": {
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.document.font-family}"
+            "value": "{utrecht.document.font-family}",
+            "type": "fontFamilies"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{utrecht.document.font-size}"
+            "value": "{utrecht.document.font-size}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
+            "value": "{utrecht.document.font-weight}",
+            "type": "fontWeights"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{utrecht.document.line-height}"
+            "value": "{utrecht.document.line-height}",
+            "type": "lineHeights"
           }
         },
         "link": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
+            "value": "{voorbeeld.interaction.color}",
+            "type": "color"
           },
           "column-gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.text.mouse}"
+            "value": "{voorbeeld.space.text.mouse}",
+            "type": "spacing"
           },
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
+            "value": "None",
+            "type": "textDecoration"
           },
           "current": {
             "font-weight": {
-              "$type": "fontWeights",
-              "$value": "{voorbeeld.document.strong.font-weight}"
+              "value": "{voorbeeld.document.strong.font-weight}",
+              "type": "fontWeights"
             }
           },
           "hover": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
+              "value": "{voorbeeld.interaction.hover.color}",
+              "type": "color"
             }
           },
           "active": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
+              "value": "{voorbeeld.interaction.active.color}",
+              "type": "color"
             }
           }
         },
         "list": {
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "0px"
+            "value": "0px",
+            "type": "spacing"
           }
         }
       }
@@ -7349,40 +7349,40 @@
         "link": {
           "current": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
+              "value": "{utrecht.document.color}",
+              "type": "color"
             }
           },
           "active": {
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "underline"
+              "value": "underline",
+              "type": "textDecoration"
             }
           },
           "focus": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.background-color}"
+              "value": "{utrecht.focus.background-color}",
+              "type": "color"
             },
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "value": "{utrecht.focus.color}",
+              "type": "color"
             },
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
+              "value": "None",
+              "type": "textDecoration"
             }
           },
           "hover": {
             "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "underline"
+              "value": "underline",
+              "type": "textDecoration"
             }
           },
           "icon": {
             "size": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.icon.functional.size}"
+              "value": "{voorbeeld.icon.functional.size}",
+              "type": "sizing"
             }
           }
         }
@@ -7393,99 +7393,99 @@
     "nl": {
       "skip-link": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.document.inverse.background-color}"
+          "value": "{voorbeeld.document.inverse.background-color}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.document.inverse.color}"
+          "value": "{voorbeeld.document.inverse.color}",
+          "type": "color"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "padding-block": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-inline": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "min-inline-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "text-decoration-thickness": {
-          "$type": "other",
-          "$value": "1px"
+          "value": "1px",
+          "type": "other"
         },
         "text-underline-offset": {
-          "$type": "other",
-          "$value": "1px"
+          "value": "1px",
+          "type": "other"
         }
       }
     },
     "utrecht": {
       "skip-link": {
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.document.inverse.background-color}"
+          "value": "{voorbeeld.document.inverse.background-color}",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{voorbeeld.document.inverse.color}"
+          "value": "{voorbeeld.document.inverse.color}",
+          "type": "color"
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "min-inline-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "text-decoration": {
-          "$type": "textDecoration",
-          "$value": "underline"
+          "value": "underline",
+          "type": "textDecoration"
         },
         "focus": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.background-color}"
+            "value": "{utrecht.focus.background-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.color}"
+            "value": "{utrecht.focus.color}",
+            "type": "color"
           }
         },
         "focus-visible": {
           "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
+            "value": "None",
+            "type": "textDecoration"
           }
         }
       }
@@ -7493,8 +7493,8 @@
     "todo": {
       "skip-link": {
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
+          "value": "{voorbeeld.document.strong.font-weight}",
+          "type": "fontWeights"
         }
       }
     }
@@ -7503,104 +7503,104 @@
     "todo": {
       "status-badge": {
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{voorbeeld.typography.font-size.sm}"
+          "value": "{voorbeeld.typography.font-size.sm}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
+          "value": "{voorbeeld.document.strong.font-weight}",
+          "type": "fontWeights"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.sm}"
+          "value": "{voorbeeld.border-width.sm}",
+          "type": "borderWidth"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{voorbeeld.border-radius.sm}"
+          "value": "{voorbeeld.border-radius.sm}",
+          "type": "borderRadius"
         },
         "padding-inline": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.ant}"
+          "value": "{voorbeeld.space.inline.ant}",
+          "type": "spacing"
         },
         "padding-block": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.flea}"
+          "value": "{voorbeeld.space.block.flea}",
+          "type": "spacing"
         },
         "informative": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.alert.info.background-color}"
+            "value": "{utrecht.alert.info.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.informative.color}"
+            "value": "{voorbeeld.feedback.informative.color}",
+            "type": "color"
           }
         },
         "positive": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.alert.ok.background-color}"
+            "value": "{utrecht.alert.ok.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.positive.color}"
+            "value": "{voorbeeld.feedback.positive.color}",
+            "type": "color"
           }
         },
         "negative": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.negative.background-color}"
+            "value": "{voorbeeld.feedback.negative.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.negative.color}"
+            "value": "{voorbeeld.feedback.negative.color}",
+            "type": "color"
           }
         },
         "warning": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.feedback.warning.background-color}"
+            "value": "{utrecht.feedback.warning.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.feedback.warning.color}"
+            "value": "{utrecht.feedback.warning.color}",
+            "type": "color"
           }
         },
         "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.violet.100}"
+          "value": "{voorbeeld.color.violet.100}",
+          "type": "color"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "value": "transparent",
+          "type": "color"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "value": "{utrecht.document.color}",
+          "type": "color"
         }
       }
     }
@@ -7609,200 +7609,200 @@
     "denhaag": {
       "step-marker": {
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{voorbeeld.border-width.md}"
+          "value": "{voorbeeld.border-width.md}",
+          "type": "borderWidth"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "padding": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "margin": {
-          "$type": "spacing",
-          "$value": "0"
+          "value": "0",
+          "type": "spacing"
         },
         "size": {
-          "$type": "sizing",
-          "$value": "{voorbeeld.size.sm}"
+          "value": "{voorbeeld.size.sm}",
+          "type": "sizing"
         },
         "icon": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           }
         },
         "current": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.violet.600}"
+            "value": "{voorbeeld.color.violet.600}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.document.inverse.color}"
+            "value": "{voorbeeld.document.inverse.color}",
+            "type": "color"
           },
           "nested": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.document.inverse.color}"
+              "value": "{voorbeeld.document.inverse.color}",
+              "type": "color"
             }
           }
         },
         "checked": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.positive.color}"
+            "value": "{voorbeeld.feedback.positive.color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.document.inverse.color}"
+            "value": "{voorbeeld.document.inverse.color}",
+            "type": "color"
           }
         },
         "default": {
           "background-color": {
-            "$type": "color",
-            "$value": "{denhaag.step-marker.default.border-color}"
+            "value": "{denhaag.step-marker.default.border-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           },
           "nested": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
+              "value": "{utrecht.document.color}",
+              "type": "color"
             }
           }
         },
         "disabled": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.50}"
+            "value": "{voorbeeld.color.gray.50}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
           }
         },
         "error": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.feedback.negative.color}"
+            "value": "{voorbeeld.feedback.negative.color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.document.inverse.color}"
+            "value": "{voorbeeld.document.inverse.color}",
+            "type": "color"
           }
         },
         "not-checked": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.document.background-color}"
+            "value": "{utrecht.document.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           }
         },
         "warning": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.feedback.warning.color}"
+            "value": "{utrecht.feedback.warning.color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.document.inverse.color}"
+            "value": "{voorbeeld.document.inverse.color}",
+            "type": "color"
           },
           "nested": {
             "background-color": {
-              "$type": "color",
-              "$value": "{denhaag.step-marker.warning.background-color}"
+              "value": "{denhaag.step-marker.warning.background-color}",
+              "type": "color"
             },
             "border-color": {
-              "$type": "color",
-              "$value": "{denhaag.step-marker.warning.border-color}"
+              "value": "{denhaag.step-marker.warning.border-color}",
+              "type": "color"
             }
           }
         },
         "nested": {
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.size.2xs}"
+            "value": "{voorbeeld.size.2xs}",
+            "type": "sizing"
           },
           "icon": {
             "size": {
-              "$type": "sizing",
-              "$value": "12px"
+              "value": "12px",
+              "type": "sizing"
             }
           }
         },
         "connector": {
           "outline-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           },
           "checked": {
             "outline-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.positive.border-color}"
+              "value": "{voorbeeld.feedback.positive.border-color}",
+              "type": "color"
             }
           },
           "default": {
             "outline-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.line.border-color}"
+              "value": "{voorbeeld.line.border-color}",
+              "type": "color"
             }
           },
           "error": {
             "outline-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.feedback.negative.border-color}"
+              "value": "{voorbeeld.feedback.negative.border-color}",
+              "type": "color"
             }
           },
           "not-checked": {
             "outline-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.line.border-color}"
+              "value": "{voorbeeld.line.border-color}",
+              "type": "color"
             }
           },
           "warning": {
             "outline-color": {
-              "$type": "color",
-              "$value": "{utrecht.feedback.warning.border-color}"
+              "value": "{utrecht.feedback.warning.border-color}",
+              "type": "color"
             }
           }
         }
@@ -7814,154 +7814,154 @@
       "switch": {
         "track": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
+            "value": "{voorbeeld.color.gray.500}",
+            "type": "color"
           },
           "active": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.700}"
+              "value": "{voorbeeld.color.gray.700}",
+              "type": "color"
             }
           },
           "hover": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.600}"
+              "value": "{voorbeeld.color.gray.600}",
+              "type": "color"
             }
           },
           "focus": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.background-color}"
+              "value": "{utrecht.focus.background-color}",
+              "type": "color"
             }
           },
           "disabled": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.300}"
+              "value": "{voorbeeld.color.gray.300}",
+              "type": "color"
             }
           },
           "checked": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.green.500}"
+              "value": "{voorbeeld.color.green.500}",
+              "type": "color"
             },
             "hover": {
               "background-color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.green.600}"
+                "value": "{voorbeeld.color.green.600}",
+                "type": "color"
               }
             },
             "active": {
               "background-color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.green.700}"
+                "value": "{voorbeeld.color.green.700}",
+                "type": "color"
               }
             },
             "focus": {
               "background-color": {
-                "$type": "color",
-                "$value": "{utrecht.focus.background-color}"
+                "value": "{utrecht.focus.background-color}",
+                "type": "color"
               }
             },
             "disabled": {
               "background-color": {
-                "$type": "color",
-                "$value": "{voorbeeld.color.gray.300}"
+                "value": "{voorbeeld.color.gray.300}",
+                "type": "color"
               }
             }
           },
           "border-radius": {
-            "$type": "borderRadius",
-            "$value": "{voorbeeld.border-radius.round}"
+            "value": "{voorbeeld.border-radius.round}",
+            "type": "borderRadius"
           },
           "padding-block": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.ant}"
+            "value": "{voorbeeld.space.inline.ant}",
+            "type": "spacing"
           },
           "padding-inline": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.ant}"
+            "value": "{voorbeeld.space.inline.ant}",
+            "type": "spacing"
           },
           "inline-size": {
-            "$type": "sizing",
-            "$value": "5rem"
+            "value": "5rem",
+            "type": "sizing"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           }
         },
         "icon": {
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
           },
           "focus": {
             "color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "value": "{utrecht.focus.color}",
+              "type": "color"
             }
           },
           "disabled": {
             "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.600}"
+              "value": "{voorbeeld.color.gray.600}",
+              "type": "color"
             }
           },
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.icon.functional.size}"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           }
         },
         "border-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "value": "transparent",
+          "type": "color"
         },
         "thumb": {
           "disabled": {
             "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
+              "value": "{voorbeeld.color.white}",
+              "type": "color"
             },
             "box-shadow": {
-              "$type": "boxShadow",
-              "$value": "None"
+              "value": "None",
+              "type": "boxShadow"
             }
           },
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.white}"
+            "value": "{voorbeeld.color.white}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "focus": {
             "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.color}"
+              "value": "{utrecht.focus.color}",
+              "type": "color"
             }
           },
           "min-inline-size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.size.sm}"
+            "value": "{voorbeeld.size.sm}",
+            "type": "sizing"
           },
           "min-block-size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.size.sm}"
+            "value": "{voorbeeld.size.sm}",
+            "type": "sizing"
           },
           "box-shadow": {
-            "$type": "boxShadow",
-            "$value": "{voorbeeld.box-shadow.sm}"
+            "value": "{voorbeeld.box-shadow.sm}",
+            "type": "boxShadow"
           },
           "border-radius": {
-            "$type": "borderRadius",
-            "$value": "{voorbeeld.border-radius.round}"
+            "value": "{voorbeeld.border-radius.round}",
+            "type": "borderRadius"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           }
         }
       }
@@ -7971,103 +7971,103 @@
     "utrecht": {
       "table": {
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "caption": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.heading.color}"
+            "value": "{utrecht.heading.color}",
+            "type": "color"
           },
           "line-height": {
-            "$type": "lineHeights",
-            "$value": "{voorbeeld.typography.line-height.sm}"
+            "value": "{voorbeeld.typography.line-height.sm}",
+            "type": "lineHeights"
           },
           "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{utrecht.heading.font-family}"
+            "value": "{utrecht.heading.font-family}",
+            "type": "fontFamilies"
           },
           "font-size": {
-            "$type": "fontSizes",
-            "$value": "{voorbeeld.typography.font-size.xl}"
+            "value": "{voorbeeld.typography.font-size.xl}",
+            "type": "fontSizes"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.heading.font-weight}"
+            "value": "{utrecht.heading.font-weight}",
+            "type": "fontWeights"
           },
           "margin-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.rabbit}"
+            "value": "{voorbeeld.space.block.rabbit}",
+            "type": "spacing"
           }
         },
         "cell": {
           "padding-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.snail}"
+            "value": "{voorbeeld.space.block.snail}",
+            "type": "spacing"
           },
           "padding-inline-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           },
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.mouse}"
+            "value": "{voorbeeld.space.inline.mouse}",
+            "type": "spacing"
           }
         },
         "footer": {
           "background-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           }
         },
         "header": {
           "background-color": {
-            "$type": "color",
-            "$value": "transparent"
+            "value": "transparent",
+            "type": "color"
           },
           "border-block-end-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           },
           "border-block-end-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           }
         },
         "header-cell": {
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           }
         },
         "row": {
           "border-block-end-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           },
           "border-block-end-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.sm}"
+            "value": "{voorbeeld.border-width.sm}",
+            "type": "borderWidth"
           }
         }
       }
@@ -8076,26 +8076,26 @@
       "table": {
         "container": {
           "box-inline-end-shadow": {
-            "$type": "boxShadow",
-            "$value": "{voorbeeld.box-shadow.lg}"
+            "value": "{voorbeeld.box-shadow.lg}",
+            "type": "boxShadow"
           },
           "box-inline-start-shadow": {
-            "$type": "boxShadow",
-            "$value": "{voorbeeld.box-shadow.lg}"
+            "value": "{voorbeeld.box-shadow.lg}",
+            "type": "boxShadow"
           }
         },
         "footer": {
           "border-block-start-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
+            "value": "{voorbeeld.line.border-color}",
+            "type": "color"
           },
           "border-block-start-width": {
-            "$type": "borderWidth",
-            "$value": "{voorbeeld.border-width.md}"
+            "value": "{voorbeeld.border-width.md}",
+            "type": "borderWidth"
           },
           "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{voorbeeld.document.strong.font-weight}"
+            "value": "{voorbeeld.document.strong.font-weight}",
+            "type": "fontWeights"
           }
         }
       }
@@ -8105,86 +8105,58 @@
     "todo": {
       "task-list": {
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
+          "type": "color",
+          "value": "{utrecht.document.color}"
         },
-        "marker": {
-          "checked": {
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.white}"
-            },
-            "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.green.600}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "transparent"
-            }
+        "icon": {
+          "color": {
+            "type": "color",
+            "value": "{voorbeeld.feedback.positive.color}"
           },
           "size": {
-            "$type": "sizing",
-            "$value": "{voorbeeld.size.xs}"
-          },
-          "icon": {
-            "size": {
-              "$type": "sizing",
-              "$value": "{voorbeeld.size.icon.sm}"
-            }
-          },
-          "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.border-width}"
-          },
-          "not-checked": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.read-only.background-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{utrecht.form-control.read-only.border-color}"
-            }
-          },
-          "border-radius": {
-            "$type": "borderRadius",
-            "$value": "0px"
+            "value": "{voorbeeld.icon.functional.size}",
+            "type": "sizing"
           }
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
+          "value": "{utrecht.document.font-weight}",
+          "type": "fontWeights"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "item": {
           "column-gap": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.column.mouse}"
-          },
-          "margin-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.ant}"
+            "value": "{voorbeeld.space.column.mouse}",
+            "type": "spacing"
           },
           "margin-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.ant}"
+            "value": "{voorbeeld.space.block.ant}",
+            "type": "spacing"
+          },
+          "margin-block-end": {
+            "value": "{voorbeeld.space.block.ant}",
+            "type": "spacing"
           }
         },
         "row-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.row.rat}"
+          "value": "{voorbeeld.space.row.snail}",
+          "type": "spacing"
+        },
+        "marker": {
+          "color": {
+            "type": "color",
+            "value": "{utrecht.document.color}"
+          }
         }
       }
     }
@@ -8193,138 +8165,138 @@
     "utrecht": {
       "textarea": {
         "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.background-color}"
+          "value": "{utrecht.form-control.background-color}",
+          "type": "color"
         },
         "border-block-end-width": {
-          "$type": "borderWidth",
-          "$value": "{utrecht.textarea.border-width}"
+          "value": "{utrecht.textarea.border-width}",
+          "type": "borderWidth"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.border-color}"
+          "value": "{utrecht.form-control.border-color}",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{utrecht.form-control.border-radius}"
+          "value": "{utrecht.form-control.border-radius}",
+          "type": "borderRadius"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{utrecht.form-control.border-width}"
+          "value": "{utrecht.form-control.border-width}",
+          "type": "borderWidth"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.color}"
+          "value": "{utrecht.form-control.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.form-control.font-family}"
+          "value": "{utrecht.form-control.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.form-control.font-size}"
+          "value": "{utrecht.form-control.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "max-inline-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.form-control.max-inline-size}"
+          "value": "{utrecht.form-control.max-inline-size}",
+          "type": "sizing"
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{utrecht.form-control.padding-block-end}"
+          "value": "{utrecht.form-control.padding-block-end}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{utrecht.form-control.padding-block-start}"
+          "value": "{utrecht.form-control.padding-block-start}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{utrecht.form-control.padding-inline-end}"
+          "value": "{utrecht.form-control.padding-inline-end}",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{utrecht.form-control.padding-inline-start}"
+          "value": "{utrecht.form-control.padding-inline-start}",
+          "type": "spacing"
         },
         "placeholder": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.placeholder.color}"
+            "value": "{utrecht.form-control.placeholder.color}",
+            "type": "color"
           }
         },
         "focus": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.background-color}"
+            "value": "{utrecht.form-control.focus.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.border-color}"
+            "value": "{utrecht.form-control.focus.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.color}"
+            "value": "{utrecht.form-control.focus.color}",
+            "type": "color"
           }
         },
         "disabled": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.background-color}"
+            "value": "{utrecht.form-control.disabled.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.border-color}"
+            "value": "{utrecht.form-control.disabled.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.color}"
+            "value": "{utrecht.form-control.disabled.color}",
+            "type": "color"
           }
         },
         "invalid": {
           "border-block-end-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.textarea.invalid.border-width}"
+            "value": "{utrecht.textarea.invalid.border-width}",
+            "type": "borderWidth"
           },
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.background-color}"
+            "value": "{utrecht.form-control.invalid.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.border-color}"
+            "value": "{utrecht.form-control.invalid.border-color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.invalid.border-width}"
+            "value": "{utrecht.form-control.invalid.border-width}",
+            "type": "borderWidth"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.color}"
+            "value": "{utrecht.form-control.color}",
+            "type": "color"
           }
         },
         "read-only": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.read-only.background-color}"
+            "value": "{utrecht.form-control.read-only.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.read-only.border-color}"
+            "value": "{utrecht.form-control.read-only.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.read-only.color}"
+            "value": "{utrecht.form-control.read-only.color}",
+            "type": "color"
           }
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.form-control.font-weight}"
+          "value": "{utrecht.form-control.font-weight}",
+          "type": "fontWeights"
         }
       }
     },
@@ -8332,16 +8304,16 @@
       "textarea": {
         "hover": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.background-color}"
+            "value": "{voorbeeld.form-control.hover.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.border-color}"
+            "value": "{voorbeeld.form-control.hover.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.color}"
+            "value": "{voorbeeld.form-control.hover.color}",
+            "type": "color"
           }
         }
       }
@@ -8351,138 +8323,138 @@
     "utrecht": {
       "textbox": {
         "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.background-color}"
+          "value": "{utrecht.form-control.background-color}",
+          "type": "color"
         },
         "border-block-end-width": {
-          "$type": "borderWidth",
-          "$value": "{utrecht.textbox.border-width}"
+          "value": "{utrecht.textbox.border-width}",
+          "type": "borderWidth"
         },
         "border-color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.border-color}"
+          "value": "{utrecht.form-control.border-color}",
+          "type": "color"
         },
         "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{utrecht.form-control.border-radius}"
+          "value": "{utrecht.form-control.border-radius}",
+          "type": "borderRadius"
         },
         "border-width": {
-          "$type": "borderWidth",
-          "$value": "{utrecht.form-control.border-width}"
+          "value": "{utrecht.form-control.border-width}",
+          "type": "borderWidth"
         },
         "color": {
-          "$type": "color",
-          "$value": "{utrecht.form-control.color}"
+          "value": "{utrecht.form-control.color}",
+          "type": "color"
         },
         "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.form-control.font-family}"
+          "value": "{utrecht.form-control.font-family}",
+          "type": "fontFamilies"
         },
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.form-control.font-size}"
+          "value": "{utrecht.form-control.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.form-control.line-height}"
+          "value": "{utrecht.form-control.line-height}",
+          "type": "lineHeights"
         },
         "max-inline-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.form-control.max-inline-size}"
+          "value": "{utrecht.form-control.max-inline-size}",
+          "type": "sizing"
         },
         "min-block-size": {
-          "$type": "sizing",
-          "$value": "{utrecht.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}",
+          "type": "sizing"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{utrecht.form-control.padding-block-end}"
+          "value": "{utrecht.form-control.padding-block-end}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{utrecht.form-control.padding-block-start}"
+          "value": "{utrecht.form-control.padding-block-start}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{utrecht.form-control.padding-inline-end}"
+          "value": "{utrecht.form-control.padding-inline-end}",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{utrecht.form-control.padding-inline-start}"
+          "value": "{utrecht.form-control.padding-inline-start}",
+          "type": "spacing"
         },
         "placeholder": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.placeholder.color}"
+            "value": "{utrecht.form-control.placeholder.color}",
+            "type": "color"
           }
         },
         "disabled": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.background-color}"
+            "value": "{utrecht.form-control.disabled.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.border-color}"
+            "value": "{utrecht.form-control.disabled.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.disabled.color}"
+            "value": "{utrecht.form-control.disabled.color}",
+            "type": "color"
           }
         },
         "focus": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.background-color}"
+            "value": "{utrecht.form-control.focus.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.border-color}"
+            "value": "{utrecht.form-control.focus.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.focus.color}"
+            "value": "{utrecht.form-control.focus.color}",
+            "type": "color"
           }
         },
         "invalid": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.background-color}"
+            "value": "{utrecht.form-control.invalid.background-color}",
+            "type": "color"
           },
           "border-block-end-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.textbox.invalid.border-width}"
+            "value": "{utrecht.textbox.invalid.border-width}",
+            "type": "borderWidth"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.invalid.border-color}"
+            "value": "{utrecht.form-control.invalid.border-color}",
+            "type": "color"
           },
           "border-width": {
-            "$type": "borderWidth",
-            "$value": "{utrecht.form-control.invalid.border-width}"
+            "value": "{utrecht.form-control.invalid.border-width}",
+            "type": "borderWidth"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.color}"
+            "value": "{utrecht.form-control.color}",
+            "type": "color"
           }
         },
         "read-only": {
           "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.read-only.background-color}"
+            "value": "{utrecht.form-control.read-only.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.read-only.border-color}"
+            "value": "{utrecht.form-control.read-only.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.form-control.read-only.color}"
+            "value": "{utrecht.form-control.read-only.color}",
+            "type": "color"
           }
         },
         "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.form-control.font-weight}"
+          "value": "{utrecht.form-control.font-weight}",
+          "type": "fontWeights"
         }
       }
     },
@@ -8490,16 +8462,16 @@
       "textbox": {
         "hover": {
           "background-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.background-color}"
+            "value": "{voorbeeld.form-control.hover.background-color}",
+            "type": "color"
           },
           "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.border-color}"
+            "value": "{voorbeeld.form-control.hover.border-color}",
+            "type": "color"
           },
           "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.form-control.hover.color}"
+            "value": "{voorbeeld.form-control.hover.color}",
+            "type": "color"
           }
         }
       }
@@ -8509,24 +8481,24 @@
     "todo": {
       "toolbar-button": {
         "column-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.text.beetle}"
+          "value": "{voorbeeld.space.text.beetle}",
+          "type": "spacing"
         },
         "padding-block-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-block-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.block.snail}"
+          "value": "{voorbeeld.space.block.snail}",
+          "type": "spacing"
         },
         "padding-inline-end": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.beetle}"
+          "value": "{voorbeeld.space.inline.beetle}",
+          "type": "spacing"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.beetle}"
+          "value": "{voorbeeld.space.inline.beetle}",
+          "type": "spacing"
         }
       }
     }
@@ -8535,35 +8507,35 @@
     "utrecht": {
       "unordered-list": {
         "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
         },
         "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
         },
         "padding-inline-start": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.inline.mouse}"
+          "value": "{voorbeeld.space.inline.mouse}",
+          "type": "spacing"
         },
         "item": {
           "padding-inline-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.inline.beetle}"
+            "value": "{voorbeeld.space.inline.beetle}",
+            "type": "spacing"
           },
           "margin-block-end": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.ant}"
+            "value": "{voorbeeld.space.block.ant}",
+            "type": "spacing"
           },
           "margin-block-start": {
-            "$type": "spacing",
-            "$value": "{voorbeeld.space.block.ant}"
+            "value": "{voorbeeld.space.block.ant}",
+            "type": "spacing"
           }
         },
         "marker": {
           "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "value": "{utrecht.document.color}",
+            "type": "color"
           }
         }
       }


### PR DESCRIPTION
On the 3rd of June I created [this PR](task-list-token-update) to save the updated design tokens for the simplified [Task List component (Experimental)](https://www.figma.com/design/gX3fq7k0uUKC45AJbuItDv/Local---Voorbeeld---Bibliotheek?node-id=922-1713). This component was created to show the completed checkpoints of the Estafette Model on our documentation page.

For the clean-up we are doing I would like to merge these changed to the main branch.