### PR TITLE
ci: use GitHub Actions workflow for GitHub Pages

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   continuous-integration:
     name: Continuous integration
@@ -17,6 +21,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
       - name: Install pnpm package manager
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
@@ -27,24 +34,16 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies specified in package.json
-        run: |
-          pnpm install
-          pnpm ls --recursive
+        run: pnpm install
 
       - name: Run the lint script in package.json scripts
-        run: |
-          pnpm run --if-present lint
-
-      # - name: "Continuous Integration: public code validator"
-      #   uses: nl-design-system/publiccode-parser-action@latest
+        run: pnpm run --if-present lint
 
       - name: Run the build script in package.json scripts
-        run: |
-          pnpm run --if-present build
+        run: pnpm run --if-present build
 
       - name: Run the test script in package.json scripts
-        run: |
-          pnpm run --if-present test
+        run: pnpm run --if-present test
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v4.0.1
@@ -62,32 +61,27 @@ jobs:
           storybookBuildDir: packages/storybook/dist/
 
       - name: Upload the Storybook artifact from the build step
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          name: storybook
           path: packages/storybook/dist/
-          retention-days: 1
 
   publish-storybook:
     runs-on: ubuntu-latest
     needs: continuous-integration
     if: github.ref == 'refs/heads/main'
 
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
+
+    permissions:
+      pages: write
+      id-token: write
+
     steps:
-      - name: Download code from GitHub
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Download the Storybook artifact from the "Build" job
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-        with:
-          name: storybook
-          path: packages/storybook/dist/
-
-      - name: Continuous Deployment to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@15de0f09300eea763baee31dff6c6184995c5f6a # v4.7.2
-        with:
-          branch: gh-pages
-          folder: packages/storybook/dist/
+      - name: Deploy to GitHub Pages
+        id: deploy-pages
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   publish-npm:
     runs-on: ubuntu-latest
@@ -109,13 +103,10 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install dependencies specified in package.json
-        run: |
-          pnpm install
-          pnpm ls --recursive
+        run: pnpm install
 
       - name: Run the build script in package.json
-        run: |
-          pnpm run --if-present build
+        run: pnpm run --if-present build
 
       - name: Check the release
         run: pnpm run lint-release


### PR DESCRIPTION
Switch from the legacy branch based workflow to deploy to GitHub Pages to the more modern workflow based one.

Add concurrency for builds.

Closes #945 
