### PR TITLE
chore: rename focus tokens to focus-visible

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -2109,7 +2109,7 @@
               "$value": "None"
             }
           },
-          "focus": {
+          "focus-visible": {
             "background-color": {
               "$type": "color",
               "$value": "{utrecht.focus.background-color}"
@@ -2810,7 +2810,7 @@
                 "$value": "{voorbeeld.color.violet.400}"
               }
             },
-            "focus": {
+            "focus-visible": {
               "background-color": {
                 "$type": "color",
                 "$value": "{voorbeeld.color.yellow.300}"
@@ -2818,7 +2818,7 @@
             }
           }
         },
-        "focus": {
+        "focus-visible": {
           "background-color": {
             "$type": "color",
             "$value": "{utrecht.focus.background-color}"
@@ -2975,7 +2975,7 @@
     "todo": {
       "checkbox": {
         "checked": {
-          "focus": {
+          "focus-visible": {
             "border-width": {
               "$type": "borderWidth",
               "$value": "{utrecht.form-control.focus.border-width}"
@@ -3081,7 +3081,7 @@
               "$value": "{voorbeeld.color.white}"
             }
           },
-          "focus": {
+          "focus-visible": {
             "border-width": {
               "$type": "borderWidth",
               "$value": "{utrecht.form-control.focus.border-width}"
@@ -3478,7 +3478,7 @@
       "contact-timeline": {
         "step-header": {
           "toggle": {
-            "focus": {
+            "focus-visible": {
               "background-color": {
                 "$type": "color",
                 "$value": "{utrecht.focus.background-color}"
@@ -5547,7 +5547,7 @@
               "$value": "underline"
             }
           },
-          "focus": {
+          "focus-visible": {
             "background-color": {
               "$type": "color",
               "$value": "{utrecht.focus.background-color}"
@@ -5665,7 +5665,7 @@
             "$type": "spacing",
             "$value": "{voorbeeld.space.inline.snail}"
           },
-          "focus": {
+          "focus-visible": {
             "text-decoration": {
               "$type": "textDecoration",
               "$value": "None"
@@ -6311,7 +6311,7 @@
                   "$value": "{voorbeeld.interaction.hover.color}"
                 }
               },
-              "focus": {
+              "focus-visible": {
                 "color": {
                   "$type": "color",
                   "$value": "{utrecht.focus.color}"
@@ -6341,7 +6341,7 @@
                   "$value": "{voorbeeld.color.violet.700}"
                 }
               },
-              "focus": {
+              "focus-visible": {
                 "color": {
                   "$type": "color",
                   "$value": "{utrecht.focus.color}"
@@ -6365,7 +6365,7 @@
                   "$value": "{voorbeeld.color.yellow.700}"
                 }
               },
-              "focus": {
+              "focus-visible": {
                 "color": {
                   "$type": "color",
                   "$value": "{utrecht.focus.color}"
@@ -6389,7 +6389,7 @@
                   "$value": "{voorbeeld.color.red.700}"
                 }
               },
-              "focus": {
+              "focus-visible": {
                 "color": {
                   "$type": "color",
                   "$value": "{utrecht.focus.color}"
@@ -6434,7 +6434,7 @@
                 "$value": "transparent"
               }
             },
-            "focus": {
+            "focus-visible": {
               "background-color": {
                 "$type": "color",
                 "$value": "{utrecht.focus.background-color}"
@@ -6486,7 +6486,7 @@
                 "$value": "transparent"
               }
             },
-            "focus": {
+            "focus-visible": {
               "background-color": {
                 "$type": "color",
                 "$value": "{utrecht.focus.background-color}"
@@ -6538,7 +6538,7 @@
                 "$value": "transparent"
               }
             },
-            "focus": {
+            "focus-visible": {
               "background-color": {
                 "$type": "color",
                 "$value": "{utrecht.focus.background-color}"
@@ -6590,7 +6590,7 @@
                 "$value": "transparent"
               }
             },
-            "focus": {
+            "focus-visible": {
               "background-color": {
                 "$type": "color",
                 "$value": "{utrecht.focus.background-color}"
@@ -7369,7 +7369,7 @@
     "todo": {
       "sidenav": {
         "link": {
-          "focus": {
+          "focus-visible": {
             "text-decoration": {
               "$type": "textDecoration",
               "$value": "None"
@@ -7831,7 +7831,7 @@
               "$value": "{voorbeeld.color.gray.600}"
             }
           },
-          "focus": {
+          "focus-visible": {
             "background-color": {
               "$type": "color",
               "$value": "{utrecht.focus.background-color}"
@@ -7860,7 +7860,7 @@
                 "$value": "{voorbeeld.color.green.700}"
               }
             },
-            "focus": {
+            "focus-visible": {
               "background-color": {
                 "$type": "color",
                 "$value": "{utrecht.focus.background-color}"
@@ -7899,7 +7899,7 @@
             "$type": "color",
             "$value": "{voorbeeld.color.white}"
           },
-          "focus": {
+          "focus-visible": {
             "color": {
               "$type": "color",
               "$value": "{utrecht.focus.color}"
@@ -7939,7 +7939,7 @@
             "$type": "color",
             "$value": "transparent"
           },
-          "focus": {
+          "focus-visible": {
             "background-color": {
               "$type": "color",
               "$value": "{utrecht.focus.color}"


### PR DESCRIPTION
As discussed with Robbert and Jeffrey during the Figma hygiene review, all `focus` tokens for Help Wanted components (with prefix `todo`) have been updated to `focus-visible`.

This update has been applied to the following components:

- Breadcrumb Navigation
- Case Card
- Checkbox
- Contact Timeline
- Page Number Navigation
- Progress List
- Side Navigation
- Switch