### PR TITLE
Feat: Add tokens to support suffix for Form Field Label todo component

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4038,15 +4038,9 @@
           "$type": "color",
           "$value": "{utrecht.document.color}"
         },
-        "suffix": {
-          "color": {
-            "$type": "color",
-            "$value": "{utrecht.document.color}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
-          }
+        "column-gap": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.text.beetle}"
         },
         "font-family": {
           "$type": "fontFamilies",
@@ -4064,9 +4058,15 @@
           "$type": "lineHeights",
           "$value": "{utrecht.document.line-height}"
         },
-        "column-gap": {
-          "$type": "spacing",
-          "$value": "{voorbeeld.space.text.beetle}"
+        "suffix": {
+          "color": {
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
+          }
         }
       }
     }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4038,6 +4038,16 @@
           "$type": "color",
           "$value": "{utrecht.document.color}"
         },
+        "suffix": {
+          "color": {
+            "$type": "color",
+            "$value": "{utrecht.document.color}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
+          }
+        },
         "font-family": {
           "$type": "fontFamilies",
           "$value": "{utrecht.document.font-family}"
@@ -4053,6 +4063,10 @@
         "line-height": {
           "$type": "lineHeights",
           "$value": "{utrecht.document.line-height}"
+        },
+        "column-gap": {
+          "$type": "spacing",
+          "$value": "{voorbeeld.space.text.beetle}"
         }
       }
     }


### PR DESCRIPTION
Added the following tokens to support suffix for Form Field Label todo component:

- `todo.form-field-label.suffix.color`
- `todo.form-field-label.suffix.font-weight`
- `todo.form-field-label.column-gap`