### PR TITLE
fix: npm-package-json-lint

### DIFF
--- a/npmpackagejsonlint.config.cjs
+++ b/npmpackagejsonlint.config.cjs
@@ -9,7 +9,7 @@ module.exports = {
   },
   overrides: [
     {
-      patterns: ['proprietary/**/package.json'],
+      patterns: ['proprietary/*/package.json'],
       rules: {
         'valid-values-license': ['error', ['SEE LICENSE IN LICENSE.md']],
       },


### PR DESCRIPTION
Make running npm-package-json-lint fast once more. This solution works because proprietary packages all live at `proprietary/*` and not nested any deeper.