### PR TITLE
fix: renamed token of progress-list

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -6150,11 +6150,9 @@
               "$type": "sizing",
               "$value": "{voorbeeld.size.2xs}"
             },
-            "figma": {
-              "inset-block-start": {
-                "$type": "spacing",
-                "$value": "{voorbeeld.space.block.ant}"
-              }
+            "inset-block-start": {
+              "$type": "spacing",
+              "$value": "{voorbeeld.space.block.ant}"
             },
             "padding-inline-start": {
               "$type": "spacing",


### PR DESCRIPTION
Renamed

`todo.progress-list.step-marker.nested.figma.inset-block-start`

to

`todo.progress-list.step-marker.nested.inset-block-start`