### PR TITLE
Refactor: split tokens per org

### DIFF
--- a/.changeset/hocus-pocus-pas.md
+++ b/.changeset/hocus-pocus-pas.md
@@ -1,0 +1,6 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": patch
+---
+
+- Split up component tokensets per organisation, making it easier to copy and paste a token set of a specific component from an organisation.
+- Changed the order of tokens, making them easier to scan.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -2083,6 +2083,114 @@
       }
     }
   },
+  "components/breadcrumb-nav/utrecht": {
+    "utrecht": {
+      "breadcrumb-nav": {
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
+        },
+        "min-block-size": {
+          "$type": "dimension",
+          "$value": "{utrecht.pointer-target.min-size}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
+        },
+        "item": {
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.snail}"
+          },
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.snail}"
+          },
+          "padding-inline-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.inline.beetle}"
+          },
+          "padding-inline-end": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.inline.beetle}"
+          }
+        },
+        "link": {
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
+          },
+          "focus": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{utrecht.focus.background-color}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{utrecht.focus.color}"
+            },
+            "text-decoration": {
+              "$type": "textDecoration",
+              "$value": "None"
+            }
+          },
+          "hover": {
+            "text-decoration": {
+              "$type": "textDecoration",
+              "$value": "None"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
+            }
+          },
+          "disabled": {
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.500}"
+            }
+          },
+          "current": {
+            "font-weight": {
+              "$type": "fontWeights",
+              "$value": "{utrecht.document.font-weight}"
+            }
+          },
+          "text-decoration": {
+            "$type": "textDecoration",
+            "$value": "underline"
+          },
+          "active": {
+            "text-decoration": {
+              "$type": "textDecoration",
+              "$value": "None"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.active.color}"
+            }
+          }
+        },
+        "separator": {
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.document.subtle.color}"
+          },
+          "icon": {
+            "size": {
+              "$type": "dimension",
+              "$value": "{voorbeeld.size.2xs}"
+            }
+          }
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
+        }
+      }
+    }
+  },
   "components/breadcrumb-nav/todo": {
     "todo": {
       "breadcrumb-nav": {
@@ -2191,114 +2299,6 @@
         "font-weight": {
           "$type": "fontWeights",
           "$value": "{utrecht.document.font-weight}"
-        }
-      }
-    }
-  },
-  "components/breadcrumb-nav/utrecht": {
-    "utrecht": {
-      "breadcrumb-nav": {
-        "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
-        },
-        "min-block-size": {
-          "$type": "dimension",
-          "$value": "{utrecht.pointer-target.min-size}"
-        },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
-        "item": {
-          "padding-block-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.snail}"
-          },
-          "padding-block-end": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.snail}"
-          },
-          "padding-inline-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.inline.beetle}"
-          },
-          "padding-inline-end": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.inline.beetle}"
-          }
-        },
-        "link": {
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
-          },
-          "focus": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.background-color}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{utrecht.focus.color}"
-            },
-            "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
-            }
-          },
-          "hover": {
-            "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
-            }
-          },
-          "disabled": {
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.500}"
-            }
-          },
-          "current": {
-            "font-weight": {
-              "$type": "fontWeights",
-              "$value": "{utrecht.document.font-weight}"
-            }
-          },
-          "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "underline"
-          },
-          "active": {
-            "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
-            }
-          }
-        },
-        "separator": {
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.document.subtle.color}"
-          },
-          "icon": {
-            "size": {
-              "$type": "dimension",
-              "$value": "{voorbeeld.size.2xs}"
-            }
-          }
-        },
-        "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
         }
       }
     }
@@ -3147,7 +3147,7 @@
       }
     }
   },
-  "components/code": {
+  "components/code/nl": {
     "nl": {
       "code": {
         "background-color": {
@@ -3167,7 +3167,9 @@
           "$value": "{utrecht.document.font-size}"
         }
       }
-    },
+    }
+  },
+  "components/code/utrecht": {
     "utrecht": {
       "code": {
         "background-color": {
@@ -3193,7 +3195,7 @@
       }
     }
   },
-  "components/code-block": {
+  "components/code-block/nl": {
     "nl": {
       "code-block": {
         "background-color": {
@@ -3229,7 +3231,9 @@
           "$value": "{voorbeeld.space.inline.mouse}"
         }
       }
-    },
+    }
+  },
+  "components/code-block/utrecht": {
     "utrecht": {
       "code-block": {
         "background-color": {
@@ -3271,7 +3275,7 @@
       }
     }
   },
-  "components/color-sample": {
+  "components/color-sample/nl": {
     "nl": {
       "color-sample": {
         "background-color": {
@@ -3299,7 +3303,9 @@
           "$value": "{voorbeeld.size.sm}"
         }
       }
-    },
+    }
+  },
+  "components/color-sample/utrecht": {
     "utrecht": {
       "color-sample": {
         "background-color": {
@@ -3501,7 +3507,7 @@
       }
     }
   },
-  "components/data-badge": {
+  "components/data-badge/nl": {
     "nl": {
       "data-badge": {
         "background-color": {
@@ -3557,7 +3563,9 @@
           "$value": "{voorbeeld.space.inline.ant}"
         }
       }
-    },
+    }
+  },
+  "components/data-badge/utrecht": {
     "utrecht": {
       "data-badge": {
         "min-block-size": {
@@ -3615,7 +3623,71 @@
       }
     }
   },
-  "components/drawer": {
+  "components/drawer/utrecht": {
+    "utrecht": {
+      "drawer": {
+        "border-width": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.border-width.sm}"
+        },
+        "padding-inline-start": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.space.inline.mouse}"
+        },
+        "padding-inline-end": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.space.inline.mouse}"
+        },
+        "background-color": {
+          "$type": "color",
+          "$value": "{utrecht.document.background-color}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.container.border-color}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        },
+        "border-radius": {
+          "$type": "dimension",
+          "$value": "0px"
+        },
+        "max-block-size": {
+          "$type": "dimension",
+          "$value": "800px"
+        },
+        "max-inline-size": {
+          "$type": "dimension",
+          "$value": "1440px"
+        },
+        "min-inline-size": {
+          "$type": "dimension",
+          "$value": "312px"
+        },
+        "min-block-size": {
+          "$type": "dimension",
+          "$value": "{utrecht.pointer-target.min-size}"
+        },
+        "padding-block-start": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.space.block.rabbit}"
+        },
+        "padding-block-end": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.space.block.rabbit}"
+        },
+        "backdrop": {
+          "min-size": {
+            "$type": "dimension",
+            "$value": "{utrecht.pointer-target.min-size}"
+          }
+        }
+      }
+    }
+  },
+  "components/drawer/todo": {
     "todo": {
       "drawer": {
         "header": {
@@ -3741,68 +3813,6 @@
         "box-shadow": {
           "$type": "boxShadow",
           "$value": "{voorbeeld.box-shadow.lg}"
-        }
-      }
-    },
-    "utrecht": {
-      "drawer": {
-        "border-width": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.border-width.sm}"
-        },
-        "padding-inline-start": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.space.inline.mouse}"
-        },
-        "padding-inline-end": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.space.inline.mouse}"
-        },
-        "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.document.background-color}"
-        },
-        "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.container.border-color}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
-        },
-        "border-radius": {
-          "$type": "dimension",
-          "$value": "0px"
-        },
-        "max-block-size": {
-          "$type": "dimension",
-          "$value": "800px"
-        },
-        "max-inline-size": {
-          "$type": "dimension",
-          "$value": "1440px"
-        },
-        "min-inline-size": {
-          "$type": "dimension",
-          "$value": "312px"
-        },
-        "min-block-size": {
-          "$type": "dimension",
-          "$value": "{utrecht.pointer-target.min-size}"
-        },
-        "padding-block-start": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.space.block.rabbit}"
-        },
-        "padding-block-end": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.space.block.rabbit}"
-        },
-        "backdrop": {
-          "min-size": {
-            "$type": "dimension",
-            "$value": "{utrecht.pointer-target.min-size}"
-          }
         }
       }
     }
@@ -4023,7 +4033,7 @@
       }
     }
   },
-  "components/form-field-label": {
+  "components/form-field-label/utrecht": {
     "utrecht": {
       "form-label": {
         "color": {
@@ -4071,7 +4081,9 @@
           }
         }
       }
-    },
+    }
+  },
+  "components/form-field-label/todo": {
     "todo": {
       "form-field-label": {
         "color": {
@@ -4305,7 +4317,7 @@
       }
     }
   },
-  "components/heading": {
+  "components/heading/nl": {
     "nl": {
       "heading": {
         "level-1": {
@@ -4441,7 +4453,9 @@
           }
         }
       }
-    },
+    }
+  },
+  "components/heading/amsterdam": {
     "ams": {
       "heading": {
         "font-weight": {
@@ -4713,7 +4727,7 @@
       }
     }
   },
-  "components/link": {
+  "components/link/nl": {
     "nl": {
       "link": {
         "color": {
@@ -4799,7 +4813,9 @@
           }
         }
       }
-    },
+    }
+  },
+  "components/link/utrecht": {
     "utrecht": {
       "link": {
         "color": {
@@ -5071,7 +5087,7 @@
       }
     }
   },
-  "components/mark": {
+  "components/mark/nl": {
     "nl": {
       "mark": {
         "background-color": {
@@ -5083,7 +5099,9 @@
           "$value": "{voorbeeld.document.inverse.color}"
         }
       }
-    },
+    }
+  },
+  "components/mark/utrecht": {
     "utrecht": {
       "mark": {
         "background-color": {
@@ -5265,7 +5283,7 @@
       }
     }
   },
-  "components/number-badge": {
+  "components/number-badge/nl": {
     "nl": {
       "number-badge": {
         "background-color": {
@@ -5317,7 +5335,9 @@
           "$value": "{voorbeeld.space.inline.ant}"
         }
       }
-    },
+    }
+  },
+  "components/number-badge/utrecht": {
     "utrecht": {
       "number-badge": {
         "font-size": {
@@ -5403,7 +5423,169 @@
       }
     }
   },
-  "components/page-number-navigation": {
+  "components/page-number-navigation/utrecht": {
+    "utrecht": {
+      "pagination": {
+        "relative-link": {
+          "border-width": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.border-width.sm}"
+          },
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.snail}"
+          },
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.snail}"
+          },
+          "padding-inline-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.inline.mouse}"
+          },
+          "padding-inline-end": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.inline.mouse}"
+          },
+          "text-decoration": {
+            "$type": "textDecoration",
+            "$value": "None"
+          },
+          "border-radius": {
+            "$type": "dimension",
+            "$value": "0px"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "transparent"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "transparent"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
+          },
+          "hover": {
+            "background-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
+            }
+          },
+          "disabled": {
+            "background-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.500}"
+            }
+          },
+          "text-transform": {
+            "$type": "textCase",
+            "$value": "None"
+          }
+        },
+        "page-link": {
+          "border-width": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.border-width.sm}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
+          },
+          "current": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.100}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{utrecht.document.color}"
+            }
+          },
+          "border-radius": {
+            "$type": "dimension",
+            "$value": "0px"
+          },
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.snail}"
+          },
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.snail}"
+          },
+          "padding-inline-end": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.inline.mouse}"
+          },
+          "padding-inline-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.inline.mouse}"
+          },
+          "hover": {
+            "background-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
+            }
+          },
+          "text-decoration": {
+            "$type": "textDecoration",
+            "$value": "None"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "transparent"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "transparent"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
+          }
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
+        }
+      }
+    }
+  },
+  "components/page-number-navigation/todo": {
     "todo": {
       "pagination": {
         "relative-link": {
@@ -5709,166 +5891,6 @@
           }
         }
       }
-    },
-    "utrecht": {
-      "pagination": {
-        "relative-link": {
-          "border-width": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.border-width.sm}"
-          },
-          "padding-block-end": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.snail}"
-          },
-          "padding-block-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.snail}"
-          },
-          "padding-inline-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.inline.mouse}"
-          },
-          "padding-inline-end": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.inline.mouse}"
-          },
-          "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
-          },
-          "border-radius": {
-            "$type": "dimension",
-            "$value": "0px"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "transparent"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "transparent"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
-          },
-          "hover": {
-            "background-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
-            }
-          },
-          "disabled": {
-            "background-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.500}"
-            }
-          },
-          "text-transform": {
-            "$type": "textCase",
-            "$value": "None"
-          }
-        },
-        "page-link": {
-          "border-width": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.border-width.sm}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
-          },
-          "current": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.100}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{utrecht.document.color}"
-            }
-          },
-          "border-radius": {
-            "$type": "dimension",
-            "$value": "0px"
-          },
-          "padding-block-end": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.snail}"
-          },
-          "padding-block-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.snail}"
-          },
-          "padding-inline-end": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.inline.mouse}"
-          },
-          "padding-inline-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.inline.mouse}"
-          },
-          "hover": {
-            "background-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
-            }
-          },
-          "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "transparent"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "transparent"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
-          }
-        },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
-        "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
-        }
-      }
     }
   },
   "components/paragraph/nl": {
@@ -5999,7 +6021,7 @@
       }
     }
   },
-  "components/progress-list": {
+  "components/progress-list/den-haag/todo": {
     "todo": {
       "progress-list": {
         "step-marker": {
@@ -8447,30 +8469,37 @@
       "components/avatar",
       "components/backdrop",
       "components/blockquote",
-      "components/breadcrumb-nav/todo",
       "components/breadcrumb-nav/utrecht",
+      "components/breadcrumb-nav/todo",
       "components/button",
       "components/case-card",
       "components/checkbox",
       "components/checkbox-group",
-      "components/code",
-      "components/code-block",
-      "components/color-sample",
+      "components/code/nl",
+      "components/code/utrecht",
+      "components/code-block/nl",
+      "components/code-block/utrecht",
+      "components/color-sample/nl",
+      "components/color-sample/utrecht",
       "components/contact-timeline",
-      "components/data-badge",
-      "components/drawer",
+      "components/data-badge/nl",
+      "components/data-badge/utrecht",
+      "components/drawer/utrecht",
+      "components/drawer/todo",
       "components/figure",
       "components/file",
       "components/form-field",
       "components/form-field-checkbox-option",
       "components/form-field-description",
       "components/form-field-error-message",
-      "components/form-field-label",
+      "components/form-field-label/utrecht",
+      "components/form-field-label/todo",
       "components/form-field-label-suffix",
       "components/form-field-option-label",
       "components/form-field-radio-option",
       "components/form-summary",
-      "components/heading",
+      "components/heading/nl",
+      "components/heading/amsterdam",
       "components/heading-1",
       "components/heading-2",
       "components/heading-3",
@@ -8479,20 +8508,24 @@
       "components/heading-6",
       "components/icon",
       "components/icon-only-button",
-      "components/link",
+      "components/link/nl",
+      "components/link/utrecht",
       "components/link-list",
       "components/login-link",
       "components/logo",
-      "components/mark",
+      "components/mark/nl",
+      "components/mark/utrecht",
       "components/modal-dialog",
       "components/navigation-bar",
-      "components/number-badge",
+      "components/number-badge/nl",
+      "components/number-badge/utrecht",
       "components/ordered-list",
-      "components/page-number-navigation",
+      "components/page-number-navigation/utrecht",
+      "components/page-number-navigation/todo",
       "components/paragraph/nl",
       "components/paragraph/utrecht",
       "components/pre-heading",
-      "components/progress-list",
+      "components/progress-list/den-haag/todo",
       "components/radio-button",
       "components/radio-group",
       "components/select",

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -2086,6 +2086,14 @@
   "components/breadcrumb-nav/utrecht": {
     "utrecht": {
       "breadcrumb-nav": {
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
+        },
         "line-height": {
           "$type": "lineHeights",
           "$value": "{utrecht.document.line-height}"
@@ -2094,24 +2102,20 @@
           "$type": "dimension",
           "$value": "{utrecht.pointer-target.min-size}"
         },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
         "item": {
-          "padding-block-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.snail}"
-          },
           "padding-block-end": {
             "$type": "dimension",
             "$value": "{voorbeeld.space.block.snail}"
           },
-          "padding-inline-start": {
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.snail}"
+          },
+          "padding-inline-end": {
             "$type": "dimension",
             "$value": "{voorbeeld.space.inline.beetle}"
           },
-          "padding-inline-end": {
+          "padding-inline-start": {
             "$type": "dimension",
             "$value": "{voorbeeld.space.inline.beetle}"
           }
@@ -2120,6 +2124,32 @@
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.interaction.color}"
+          },
+          "text-decoration": {
+            "$type": "textDecoration",
+            "$value": "underline"
+          },
+          "active": {
+            "text-decoration": {
+              "$type": "textDecoration",
+              "$value": "None"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.active.color}"
+            }
+          },
+          "current": {
+            "font-weight": {
+              "$type": "fontWeights",
+              "$value": "{utrecht.document.font-weight}"
+            }
+          },
+          "disabled": {
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.500}"
+            }
           },
           "focus": {
             "background-color": {
@@ -2144,32 +2174,6 @@
               "$type": "color",
               "$value": "{voorbeeld.interaction.hover.color}"
             }
-          },
-          "disabled": {
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.500}"
-            }
-          },
-          "current": {
-            "font-weight": {
-              "$type": "fontWeights",
-              "$value": "{utrecht.document.font-weight}"
-            }
-          },
-          "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "underline"
-          },
-          "active": {
-            "text-decoration": {
-              "$type": "textDecoration",
-              "$value": "None"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.active.color}"
-            }
           }
         },
         "separator": {
@@ -2183,10 +2187,6 @@
               "$value": "{voorbeeld.size.2xs}"
             }
           }
-        },
-        "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
         }
       }
     }
@@ -2194,23 +2194,35 @@
   "components/breadcrumb-nav/todo": {
     "todo": {
       "breadcrumb-nav": {
-        "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
+        "column-gap": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.space.column.snail}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
         },
         "font-size": {
           "$type": "fontSizes",
           "$value": "{utrecht.document.font-size}"
         },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{utrecht.document.font-weight}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
+        },
         "link": {
           "icon": {
-            "size": {
-              "$type": "dimension",
-              "$value": "{voorbeeld.icon.functional.size}"
-            },
             "column-gap": {
               "$type": "dimension",
               "$value": "{voorbeeld.space.text.beetle}"
+            },
+            "size": {
+              "$type": "dimension",
+              "$value": "{voorbeeld.icon.functional.size}"
             }
           },
           "padding-block-end": {
@@ -2279,26 +2291,14 @@
           }
         },
         "separator": {
-          "size": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.size.2xs}"
-          },
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.document.subtle.color}"
+          },
+          "size": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.size.2xs}"
           }
-        },
-        "column-gap": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.space.column.snail}"
-        },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.document.font-weight}"
         }
       }
     }
@@ -3568,6 +3568,42 @@
   "components/data-badge/utrecht": {
     "utrecht": {
       "data-badge": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.violet.100}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "transparent"
+        },
+        "border-radius": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.border-radius.sm}"
+        },
+        "border-width": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.border-width.sm}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.document.strong.font-weight}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{utrecht.document.line-height}"
+        },
         "min-block-size": {
           "$type": "dimension",
           "$value": "{voorbeeld.size.xs}"
@@ -3583,42 +3619,6 @@
         "padding-inline": {
           "$type": "dimension",
           "$value": "{voorbeeld.space.inline.ant}"
-        },
-        "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.violet.100}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
-        },
-        "border-color": {
-          "$type": "color",
-          "$value": "transparent"
-        },
-        "border-radius": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.border-radius.sm}"
-        },
-        "border-width": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.border-width.sm}"
-        },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
-        },
-        "line-height": {
-          "$type": "lineHeights",
-          "$value": "{utrecht.document.line-height}"
-        },
-        "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
         }
       }
     }
@@ -3626,18 +3626,6 @@
   "components/drawer/utrecht": {
     "utrecht": {
       "drawer": {
-        "border-width": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.border-width.sm}"
-        },
-        "padding-inline-start": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.space.inline.mouse}"
-        },
-        "padding-inline-end": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.space.inline.mouse}"
-        },
         "background-color": {
           "$type": "color",
           "$value": "{utrecht.document.background-color}"
@@ -3646,13 +3634,25 @@
           "$type": "color",
           "$value": "{voorbeeld.container.border-color}"
         },
+        "border-radius": {
+          "$type": "dimension",
+          "$value": "0px"
+        },
+        "border-width": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.border-width.sm}"
+        },
         "color": {
           "$type": "color",
           "$value": "{utrecht.document.color}"
         },
-        "border-radius": {
+        "padding-inline-end": {
           "$type": "dimension",
-          "$value": "0px"
+          "$value": "{voorbeeld.space.inline.mouse}"
+        },
+        "padding-inline-start": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.space.inline.mouse}"
         },
         "max-block-size": {
           "$type": "dimension",
@@ -3662,19 +3662,19 @@
           "$type": "dimension",
           "$value": "1440px"
         },
-        "min-inline-size": {
-          "$type": "dimension",
-          "$value": "312px"
-        },
         "min-block-size": {
           "$type": "dimension",
           "$value": "{utrecht.pointer-target.min-size}"
         },
-        "padding-block-start": {
+        "min-inline-size": {
+          "$type": "dimension",
+          "$value": "312px"
+        },
+        "padding-block-end": {
           "$type": "dimension",
           "$value": "{voorbeeld.space.block.rabbit}"
         },
-        "padding-block-end": {
+        "padding-block-start": {
           "$type": "dimension",
           "$value": "{voorbeeld.space.block.rabbit}"
         },
@@ -3690,10 +3690,62 @@
   "components/drawer/todo": {
     "todo": {
       "drawer": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{utrecht.document.background-color}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.container.border-color}"
+        },
+        "border-radius": {
+          "$type": "dimension",
+          "$value": "0px"
+        },
+        "border-width": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.border-width.sm}"
+        },
+        "box-shadow": {
+          "$type": "boxShadow",
+          "$value": "{voorbeeld.box-shadow.lg}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        },
         "header": {
+          "background-color": {
+            "$type": "color",
+            "$value": "transparent"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.line.border-color}"
+          },
           "border-width": {
             "$type": "dimension",
             "$value": "{voorbeeld.border-width.sm}"
+          },
+          "column-gap": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.column.snail}"
+          },
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.beetle}"
+          },
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.beetle}"
+          },
+          "padding-inline-end": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.inline.beetle}"
+          },
+          "padding-inline-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.inline.mouse}"
           },
           "label": {
             "color": {
@@ -3716,73 +3768,7 @@
               "$type": "lineHeights",
               "$value": "{utrecht.document.line-height}"
             }
-          },
-          "padding-block-end": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.beetle}"
-          },
-          "padding-block-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.beetle}"
-          },
-          "padding-inline-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.inline.mouse}"
-          },
-          "padding-inline-end": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.inline.beetle}"
-          },
-          "column-gap": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.column.snail}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "transparent"
           }
-        },
-        "border-radius": {
-          "$type": "dimension",
-          "$value": "0px"
-        },
-        "footer": {
-          "border-width": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.border-width.sm}"
-          },
-          "padding-block-end": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.mouse}"
-          },
-          "padding-block-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.mouse}"
-          },
-          "padding-inline-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.inline.mouse}"
-          },
-          "padding-inline-end": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.inline.mouse}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{voorbeeld.line.border-color}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "transparent"
-          }
-        },
-        "border-width": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.border-width.sm}"
         },
         "content": {
           "padding-block-end": {
@@ -3798,21 +3784,35 @@
             "$value": "{voorbeeld.space.inline.mouse}"
           }
         },
-        "background-color": {
-          "$type": "color",
-          "$value": "{utrecht.document.background-color}"
-        },
-        "border-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.container.border-color}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
-        },
-        "box-shadow": {
-          "$type": "boxShadow",
-          "$value": "{voorbeeld.box-shadow.lg}"
+        "footer": {
+          "background-color": {
+            "$type": "color",
+            "$value": "transparent"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{voorbeeld.line.border-color}"
+          },
+          "border-width": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.border-width.sm}"
+          },
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.mouse}"
+          },
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.mouse}"
+          },
+          "padding-inline-end": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.inline.mouse}"
+          },
+          "padding-inline-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.inline.mouse}"
+          }
         }
       }
     }
@@ -4458,81 +4458,81 @@
   "components/heading/amsterdam": {
     "ams": {
       "heading": {
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{utrecht.heading.font-weight}"
-        },
         "color": {
           "$type": "color",
           "$value": "{utrecht.heading.color}"
-        },
-        "inverse-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.document.inverse.color}"
         },
         "font-family": {
           "$type": "fontFamilies",
           "$value": "{utrecht.heading.font-family}"
         },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{utrecht.heading.font-weight}"
+        },
+        "inverse-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.document.inverse.color}"
+        },
         "level": {
           "1": {
-            "line-height": {
-              "$type": "lineHeights",
-              "$value": "{voorbeeld.typography.line-height.sm}"
-            },
             "font-size": {
               "$type": "fontSizes",
               "$value": "{voorbeeld.typography.font-size.3xl}"
+            },
+            "line-height": {
+              "$type": "lineHeights",
+              "$value": "{voorbeeld.typography.line-height.sm}"
             }
           },
           "2": {
-            "line-height": {
-              "$type": "lineHeights",
-              "$value": "{voorbeeld.typography.line-height.sm}"
-            },
             "font-size": {
               "$type": "fontSizes",
               "$value": "{voorbeeld.typography.font-size.2xl}"
-            }
-          },
-          "3": {
+            },
             "line-height": {
               "$type": "lineHeights",
               "$value": "{voorbeeld.typography.line-height.sm}"
-            },
+            }
+          },
+          "3": {
             "font-size": {
               "$type": "fontSizes",
               "$value": "{voorbeeld.typography.font-size.xl}"
+            },
+            "line-height": {
+              "$type": "lineHeights",
+              "$value": "{voorbeeld.typography.line-height.sm}"
             }
           },
           "4": {
-            "line-height": {
-              "$type": "lineHeights",
-              "$value": "{voorbeeld.typography.line-height.md}"
-            },
             "font-size": {
               "$type": "fontSizes",
               "$value": "{voorbeeld.typography.font-size.lg}"
+            },
+            "line-height": {
+              "$type": "lineHeights",
+              "$value": "{voorbeeld.typography.line-height.md}"
             }
           },
           "5": {
-            "line-height": {
-              "$type": "lineHeights",
-              "$value": "{voorbeeld.typography.line-height.md}"
-            },
             "font-size": {
               "$type": "fontSizes",
               "$value": "{voorbeeld.typography.font-size.md}"
-            }
-          },
-          "6": {
+            },
             "line-height": {
               "$type": "lineHeights",
               "$value": "{voorbeeld.typography.line-height.md}"
-            },
+            }
+          },
+          "6": {
             "font-size": {
               "$type": "fontSizes",
               "$value": "{voorbeeld.typography.font-size.sm}"
+            },
+            "line-height": {
+              "$type": "lineHeights",
+              "$value": "{voorbeeld.typography.line-height.md}"
             }
           }
         }
@@ -4734,13 +4734,13 @@
           "$type": "color",
           "$value": "{voorbeeld.interaction.color}"
         },
-        "text-decoration-line": {
-          "$type": "textDecoration",
-          "$value": "underline"
-        },
         "text-decoration-color": {
           "$type": "color",
           "$value": "{voorbeeld.interaction.color}"
+        },
+        "text-decoration-line": {
+          "$type": "textDecoration",
+          "$value": "underline"
         },
         "text-decoration-thickness": {
           "$type": "other",
@@ -4762,6 +4762,22 @@
           "text-decoration-thickness": {
             "$type": "other",
             "$value": "auto"
+          }
+        },
+        "current": {
+          "cursor": {
+            "$type": "other",
+            "$value": "default"
+          }
+        },
+        "disabled": {
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.color.gray.500}"
+          },
+          "cursor": {
+            "$type": "other",
+            "$value": "disabled"
           }
         },
         "focus-visible": {
@@ -4794,22 +4810,6 @@
           "text-decoration-thickness": {
             "$type": "other",
             "$value": "auto"
-          }
-        },
-        "disabled": {
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.color.gray.500}"
-          },
-          "cursor": {
-            "$type": "other",
-            "$value": "disabled"
-          }
-        },
-        "current": {
-          "cursor": {
-            "$type": "other",
-            "$value": "default"
           }
         }
       }
@@ -5310,13 +5310,13 @@
           "$type": "fontFamilies",
           "$value": "{utrecht.document.font-family}"
         },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
-        },
         "font-size": {
           "$type": "fontSizes",
           "$value": "{voorbeeld.typography.font-size.sm}"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.document.strong.font-weight}"
         },
         "min-block-size": {
           "$type": "dimension",
@@ -5340,9 +5340,37 @@
   "components/number-badge/utrecht": {
     "utrecht": {
       "number-badge": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{voorbeeld.color.violet.100}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "transparent"
+        },
+        "border-radius": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.border-radius.round}"
+        },
+        "border-width": {
+          "$type": "dimension",
+          "$value": "{voorbeeld.border-width.sm}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{utrecht.document.color}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
+        },
         "font-size": {
           "$type": "fontSizes",
           "$value": "{voorbeeld.typography.font-size.sm}"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{voorbeeld.document.strong.font-weight}"
         },
         "min-block-size": {
           "$type": "dimension",
@@ -5352,41 +5380,13 @@
           "$type": "dimension",
           "$value": "{voorbeeld.size.xs}"
         },
-        "border-radius": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.border-radius.round}"
-        },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
-        "background-color": {
-          "$type": "color",
-          "$value": "{voorbeeld.color.violet.100}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{utrecht.document.color}"
-        },
-        "padding-inline": {
-          "$type": "dimension",
-          "$value": "{voorbeeld.space.inline.ant}"
-        },
         "padding-block": {
           "$type": "dimension",
           "$value": "{voorbeeld.space.block.ant}"
         },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{voorbeeld.document.strong.font-weight}"
-        },
-        "border-width": {
+        "padding-inline": {
           "$type": "dimension",
-          "$value": "{voorbeeld.border-width.sm}"
-        },
-        "border-color": {
-          "$type": "color",
-          "$value": "transparent"
+          "$value": "{voorbeeld.space.inline.ant}"
         }
       }
     }
@@ -5426,79 +5426,13 @@
   "components/page-number-navigation/utrecht": {
     "utrecht": {
       "pagination": {
-        "relative-link": {
-          "border-width": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.border-width.sm}"
-          },
-          "padding-block-end": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.snail}"
-          },
-          "padding-block-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.block.snail}"
-          },
-          "padding-inline-start": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.inline.mouse}"
-          },
-          "padding-inline-end": {
-            "$type": "dimension",
-            "$value": "{voorbeeld.space.inline.mouse}"
-          },
-          "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
-          },
-          "border-radius": {
-            "$type": "dimension",
-            "$value": "0px"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{utrecht.document.font-weight}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "transparent"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "transparent"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{voorbeeld.interaction.color}"
-          },
-          "hover": {
-            "background-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.interaction.hover.color}"
-            }
-          },
-          "disabled": {
-            "background-color": {
-              "$type": "color",
-              "$value": "transparent"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{voorbeeld.color.gray.500}"
-            }
-          },
-          "text-transform": {
-            "$type": "textCase",
-            "$value": "None"
-          }
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{utrecht.document.font-family}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{utrecht.document.font-size}"
         },
         "page-link": {
           "border-width": {
@@ -5574,13 +5508,79 @@
             "$value": "{voorbeeld.interaction.color}"
           }
         },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{utrecht.document.font-family}"
-        },
-        "font-size": {
-          "$type": "fontSizes",
-          "$value": "{utrecht.document.font-size}"
+        "relative-link": {
+          "border-width": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.border-width.sm}"
+          },
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.snail}"
+          },
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.block.snail}"
+          },
+          "padding-inline-start": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.inline.mouse}"
+          },
+          "padding-inline-end": {
+            "$type": "dimension",
+            "$value": "{voorbeeld.space.inline.mouse}"
+          },
+          "text-decoration": {
+            "$type": "textDecoration",
+            "$value": "None"
+          },
+          "border-radius": {
+            "$type": "dimension",
+            "$value": "0px"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{utrecht.document.font-weight}"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "transparent"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "transparent"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{voorbeeld.interaction.color}"
+          },
+          "hover": {
+            "background-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.interaction.hover.color}"
+            }
+          },
+          "disabled": {
+            "background-color": {
+              "$type": "color",
+              "$value": "transparent"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{voorbeeld.color.gray.500}"
+            }
+          },
+          "text-transform": {
+            "$type": "textCase",
+            "$value": "None"
+          }
         }
       }
     }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -6021,7 +6021,7 @@
       }
     }
   },
-  "components/progress-list/den-haag/todo": {
+  "components/progress-list/todo": {
     "todo": {
       "progress-list": {
         "step-marker": {
@@ -6595,7 +6595,9 @@
           }
         }
       }
-    },
+    }
+  },
+  "components/progress-list/den-haag": {
     "denhaag": {
       "process-steps": {
         "font-familiy": {
@@ -7311,7 +7313,7 @@
       }
     }
   },
-  "components/skip-link": {
+  "components/skip-link/nl": {
     "nl": {
       "skip-link": {
         "background-color": {
@@ -7355,7 +7357,9 @@
           "$value": "1px"
         }
       }
-    },
+    }
+  },
+  "components/skip-link/utrecht": {
     "utrecht": {
       "skip-link": {
         "background-color": {
@@ -8525,13 +8529,15 @@
       "components/paragraph/nl",
       "components/paragraph/utrecht",
       "components/pre-heading",
-      "components/progress-list/den-haag/todo",
+      "components/progress-list/todo",
+      "components/progress-list/den-haag",
       "components/radio-button",
       "components/radio-group",
       "components/select",
       "components/separator",
       "components/side-nav",
-      "components/skip-link",
+      "components/skip-link/nl",
+      "components/skip-link/utrecht",
       "components/status-badge",
       "components/step-marker",
       "components/switch",

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -2083,7 +2083,7 @@
       }
     }
   },
-  "components/breadcrumb-nav": {
+  "components/breadcrumb-nav/todo": {
     "todo": {
       "breadcrumb-nav": {
         "line-height": {
@@ -2193,7 +2193,9 @@
           "$value": "{utrecht.document.font-weight}"
         }
       }
-    },
+    }
+  },
+  "components/breadcrumb-nav/utrecht": {
     "utrecht": {
       "breadcrumb-nav": {
         "line-height": {
@@ -5869,7 +5871,7 @@
       }
     }
   },
-  "components/paragraph": {
+  "components/paragraph/nl": {
     "nl": {
       "paragraph": {
         "color": {
@@ -5907,7 +5909,9 @@
           }
         }
       }
-    },
+    }
+  },
+  "components/paragraph/utrecht": {
     "utrecht": {
       "paragraph": {
         "color": {
@@ -8443,7 +8447,8 @@
       "components/avatar",
       "components/backdrop",
       "components/blockquote",
-      "components/breadcrumb-nav",
+      "components/breadcrumb-nav/todo",
+      "components/breadcrumb-nav/utrecht",
       "components/button",
       "components/case-card",
       "components/checkbox",
@@ -8484,7 +8489,8 @@
       "components/number-badge",
       "components/ordered-list",
       "components/page-number-navigation",
-      "components/paragraph",
+      "components/paragraph/nl",
+      "components/paragraph/utrecht",
       "components/pre-heading",
       "components/progress-list",
       "components/radio-button",


### PR DESCRIPTION
This PR relates to: https://github.com/nl-design-system/documentatie/issues/2114

It will split up component token sets per organisation, making it easier to copy and paste a token set of a specific component from an organisation.

Component tokens affected:

- Breadcrumb Navigation
- Code
- Code Block
- Color Sample
- Data Badge
- Drawer
- Form Field Label
- Heading
- Link
- Mark
- Number Badge
- Page Number Badge
- Paragraph
- Progress List
- Skip Link

P.S. Changed the order of tokens for most of the tokensets while I was at it.

