### PR TITLE
Groningen - Style fix border width koppeling secondary button 

### DIFF
--- a/proprietary/groningen-design-tokens/figma/figma.tokens.json
+++ b/proprietary/groningen-design-tokens/figma/figma.tokens.json
@@ -1232,7 +1232,7 @@
         },
         "negative": {
           "background-color": {
-            "value": "{groningen.feedback.negative.background-color}",
+            "value": "{groningen.form-control.disabled.accent-color}",
             "type": "color"
           },
           "border-color": {


### PR DESCRIPTION
Bij implementatie van open stad kwamen we erachter dat secondary button  niet goed gekoppeld is met de border width. Hierdoor lijkt secondary button momenteel op de subtle button.