### PR TITLE
feat(heading-tokens): add new tokens

### DIFF
--- a/.changeset/bax-top-step.md
+++ b/.changeset/bax-top-step.md
@@ -1,0 +1,18 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+---
+
+De volgende tokens zijn toegevoegd aan de Heading component.
+
+- `nl.heading.level-1.margin-block-start`
+- `nl.heading.level-1.margin-block-end`
+- `nl.heading.level-2.margin-block-start`
+- `nl.heading.level-2.margin-block-end`
+- `nl.heading.level-3.margin-block-start`
+- `nl.heading.level-3.margin-block-end`
+- `nl.heading.level-4.margin-block-start`
+- `nl.heading.level-4.margin-block-end`
+- `nl.heading.level-5.margin-block-start`
+- `nl.heading.level-5.margin-block-end`
+- `nl.heading.level-6.margin-block-start`
+- `nl.heading.level-6.margin-block-end`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4340,6 +4340,16 @@
           "line-height": {
             "$type": "lineHeights",
             "$value": "{voorbeeld.typography.line-height.sm}"
+          },
+          "margin-block-end": {
+            "$type": "spacing",
+            "$value": "0px",
+            "$description": "[code-only]"
+          },
+          "margin-block-start": {
+            "$type": "spacing",
+            "$value": "0px",
+            "$description": "[code-only]"
           }
         },
         "level-2": {
@@ -4362,6 +4372,16 @@
           "line-height": {
             "$type": "lineHeights",
             "$value": "{voorbeeld.typography.line-height.sm}"
+          },
+          "margin-block-end": {
+            "$type": "spacing",
+            "$value": "0px",
+            "$description": "[code-only]"
+          },
+          "margin-block-start": {
+            "$type": "spacing",
+            "$value": "0px",
+            "$description": "[code-only]"
           }
         },
         "level-3": {
@@ -4384,6 +4404,16 @@
           "line-height": {
             "$type": "lineHeights",
             "$value": "{voorbeeld.typography.line-height.sm}"
+          },
+          "margin-block-end": {
+            "$type": "spacing",
+            "$value": "0px",
+            "$description": "[code-only]"
+          },
+          "margin-block-start": {
+            "$type": "spacing",
+            "$value": "0px",
+            "$description": "[code-only]"
           }
         },
         "level-4": {
@@ -4406,6 +4436,16 @@
           "line-height": {
             "$type": "lineHeights",
             "$value": "{voorbeeld.typography.line-height.md}"
+          },
+          "margin-block-end": {
+            "$type": "spacing",
+            "$value": "0px",
+            "$description": "[code-only]"
+          },
+          "margin-block-start": {
+            "$type": "spacing",
+            "$value": "0px",
+            "$description": "[code-only]"
           }
         },
         "level-5": {
@@ -4428,6 +4468,16 @@
           "line-height": {
             "$type": "lineHeights",
             "$value": "{voorbeeld.typography.line-height.md}"
+          },
+          "margin-block-end": {
+            "$type": "spacing",
+            "$value": "0px",
+            "$description": "[code-only]"
+          },
+          "margin-block-start": {
+            "$type": "spacing",
+            "$value": "0px",
+            "$description": "[code-only]"
           }
         },
         "level-6": {
@@ -4450,6 +4500,16 @@
           "line-height": {
             "$type": "lineHeights",
             "$value": "{voorbeeld.typography.line-height.md}"
+          },
+          "margin-block-end": {
+            "$type": "spacing",
+            "$value": "0px",
+            "$description": "[code-only]"
+          },
+          "margin-block-start": {
+            "$type": "spacing",
+            "$value": "0px",
+            "$description": "[code-only]"
           }
         }
       }


### PR DESCRIPTION
De volgende tokens zijn toegevoegd aan de Heading component.

- `nl.heading.level-1.margin-block-start`
- `nl.heading.level-1.margin-block-end`
- `nl.heading.level-2.margin-block-start`
- `nl.heading.level-2.margin-block-end`
- `nl.heading.level-3.margin-block-start`
- `nl.heading.level-3.margin-block-end`
- `nl.heading.level-4.margin-block-start`
- `nl.heading.level-4.margin-block-end`
- `nl.heading.level-5.margin-block-start`
- `nl.heading.level-5.margin-block-end`
- `nl.heading.level-6.margin-block-start`
- `nl.heading.level-6.margin-block-end`