### PR TITLE
refactor(link): removed tokens

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4814,14 +4814,6 @@
           "color": {
             "$type": "color",
             "$value": "{voorbeeld.interaction.active.color}"
-          },
-          "text-decoration-line": {
-            "$type": "textDecoration",
-            "$value": "None"
-          },
-          "text-decoration-thickness": {
-            "$type": "other",
-            "$value": "auto"
           }
         },
         "current": {
@@ -4838,24 +4830,6 @@
           "cursor": {
             "$type": "other",
             "$value": "disabled"
-          }
-        },
-        "focus-visible": {
-          "background-color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.background-color}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{utrecht.focus.color}"
-          },
-          "text-decoration-line": {
-            "$type": "textDecoration",
-            "$value": "None"
-          },
-          "text-decoration-thickness": {
-            "$type": "other",
-            "$value": "auto"
           }
         },
         "hover": {


### PR DESCRIPTION
De volgende tokens zijn verwijderd uit Link component:
- `nl.link.active.text-decoration-line`
- `nl.link.active.text-decoration-thickness`
- `nl.link.focus-visible.background-color`
- `nl.link.focus-visible.color`
- `nl.link.focus-visible.text-decoration-line`
- `nl.link.focus-visible.text-decoration-thickness`