### PR TITLE
style: link-list token value

### DIFF
--- a/.changeset/link-list-this.md
+++ b/.changeset/link-list-this.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": patch
+---
+
+Waarde van token `utrecht.link-list.link.column-gap` is gewijzigd naar brand token `voorbeeld.space.text.beetle`.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -4951,7 +4951,7 @@
         "link": {
           "column-gap": {
             "$type": "dimension",
-            "$value": "{voorbeeld.space.block.beetle}"
+            "$value": "{voorbeeld.space.text.beetle}"
           },
           "text-decoration": {
             "$type": "textDecoration",


### PR DESCRIPTION
Waarde van token `utrecht.link-list.link.column-gap` is gewijzigd naar brand token `voorbeeld.space.text.beetle`.