### PR TITLE
docs: improve .changetset/README.md

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,29 +1,66 @@
-# Changeset sjabloon
+# Changesets
 
-Kopieer en plak het onderstaande sjabloon. Je kunt hiervoor de kopieer knop linksboven in het template gebruiken.
+Gebruik een changeset om een wijziging aan een package te documenteren. Hieronder vind je sjablonen voor de drie soorten
+wijzigingen: major, minor en patch.
+
+Weet je niet zeker welk type je moet kiezen? Bekijk dan de uitleg op de pagina [Versiebeheer voor design tokens][1].
+
+Vul tussen de twee sets `---` in voor welk package je veranderingen hebt doorgevoerd. Zet de naam van het package tussen
+dubbele aanhalingstekens op een nieuwe regel.
+
+## Naam van het package vinden
+
+De naam van het package kun je vinden door te kijken naar het `"name"` veld in de `package.json` die het dichtst staat
+bij het bestand waarin je je wijzigingen hebt doorgevoerd.
+
+> [!NOTE]  
+> Voor een wijziging in het bestand
+> [`proprietary/example-design-tokens/src/tokens.json`](../proprietary/example-design-tokens/src/tokens.json) is
+> [dit bestand](../proprietary/example-design-tokens/package.json#L2) de dichtstbijzijnde `package.json`. Op regel 2 van
+> dat bestand vind je de naam van het package.
+>
+> ```json filename=package.json
+> "name": "@nl-design-system-community/example-design-tokens",
+> ```
+
+### Major sjabloon
+
+Gebruik het onderstaande sjabloon voor **breaking changes**.
 
 ```markdown
 ---
-"@organisatie/package-naam": major
+"<organisatie>/<package>": major
 ---
 
-Beschrijving
+[Beschrijf wat er veranderd is, waarom dit nodig was, en hoe gebruikers hun code moeten aanpassen.]
 ```
 
-Vul tussen de twee sets `---` in voor welke packages je allemaal veranderingen hebt doorgevoerd. Zet elk package tussen
-dubbele aanhalingstekens op een nieuwe regel.
+### Minor sjabloon
 
-Gebruik:
+Gebruik het onderstaande sjabloon voor **nieuwe features of uitbereidingen**.
 
-- `"organisatie/package-naam": major` voor breaking changes
-- `"organisatie/package-naam": minor` voor nieuwe features
-- `"organisatie/package-naam": patch` voor bug fixes
+```markdown
+---
+"<organisatie>/<package>": minor
+---
 
-Beschrijf na de tweede set `---` welke veranderingen je hebt doorgevoerd.
+[Beschrijving van de nieuwe feature of uitbreiding.]
+```
 
-Lees de [documentatie][1] op nldesignsystem.nl voor uitleg over de verschillende soorten veranderingen.
+### Patch sjabloon
 
-Geef bij breaking changes aan **wat** er veranderd is, **waarom** de verandering nodig was en **hoe** gebruikers van het
-package hun code moeten aanpassen.
+Gebruik het onderstaande sjabloon voor **kleine correcties**.
 
-[1]: https://nldesignsystem.nl/handboek/design/overzicht
+> [!IMPORTANT]  
+> Het corrigeren van bijvoorbeeld een spelfout in de naam van een token lijkt misschien een kleine correctie, maar is
+> gelijk aan het verwijderen van een token en het toevoegen van een nieuw token en is dus zelfs een major wijziging.
+
+```markdown
+---
+"<organisatie>/<package>": patch
+---
+
+[Korte beschrijving van de correctie.]
+```
+
+[1]: https://nldesignsystem.nl/handboek/designer/breaking-changes

--- a/.prettierignore
+++ b/.prettierignore
@@ -30,7 +30,9 @@ packages/web-components-react/src/components.ts
 figma/*.tokens.json
 
 # Ignore changeset files, because they are temporary and frequently contributed by non-developers
-.changeset/
+.changeset/*
+# Do not ignore .changeset/README.md
+!.changeset/README.md
 
 # Ignore this config file, because apparently it considers `.markdown*` a Markdown file
 .markdownlintignore

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -25,5 +25,11 @@ module.exports = {
         singleQuote: false,
       },
     },
+    {
+      files: '.changeset/README.md',
+      options: {
+        proseWrap: 'always',
+      },
+    },
   ],
 };


### PR DESCRIPTION
- Add a template for major, minor, and patch changes
- Explain how to find the name of a package
- Hopefully simplify the templates a bit
- Add a Prettier exception for `.changeset/README.md`