### PR TITLE
Fix/task list icon size

### DIFF
--- a/.changeset/task-list-icon.md
+++ b/.changeset/task-list-icon.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": patch
+---
+
+Waarde van token `todo.task-list.icon.size` is gewijzigd naar common token `{voorbeeld.icon.functional.size}`.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -8129,7 +8129,7 @@
           },
           "size": {
             "$type": "dimension",
-            "$value": "{voorbeeld.size.icon.md}"
+            "$value": "{voorbeeld.icon.functional.size}"
           }
         }
       }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -8129,7 +8129,7 @@
           },
           "size": {
             "$type": "dimension",
-            "$value": "{voorbeeld.size.icon.sm}"
+            "$value": "{voorbeeld.size.icon.md}"
           }
         }
       }


### PR DESCRIPTION
Waarde van token `todo.task-list.icon.size` is gewijzigd naar common token `{voorbeeld.icon.functional.size}`.