### PR TITLE
fix: rename tokenset textarea to text-area

### DIFF
--- a/.changeset/text-in-area.md
+++ b/.changeset/text-in-area.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": patch
+---
+
+Tokenset `textarea` is hernoemd naar `text-area` zodat de schrijfwijze van deze tokenset overeenkomt met de gekozen naamgeving voor dit component.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -8135,7 +8135,7 @@
       }
     }
   },
-  "components/textarea": {
+  "components/text-area": {
     "utrecht": {
       "textarea": {
         "background-color": {
@@ -8597,7 +8597,7 @@
       "components/switch",
       "components/table",
       "components/task-list",
-      "components/textarea",
+      "components/text-area",
       "components/text-input",
       "components/toolbar-button",
       "components/unordered-list"


### PR DESCRIPTION
Tokenset `textarea` hernoemd naar `text-area` zodat de schrijfwijze van deze tokenset overeenkomt met de gekozen naamgeving voor dit component.