### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 
 # Changes to any file require approval from @nl-design-system/kernteam-maintainer
 * @nl-design-system/kernteam-maintainer
+/.changesets/ @nl-design-system/kernteam-maintainer @nl-design-system/kernteam-design
 
 /proprietary/amsterdam-design-tokens/src/ @nl-design-system/gemeente-amsterdam
 /proprietary/amsterdam-design-tokens/documentation/ @nl-design-system/gemeente-amsterdam


### PR DESCRIPTION
Make sure that both kernteam-maintainer and kernteam-design can approve PRs that touch files in `.changesets/`