### PR TITLE
fix(alert): remove todo heading tokens

### DIFF
--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -4659,28 +4659,6 @@
           }
         }
       }
-    },
-    "todo": {
-      "alert": {
-        "heading": {
-          "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{basis.heading.font-family}"
-          },
-          "font-size": {
-            "$type": "fontSizes",
-            "$value": "{basis.text.font-size.xl}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{basis.heading.font-weight}"
-          },
-          "line-height": {
-            "$type": "lineHeights",
-            "$value": "{basis.text.line-height.xl}"
-          }
-        }
-      }
     }
   },
   "components/avatar": {


### PR DESCRIPTION
Doordat ik candidate componenten nl-heading en nl-paragraph in de Alert gebruik, zijn de `todo.heading tokens*` niet meer nodig.