### PR TITLE
feat(note): add missing spotlight section tokens

### DIFF
--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -8115,6 +8115,162 @@
       }
     }
   },
+  "components/note": {
+    "utrecht": {
+      "spotlight-section": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{basis.color.default.bg-default}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{basis.color.default.border-default}"
+        },
+        "border-width": {
+          "$type": "dimension",
+          "$value": "{basis.border-width.md}"
+        },
+        "border-radius": {
+          "$type": "dimension",
+          "$value": "0px"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "margin-block-start": {
+          "$type": "dimension",
+          "$value": "0px",
+          "$description": "[code-only]"
+        },
+        "margin-block-end": {
+          "$type": "dimension",
+          "$value": "0px",
+          "$description": "[code-only]"
+        },
+        "padding-block-end": {
+          "$type": "dimension",
+          "$value": "{basis.space.block.2xl}"
+        },
+        "padding-block-start": {
+          "$type": "dimension",
+          "$value": "{basis.space.block.xl}"
+        },
+        "padding-inline-end": {
+          "$type": "dimension",
+          "$value": "{basis.space.inline.xl}"
+        },
+        "padding-inline-start": {
+          "$type": "dimension",
+          "$value": "{basis.space.inline.xl}"
+        },
+        "info": {
+          "border-width": {
+            "$type": "dimension",
+            "$value": "{basis.border-width.md}"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.info.bg-default}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.color.info.border-default}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.info.color-document}"
+          },
+          "icon": {
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.info.color-default}"
+            }
+          }
+        },
+        "error": {
+          "border-width": {
+            "$type": "dimension",
+            "$value": "{basis.border-width.md}"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.negative.bg-default}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.color.negative.border-default}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.negative.color-document}"
+          },
+          "icon": {
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.negative.color-default}"
+            }
+          }
+        },
+        "ok": {
+          "border-width": {
+            "$type": "dimension",
+            "$value": "{basis.border-width.md}"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.positive.bg-default}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.color.positive.border-default}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.positive.color-document}"
+          },
+          "icon": {
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.positive.color-default}"
+            }
+          }
+        },
+        "warning": {
+          "border-width": {
+            "$type": "dimension",
+            "$value": "{basis.border-width.md}"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.warning.bg-default}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.color.warning.border-default}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.warning.color-document}"
+          },
+          "icon": {
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.warning.color-default}"
+            }
+          }
+        }
+      }
+    },
+    "todo": {
+      "spotlight-section": {
+        "row-gap": {
+          "$type": "dimension",
+          "$value": "{basis.space.row.md}"
+        }
+      }
+    }
+  },
   "components/number-badge/nl": {
     "nl": {
       "number-badge": {
@@ -11798,122 +11954,6 @@
       }
     }
   },
-  "components/note": {
-    "utrecht": {
-      "spotlight-section": {
-        "background-color": {
-          "$type": "color",
-          "$value": "{basis.color.default.bg-default}"
-        },
-        "border-color": {
-          "$type": "color",
-          "$value": "{basis.color.transparent}"
-        },
-        "border-width": {
-          "$type": "dimension",
-          "$value": "{basis.border-width.md}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{basis.color.default.color-document}"
-        },
-        "padding-block-end": {
-          "$type": "dimension",
-          "$value": "{basis.space.block.2xl}"
-        },
-        "padding-block-start": {
-          "$type": "dimension",
-          "$value": "{basis.space.block.xl}"
-        },
-        "padding-inline-end": {
-          "$type": "dimension",
-          "$value": "{basis.space.inline.xl}"
-        },
-        "padding-inline-start": {
-          "$type": "dimension",
-          "$value": "{basis.space.inline.xl}"
-        },
-        "info": {
-          "background-color": {
-            "$type": "color",
-            "$value": "{basis.color.info.bg-default}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{basis.color.transparent}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{basis.color.info.color-document}"
-          }
-        },
-        "error": {
-          "background-color": {
-            "$type": "color",
-            "$value": "{basis.color.negative.bg-default}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{basis.color.transparent}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{basis.color.negative.color-document}"
-          }
-        },
-        "ok": {
-          "background-color": {
-            "$type": "color",
-            "$value": "{basis.color.positive.bg-default}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{basis.color.transparent}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{basis.color.positive.color-document}"
-          }
-        },
-        "warning": {
-          "background-color": {
-            "$type": "color",
-            "$value": "{basis.color.warning.bg-default}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{basis.color.transparent}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{basis.color.warning.color-document}"
-          }
-        }
-      }
-    },
-    "todo": {
-      "alert": {
-        "heading": {
-          "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{basis.heading.font-family}"
-          },
-          "font-size": {
-            "$type": "fontSizes",
-            "$value": "{basis.text.font-size.xl}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{basis.heading.font-weight}"
-          },
-          "line-height": {
-            "$type": "lineHeights",
-            "$value": "{basis.text.line-height.xl}"
-          }
-        }
-      }
-    }
-  },
   "$themes": [],
   "$metadata": {
     "tokenSetOrder": [
@@ -11974,6 +12014,7 @@
       "components/mark/utrecht",
       "components/modal-dialog",
       "components/navigation-bar",
+      "components/note",
       "components/number-badge/nl",
       "components/number-badge/utrecht",
       "components/ordered-list",
@@ -12008,8 +12049,7 @@
       "components/page-body",
       "components/page-footer",
       "components/article",
-      "components/listbox",
-      "components/note"
+      "components/listbox"
     ]
   }
 }


### PR DESCRIPTION
Deze PR zorgt ervoor dat tokenset 'Note' op de juiste positie komt te staan. Daarnaast heb ik enkele ontbrekende tokens voor spotlight section toegevoegd:

- `utrecht.spotlight-section.info.icon.color`
- `utrecht.spotlight-section.error.icon.color`
- `utrecht.spotlight-section.ok.icon.color`
- `utrecht.spotlight-section.warning.icon.color`
- `utrecht.spotlight-section.border-radius`
- `utrecht.spotlight-section.info.border-width`
- `utrecht.spotlight-section.error.border-width`
- `utrecht.spotlight-section.ok.border-width`
- `utrecht.spotlight-section.warning.border-width`

En 1 todo token (op dezelfde manier als een wel bestaande token voor Alert) zodat de inhoud niet tegen elkaar zit aangeplakt.

- `todo.spotlight-section.row-gap`