### PR TITLE
feat: color-scheme-dark setup

### DIFF
--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -11936,14 +11936,6 @@
             "background-color": {
               "$type": "color",
               "$value": "{basis.color.info-inverse.bg-default}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.default-inverse.color-document}"
             }
           }
         }

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -2596,1705 +2596,6 @@
       }
     }
   },
-  "dark-mode": {
-    "basis": {
-      "color": {
-        "transparent": {
-          "$type": "color",
-          "$value": "transparent"
-        },
-        "default": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#111111"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#040404"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#1D1D1D"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#262626"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#2E2E2E"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#3E3E3E"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#686868"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#727272"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#7C7C7C"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#ABABAB"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#BBBBBB"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#CCCCCC"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#8B8B8B"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#F1F1F1"
-          }
-        },
-        "accent-1": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#001126"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#000409"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#001D40"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#002551"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#002D62"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#003B81"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#3169AD"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#3F74B2"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#4E7FB8"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#8FAED2"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#A5BEDB"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#BBCEE4"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#648EC1"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#ECF1F7"
-          }
-        },
-        "accent-2": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-document}"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-subtle}"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-default}"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-hover}"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-active}"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-subtle}"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-default}"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-hover}"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-active}"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-default}"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-hover}"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-active}"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-subtle}"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-document}"
-          }
-        },
-        "accent-3": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-document}"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-subtle}"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-default}"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-hover}"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-active}"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-subtle}"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-default}"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-hover}"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-active}"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-default}"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-hover}"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-active}"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-subtle}"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-document}"
-          }
-        },
-        "action-1": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-document}"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-subtle}"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-default}"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-hover}"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-active}"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-subtle}"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-default}"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-hover}"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-active}"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-default}"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-hover}"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-active}"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-subtle}"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-document}"
-          }
-        },
-        "action-2": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-document}"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-subtle}"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-default}"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-hover}"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-active}"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-subtle}"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-default}"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-hover}"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-active}"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-default}"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-hover}"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-active}"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-subtle}"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-document}"
-          }
-        },
-        "disabled": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.bg-default}"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.bg-default}"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "{basis.color.default.bg-default}"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.bg-default}"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.bg-default}"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.default.border-subtle}"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.border-subtle}"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.border-subtle}"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.border-subtle}"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.color-subtle}"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.color-subtle}"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.color-subtle}"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.default.color-subtle}"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.color-subtle}"
-          }
-        },
-        "info": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#001126"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#000409"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#001D40"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#002551"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#002D62"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#003B81"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#3169AD"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#3F74B2"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#4E7FB8"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#8FAED2"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#A5BEDB"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#BBCEE4"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#648EC1"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#ECF1F7"
-          }
-        },
-        "negative": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#2D0000"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#100000"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#450000"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#550000"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#650000"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#820000"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#D30000"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#E60000"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#EF2929"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#F78D8D"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#F8A6A6"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#FABDBD"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#F25454"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#FEEDED"
-          }
-        },
-        "positive": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#001508"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#000502"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#00230D"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#002D11"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#003714"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#00481B"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#00792D"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#008432"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#009036"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#54BF7C"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#78CD98"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#9BDAB3"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#03A13F"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#E4F5EA"
-          }
-        },
-        "warning": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#190F05"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#060301"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#2A1A0B"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#36210E"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#432810"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#5A3511"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#9A5812"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#A96011"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#B86810"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#FC9016"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#FFA853"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#FFBF82"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#CF750C"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#FFEEDD"
-          }
-        },
-        "highlight": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#141106"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#050401"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#231D0D"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#2C2510"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#362D12"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#483D14"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#7A6718"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#867018"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#927A18"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#C9A913"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#DCB90F"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#F0C908"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#A48917"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#FFF1BB"
-          }
-        },
-        "selected": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-document}"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-subtle}"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-default}"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-hover}"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.bg-active}"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-subtle}"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-default}"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-hover}"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.border-active}"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-default}"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-hover}"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-active}"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-subtle}"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1.color-document}"
-          }
-        },
-        "default-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#242424"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#1B1B1B"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#595959"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#4B4B4B"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#3E3E3E"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#474747"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#C9C9C9"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#D4D4D4"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#DFDFDF"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#F1F1F1"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#F1F1F1"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#F1F1F1"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#C4C4C4"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#F1F1F1"
-          }
-        },
-        "accent-1-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#00234D"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#001B3C"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#2661A8"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#3169AD"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#386FAF"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#004494"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#B8CBE2"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#C6D6E8"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#D5E1EE"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#ECF1F7"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#ECF1F7"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#ECF1F7"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#B0C6DF"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#ECF1F7"
-          }
-        },
-        "accent-2-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-document}"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-subtle}"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-default}"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-hover}"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-active}"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-subtle}"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-default}"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-hover}"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-active}"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-default}"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-hover}"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-active}"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-subtle}"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-document}"
-          }
-        },
-        "accent-3-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-document}"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-subtle}"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-default}"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-hover}"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-active}"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-subtle}"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-default}"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-hover}"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-active}"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-default}"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-hover}"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-active}"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-subtle}"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-document}"
-          }
-        },
-        "action-1-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-document}"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-subtle}"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-default}"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-hover}"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-active}"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-subtle}"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-default}"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-hover}"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-active}"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-default}"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-hover}"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-active}"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-subtle}"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-document}"
-          }
-        },
-        "action-2-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-document}"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-subtle}"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-default}"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-hover}"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-active}"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-subtle}"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-default}"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-hover}"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-active}"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-default}"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-hover}"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-active}"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-subtle}"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-document}"
-          }
-        },
-        "disabled-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "{basis.color.disabled-inverse.bg-default}"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.disabled-inverse.bg-default}"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#595959"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "{basis.color.disabled-inverse.bg-default}"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "{basis.color.disabled-inverse.bg-default}"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#474747"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "{basis.color.disabled-inverse.border-subtle}"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "{basis.color.disabled-inverse.border-subtle}"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "{basis.color.disabled-inverse.border-subtle}"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "{basis.color.disabled-inverse.color-subtle}"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "{basis.color.disabled-inverse.color-subtle}"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "{basis.color.disabled-inverse.color-subtle}"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#C4C4C4"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "{basis.color.disabled-inverse.color-subtle}"
-          }
-        },
-        "info-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#00234D"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#001B3C"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#2661A8"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#3169AD"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#386FAF"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#004494"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#B8CBE2"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#C6D6E8"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#D5E1EE"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#ECF1F7"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#ECF1F7"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#ECF1F7"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#B0C6DF"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#ECF1F7"
-          }
-        },
-        "negative-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#510000"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#410000"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#C50000"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#D30000"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#DC0000"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#930000"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#FAB9B9"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#FBC8C8"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#FCD7D7"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#FEEDED"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#FEEDED"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#FEEDED"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#F9B1B1"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#FEEDED"
-          }
-        },
-        "positive-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#002B10"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#00210C"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#00702A"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#00792D"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#007F2F"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#00531F"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#96D8AE"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#ACE0C0"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#C3E9D1"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#E4F5EA"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#E4F5EA"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#E4F5EA"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#8AD3A6"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#E4F5EA"
-          }
-        },
-        "warning-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#331F0D"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#27190A"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#8F5212"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#9A5812"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#A15C11"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#683C12"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#FFBC7A"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#FFCB98"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#FFD9B4"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#FFEEDD"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#FFEEDD"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#FFEEDD"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#FFB46B"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#FFEEDD"
-          }
-        },
-        "highlight-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "#201B0C"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "#211C00"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "#725F18"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "#7A6718"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "#806B18"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "#534615"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "#ECC609"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "#F9D103"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "#FFDE56"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "#FFF1BB"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "#FFF1BB"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "#FFF1BB"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "#E6C10C"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "#FFF1BB"
-          }
-        },
-        "selected-inverse": {
-          "bg-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-document}"
-          },
-          "bg-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-subtle}"
-          },
-          "bg-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-default}"
-          },
-          "bg-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-hover}"
-          },
-          "bg-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.bg-active}"
-          },
-          "border-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-subtle}"
-          },
-          "border-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-default}"
-          },
-          "border-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-hover}"
-          },
-          "border-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.border-active}"
-          },
-          "color-default": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-default}"
-          },
-          "color-hover": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-hover}"
-          },
-          "color-active": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-active}"
-          },
-          "color-subtle": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-subtle}"
-          },
-          "color-document": {
-            "$type": "color",
-            "$value": "{basis.color.accent-1-inverse.color-document}"
-          }
-        }
-      },
-      "box-shadow": {
-        "sm": {
-          "$type": "boxShadow",
-          "$value": {
-            "x": "0",
-            "y": "2",
-            "blur": "6",
-            "spread": "0",
-            "color": "{basis.color.default.bg-document}",
-            "type": "dropShadow"
-          }
-        },
-        "md": {
-          "$type": "boxShadow",
-          "$value": {
-            "x": "0",
-            "y": "8",
-            "blur": "16",
-            "spread": "0",
-            "color": "{basis.color.default.bg-document}",
-            "type": "dropShadow"
-          }
-        },
-        "lg": {
-          "$type": "boxShadow",
-          "$value": {
-            "x": "0",
-            "y": "16",
-            "blur": "48",
-            "spread": "0",
-            "color": "{basis.color.default.bg-document}",
-            "type": "dropShadow"
-          }
-        }
-      },
-      "focus": {
-        "background-color": {
-          "$type": "color",
-          "$value": "#ffdd00"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "#0b0c0c"
-        },
-        "outline-color": {
-          "$type": "color",
-          "$value": "#ffffff"
-        },
-        "inverse": {
-          "outline-color": {
-            "$type": "color",
-            "$value": "#0b0c0c"
-          }
-        }
-      },
-      "form-control": {
-        "accent-color": {
-          "$type": "color",
-          "$value": "{basis.color.action-1.color-default}"
-        },
-        "background-color": {
-          "$type": "color",
-          "$value": "{basis.color.default.bg-document}"
-        },
-        "border-color": {
-          "$type": "color",
-          "$value": "{basis.color.default.border-default}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{basis.color.default.color-document}"
-        },
-        "placeholder": {
-          "color": {
-            "$type": "color",
-            "$value": "{basis.color.default.color-subtle}"
-          }
-        },
-        "active": {
-          "accent-color": {
-            "$type": "color",
-            "$value": "{basis.color.action-1.color-active}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "{basis.color.default.bg-active}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{basis.color.default.border-active}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{basis.form-control.color}"
-          }
-        },
-        "disabled": {
-          "accent-color": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.bg-default}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.bg-default}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.border-subtle}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{basis.color.disabled.color-subtle}"
-          }
-        },
-        "focus": {
-          "background-color": {
-            "$type": "color",
-            "$value": "{basis.form-control.background-color}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{basis.color.default.border-active}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{basis.form-control.color}"
-          }
-        },
-        "hover": {
-          "accent-color": {
-            "$type": "color",
-            "$value": "{basis.color.action-1.color-hover}"
-          },
-          "background-color": {
-            "$type": "color",
-            "$value": "{basis.color.default.bg-hover}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{basis.color.default.border-hover}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{basis.form-control.color}"
-          }
-        },
-        "invalid": {
-          "background-color": {
-            "$type": "color",
-            "$value": "{basis.color.negative.bg-default}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{basis.color.negative.border-default}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{basis.color.negative.color-default}"
-          }
-        },
-        "read-only": {
-          "background-color": {
-            "$type": "color",
-            "$value": "{basis.color.default.bg-subtle}"
-          },
-          "border-color": {
-            "$type": "color",
-            "$value": "{basis.color.transparent}"
-          },
-          "color": {
-            "$type": "color",
-            "$value": "{basis.color.default.color-document}"
-          }
-        }
-      },
-      "heading": {
-        "color": {
-          "$type": "color",
-          "$value": "{basis.color.default.color-document}"
-        }
-      }
-    }
-  },
   "components/accordion": {
     "utrecht": {
       "accordion": {
@@ -11928,12 +10229,1732 @@
       }
     }
   },
+  "color-scheme-dark/common": {
+    "basis": {
+      "color": {
+        "transparent": {
+          "$type": "color",
+          "$value": "transparent"
+        },
+        "default": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#111111"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#040404"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#1D1D1D"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#262626"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#2E2E2E"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#3E3E3E"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#686868"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#727272"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#7C7C7C"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#ABABAB"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#BBBBBB"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#CCCCCC"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#8B8B8B"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#F1F1F1"
+          }
+        },
+        "accent-1": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#001126"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#000409"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#001D40"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#002551"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#002D62"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#003B81"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#3169AD"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#3F74B2"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#4E7FB8"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#8FAED2"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#A5BEDB"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#BBCEE4"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#648EC1"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#ECF1F7"
+          }
+        },
+        "accent-2": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-document}"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-subtle}"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-default}"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-hover}"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-active}"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-subtle}"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-default}"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-hover}"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-active}"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-default}"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-hover}"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-active}"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-subtle}"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-document}"
+          }
+        },
+        "accent-3": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-document}"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-subtle}"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-default}"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-hover}"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-active}"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-subtle}"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-default}"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-hover}"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-active}"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-default}"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-hover}"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-active}"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-subtle}"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-document}"
+          }
+        },
+        "action-1": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-document}"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-subtle}"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-default}"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-hover}"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-active}"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-subtle}"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-default}"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-hover}"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-active}"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-default}"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-hover}"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-active}"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-subtle}"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-document}"
+          }
+        },
+        "action-2": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-document}"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-subtle}"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-default}"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-hover}"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-active}"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-subtle}"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-default}"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-hover}"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-active}"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-default}"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-hover}"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-active}"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-subtle}"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-document}"
+          }
+        },
+        "disabled": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.bg-default}"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.bg-default}"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "{basis.color.default.bg-default}"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.bg-default}"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.bg-default}"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.default.border-subtle}"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.border-subtle}"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.border-subtle}"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.border-subtle}"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.color-subtle}"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.color-subtle}"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.color-subtle}"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.default.color-subtle}"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.color-subtle}"
+          }
+        },
+        "info": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#001126"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#000409"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#001D40"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#002551"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#002D62"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#003B81"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#3169AD"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#3F74B2"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#4E7FB8"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#8FAED2"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#A5BEDB"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#BBCEE4"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#648EC1"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#ECF1F7"
+          }
+        },
+        "negative": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#2D0000"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#100000"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#450000"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#550000"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#650000"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#820000"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#D30000"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#E60000"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#EF2929"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#F78D8D"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#F8A6A6"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#FABDBD"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#F25454"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#FEEDED"
+          }
+        },
+        "positive": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#001508"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#000502"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#00230D"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#002D11"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#003714"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#00481B"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#00792D"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#008432"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#009036"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#54BF7C"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#78CD98"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#9BDAB3"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#03A13F"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#E4F5EA"
+          }
+        },
+        "warning": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#190F05"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#060301"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#2A1A0B"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#36210E"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#432810"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#5A3511"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#9A5812"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#A96011"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#B86810"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#FC9016"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#FFA853"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#FFBF82"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#CF750C"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#FFEEDD"
+          }
+        },
+        "highlight": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#141106"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#050401"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#231D0D"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#2C2510"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#362D12"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#483D14"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#7A6718"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#867018"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#927A18"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#C9A913"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#DCB90F"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#F0C908"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#A48917"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#FFF1BB"
+          }
+        },
+        "selected": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-document}"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-subtle}"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-default}"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-hover}"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.bg-active}"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-subtle}"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-default}"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-hover}"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.border-active}"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-default}"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-hover}"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-active}"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-subtle}"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1.color-document}"
+          }
+        },
+        "default-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#242424"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#1B1B1B"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#595959"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#4B4B4B"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#3E3E3E"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#474747"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#C9C9C9"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#D4D4D4"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#DFDFDF"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#F1F1F1"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#F1F1F1"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#F1F1F1"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#C4C4C4"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#F1F1F1"
+          }
+        },
+        "accent-1-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#00234D"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#001B3C"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#2661A8"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#3169AD"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#386FAF"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#004494"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#B8CBE2"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#C6D6E8"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#D5E1EE"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#ECF1F7"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#ECF1F7"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#ECF1F7"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#B0C6DF"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#ECF1F7"
+          }
+        },
+        "accent-2-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-document}"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-subtle}"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-default}"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-hover}"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-active}"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-subtle}"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-default}"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-hover}"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-active}"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-default}"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-hover}"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-active}"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-subtle}"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-document}"
+          }
+        },
+        "accent-3-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-document}"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-subtle}"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-default}"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-hover}"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-active}"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-subtle}"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-default}"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-hover}"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-active}"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-default}"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-hover}"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-active}"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-subtle}"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-document}"
+          }
+        },
+        "action-1-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-document}"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-subtle}"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-default}"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-hover}"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-active}"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-subtle}"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-default}"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-hover}"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-active}"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-default}"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-hover}"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-active}"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-subtle}"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-document}"
+          }
+        },
+        "action-2-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-document}"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-subtle}"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-default}"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-hover}"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-active}"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-subtle}"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-default}"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-hover}"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-active}"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-default}"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-hover}"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-active}"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-subtle}"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-document}"
+          }
+        },
+        "disabled-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "{basis.color.disabled-inverse.bg-default}"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.disabled-inverse.bg-default}"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#595959"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "{basis.color.disabled-inverse.bg-default}"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "{basis.color.disabled-inverse.bg-default}"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#474747"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "{basis.color.disabled-inverse.border-subtle}"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "{basis.color.disabled-inverse.border-subtle}"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "{basis.color.disabled-inverse.border-subtle}"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "{basis.color.disabled-inverse.color-subtle}"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "{basis.color.disabled-inverse.color-subtle}"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "{basis.color.disabled-inverse.color-subtle}"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#C4C4C4"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "{basis.color.disabled-inverse.color-subtle}"
+          }
+        },
+        "info-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#00234D"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#001B3C"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#2661A8"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#3169AD"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#386FAF"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#004494"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#B8CBE2"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#C6D6E8"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#D5E1EE"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#ECF1F7"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#ECF1F7"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#ECF1F7"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#B0C6DF"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#ECF1F7"
+          }
+        },
+        "negative-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#510000"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#410000"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#C50000"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#D30000"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#DC0000"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#930000"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#FAB9B9"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#FBC8C8"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#FCD7D7"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#FEEDED"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#FEEDED"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#FEEDED"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#F9B1B1"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#FEEDED"
+          }
+        },
+        "positive-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#002B10"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#00210C"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#00702A"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#00792D"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#007F2F"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#00531F"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#96D8AE"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#ACE0C0"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#C3E9D1"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#E4F5EA"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#E4F5EA"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#E4F5EA"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#8AD3A6"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#E4F5EA"
+          }
+        },
+        "warning-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#331F0D"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#27190A"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#8F5212"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#9A5812"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#A15C11"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#683C12"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#FFBC7A"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#FFCB98"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#FFD9B4"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#FFEEDD"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#FFEEDD"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#FFEEDD"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#FFB46B"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#FFEEDD"
+          }
+        },
+        "highlight-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "#201B0C"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "#211C00"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "#725F18"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "#7A6718"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "#806B18"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "#534615"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "#ECC609"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "#F9D103"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "#FFDE56"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "#FFF1BB"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "#FFF1BB"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "#FFF1BB"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "#E6C10C"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "#FFF1BB"
+          }
+        },
+        "selected-inverse": {
+          "bg-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-document}"
+          },
+          "bg-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-subtle}"
+          },
+          "bg-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-default}"
+          },
+          "bg-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-hover}"
+          },
+          "bg-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.bg-active}"
+          },
+          "border-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-subtle}"
+          },
+          "border-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-default}"
+          },
+          "border-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-hover}"
+          },
+          "border-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.border-active}"
+          },
+          "color-default": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-default}"
+          },
+          "color-hover": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-hover}"
+          },
+          "color-active": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-active}"
+          },
+          "color-subtle": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-subtle}"
+          },
+          "color-document": {
+            "$type": "color",
+            "$value": "{basis.color.accent-1-inverse.color-document}"
+          }
+        }
+      },
+      "box-shadow": {
+        "sm": {
+          "$type": "boxShadow",
+          "$value": {
+            "x": "0",
+            "y": "2",
+            "blur": "6",
+            "spread": "0",
+            "color": "{basis.color.default.bg-document}",
+            "type": "dropShadow"
+          }
+        },
+        "md": {
+          "$type": "boxShadow",
+          "$value": {
+            "x": "0",
+            "y": "8",
+            "blur": "16",
+            "spread": "0",
+            "color": "{basis.color.default.bg-document}",
+            "type": "dropShadow"
+          }
+        },
+        "lg": {
+          "$type": "boxShadow",
+          "$value": {
+            "x": "0",
+            "y": "16",
+            "blur": "48",
+            "spread": "0",
+            "color": "{basis.color.default.bg-document}",
+            "type": "dropShadow"
+          }
+        }
+      },
+      "focus": {
+        "background-color": {
+          "$type": "color",
+          "$value": "#ffdd00"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "#0b0c0c"
+        },
+        "outline-color": {
+          "$type": "color",
+          "$value": "#ffffff"
+        },
+        "inverse": {
+          "outline-color": {
+            "$type": "color",
+            "$value": "#0b0c0c"
+          }
+        }
+      },
+      "form-control": {
+        "accent-color": {
+          "$type": "color",
+          "$value": "{basis.color.action-1.color-default}"
+        },
+        "background-color": {
+          "$type": "color",
+          "$value": "{basis.color.default.bg-document}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{basis.color.default.border-default}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "placeholder": {
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.default.color-subtle}"
+          }
+        },
+        "active": {
+          "accent-color": {
+            "$type": "color",
+            "$value": "{basis.color.action-1.color-active}"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.default.bg-active}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.color.default.border-active}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.form-control.color}"
+          }
+        },
+        "disabled": {
+          "accent-color": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.bg-default}"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.bg-default}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.border-subtle}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.color-subtle}"
+          }
+        },
+        "focus": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.form-control.background-color}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.color.default.border-active}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.form-control.color}"
+          }
+        },
+        "hover": {
+          "accent-color": {
+            "$type": "color",
+            "$value": "{basis.color.action-1.color-hover}"
+          },
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.default.bg-hover}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.color.default.border-hover}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.form-control.color}"
+          }
+        },
+        "invalid": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.negative.bg-default}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.color.negative.border-default}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.negative.color-default}"
+          }
+        },
+        "read-only": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.default.bg-subtle}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.color.transparent}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.default.color-document}"
+          }
+        }
+      },
+      "heading": {
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        }
+      }
+    }
+  },
+  "color-scheme-dark/components/progress-list/todo": {
+    "todo": {
+      "progress-list": {
+        "step-marker": {
+          "current": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.color.info-inverse.bg-default}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.default-inverse.color-document}"
+            }
+          }
+        }
+      }
+    }
+  },
   "$themes": [],
   "$metadata": {
     "tokenSetOrder": [
       "brand",
       "common",
-      "dark-mode",
       "components/accordion",
       "components/action-group",
       "components/alert",
@@ -12023,7 +12044,9 @@
       "components/page-body",
       "components/page-footer",
       "components/article",
-      "components/listbox"
+      "components/listbox",
+      "color-scheme-dark/common",
+      "color-scheme-dark/components/progress-list/todo"
     ]
   }
 }


### PR DESCRIPTION
- Tokenset `dark-mode` onder `components` tokenset geplaatst.
- Tokenset `dark-mode` hernoemd naar `color-scheme-dark/common`
- Nieuwe tokenset toegevoegd `color-scheme-dark/components/progress-list/todo` met 1 enkele token om de achtergrond van de current state meer contrast te geven.