### PR TITLE
feat: update amsterdam design system packages (#1070)

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -24,10 +24,10 @@
     "build:storybook": "storybook build --config-dir config/ --output-dir dist/"
   },
   "devDependencies": {
-    "@amsterdam/design-system-assets": "0.2.1",
-    "@amsterdam/design-system-css": "0.11.0",
-    "@amsterdam/design-system-react": "0.11.0",
-    "@amsterdam/design-system-tokens": "0.11.0",
+    "@amsterdam/design-system-assets": "1.0.0",
+    "@amsterdam/design-system-css": "1.0.1",
+    "@amsterdam/design-system-react": "1.1.0",
+    "@amsterdam/design-system-tokens": "1.0.1",
     "@bundled-es-modules/memfs": "4.9.4",
     "@gemeente-denhaag/design-tokens-components": "4.1.0",
     "@gemeente-rotterdam/design-tokens": "1.0.0-alpha.34",

--- a/packages/theme-toolkit/package.json
+++ b/packages/theme-toolkit/package.json
@@ -42,7 +42,7 @@
     "lodash-es": "4.17.21"
   },
   "devDependencies": {
-    "@amsterdam/design-system-react": "0.11.0",
+    "@amsterdam/design-system-react": "1.1.0",
     "@babel/plugin-transform-runtime": "7.24.7",
     "@babel/preset-react": "7.24.7",
     "@bundled-es-modules/memfs": "4.9.4",

--- a/packages/tokens-lib/package.json
+++ b/packages/tokens-lib/package.json
@@ -42,7 +42,7 @@
     "lodash-es": "4.17.21"
   },
   "devDependencies": {
-    "@amsterdam/design-system-react": "0.11.0",
+    "@amsterdam/design-system-react": "1.1.0",
     "@babel/plugin-transform-runtime": "7.24.7",
     "@babel/preset-react": "7.24.7",
     "@bundled-es-modules/memfs": "4.9.4",

--- a/packages/voorbeeld-design-tokens/package.json
+++ b/packages/voorbeeld-design-tokens/package.json
@@ -26,7 +26,7 @@
     "build:style-dictionary": "node ./style-dictionary.mjs"
   },
   "devDependencies": {
-    "@amsterdam/design-system-react": "0.11.0",
+    "@amsterdam/design-system-react": "1.1.0",
     "@fontsource/fira-sans": "5.1.0",
     "@fontsource/source-serif-pro": "5.1.0",
     "@gemeente-denhaag/icons": "3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,7 +136,7 @@ importers:
         version: 1.4.0
       '@utrecht/component-library-react':
         specifier: 8.0.3
-        version: 8.0.3(@babel/runtime@7.25.7)(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.0.3(@babel/runtime@7.27.4)(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@utrecht/components':
         specifier: 7.4.0
         version: 7.4.0
@@ -279,17 +279,17 @@ importers:
   packages/storybook:
     devDependencies:
       '@amsterdam/design-system-assets':
-        specifier: 0.2.1
-        version: 0.2.1
+        specifier: 1.0.0
+        version: 1.0.0
       '@amsterdam/design-system-css':
-        specifier: 0.11.0
-        version: 0.11.0(@amsterdam/design-system-assets@0.2.1)(@amsterdam/design-system-tokens@0.11.0)
+        specifier: 1.0.1
+        version: 1.0.1(@amsterdam/design-system-assets@1.0.0)(@amsterdam/design-system-tokens@1.0.1)
       '@amsterdam/design-system-react':
-        specifier: 0.11.0
-        version: 0.11.0(@amsterdam/design-system-css@0.11.0(@amsterdam/design-system-assets@0.2.1)(@amsterdam/design-system-tokens@0.11.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.1.0
+        version: 1.1.0(@amsterdam/design-system-css@1.0.1(@amsterdam/design-system-assets@1.0.0)(@amsterdam/design-system-tokens@1.0.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@amsterdam/design-system-tokens':
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 1.0.1
+        version: 1.0.1
       '@bundled-es-modules/memfs':
         specifier: 4.9.4
         version: 4.9.4
@@ -472,7 +472,7 @@ importers:
         version: 18.3.3
       '@utrecht/component-library-react':
         specifier: 8.0.3
-        version: 8.0.3(@babel/runtime@7.25.7)(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.0.3(@babel/runtime@7.27.4)(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@utrecht/components':
         specifier: 7.4.0
         version: 7.4.0
@@ -618,8 +618,8 @@ importers:
         version: 4.17.21
     devDependencies:
       '@amsterdam/design-system-react':
-        specifier: 0.11.0
-        version: 0.11.0(@amsterdam/design-system-css@0.11.0(@amsterdam/design-system-assets@0.2.1)(@amsterdam/design-system-tokens@0.11.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.1.0
+        version: 1.1.0(@amsterdam/design-system-css@1.0.1(@amsterdam/design-system-assets@1.0.0)(@amsterdam/design-system-tokens@1.0.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@babel/plugin-transform-runtime':
         specifier: 7.24.7
         version: 7.24.7(@babel/core@7.26.0)
@@ -991,8 +991,8 @@ importers:
         version: 4.17.21
     devDependencies:
       '@amsterdam/design-system-react':
-        specifier: 0.11.0
-        version: 0.11.0(@amsterdam/design-system-css@0.11.0(@amsterdam/design-system-assets@0.2.1)(@amsterdam/design-system-tokens@0.11.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.1.0
+        version: 1.1.0(@amsterdam/design-system-css@1.0.1(@amsterdam/design-system-assets@1.0.0)(@amsterdam/design-system-tokens@1.0.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@babel/plugin-transform-runtime':
         specifier: 7.24.7
         version: 7.24.7(@babel/core@7.26.0)
@@ -1066,8 +1066,8 @@ importers:
   packages/voorbeeld-design-tokens:
     devDependencies:
       '@amsterdam/design-system-react':
-        specifier: 0.11.0
-        version: 0.11.0(@amsterdam/design-system-css@0.11.0(@amsterdam/design-system-assets@0.2.1)(@amsterdam/design-system-tokens@0.11.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.1.0
+        version: 1.1.0(@amsterdam/design-system-css@1.0.1(@amsterdam/design-system-assets@1.0.0)(@amsterdam/design-system-tokens@1.0.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@fontsource/fira-sans':
         specifier: 5.1.0
         version: 5.1.0
@@ -1112,7 +1112,7 @@ importers:
         version: 1.0.0
       '@utrecht/component-library-react':
         specifier: 8.0.3
-        version: 8.0.3(@babel/runtime@7.25.7)(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.0.3(@babel/runtime@7.27.4)(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@utrecht/components':
         specifier: 7.4.0
         version: 7.4.0
@@ -1141,8 +1141,8 @@ importers:
   proprietary/amsterdam-design-tokens:
     devDependencies:
       '@amsterdam/design-system-tokens':
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 1.0.1
+        version: 1.0.1
       '@nl-design-system-unstable/design-tokens-table-react':
         specifier: workspace:*
         version: link:../../packages/components-react/design-tokens-table-react
@@ -1619,7 +1619,7 @@ importers:
         version: 18.3.3
       '@utrecht/component-library-react':
         specifier: 8.0.3
-        version: 8.0.3(@babel/runtime@7.25.7)(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.0.3(@babel/runtime@7.27.4)(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@utrecht/components':
         specifier: 7.4.0
         version: 7.4.0
@@ -1949,8 +1949,8 @@ importers:
   proprietary/purmerend-design-tokens:
     devDependencies:
       '@amsterdam/design-system-react':
-        specifier: 0.11.0
-        version: 0.11.0(@amsterdam/design-system-css@0.11.0(@amsterdam/design-system-assets@0.2.1)(@amsterdam/design-system-tokens@0.11.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.1.0
+        version: 1.1.0(@amsterdam/design-system-css@1.0.1(@amsterdam/design-system-assets@1.0.0)(@amsterdam/design-system-tokens@1.0.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@fontsource/cantarell':
         specifier: 5.1.0
         version: 5.1.0
@@ -1986,7 +1986,7 @@ importers:
         version: 18.3.3
       '@utrecht/component-library-react':
         specifier: 8.0.3
-        version: 8.0.3(@babel/runtime@7.25.7)(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.0.3(@babel/runtime@7.27.4)(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@utrecht/components':
         specifier: 7.4.0
         version: 7.4.0
@@ -2307,30 +2307,30 @@ packages:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
     engines: {node: '>=6.0.0'}
 
-  '@amsterdam/design-system-assets@0.2.1':
-    resolution: {integrity: sha512-byLLmmF1cv2niZMXETV30nprypZY8bAFpNKKuRlmYlIREA6blz9kVIJsQeH3IldmClW1mNa8ccJN4EKJglnuRw==}
+  '@amsterdam/design-system-assets@1.0.0':
+    resolution: {integrity: sha512-OajcVs/wvJVds8i+OO8M2nCigzAlxlBMS2ljXMq5nXTUOWPv7LO7sC2p/S3L6yk7UcDABFwI6EQJdUfaU7HY+w==}
 
-  '@amsterdam/design-system-css@0.11.0':
-    resolution: {integrity: sha512-f7HIkxmvkg6O75AaK1AnsPMsCMulCGHk847TrhRY3xFN+IXBaQUQyJiqLdFYa4GVhgA5vVXZO9WgNUSc7lnDQA==}
+  '@amsterdam/design-system-css@1.0.1':
+    resolution: {integrity: sha512-nO1QCqNC0UXEdNESeJBJ8qLnYH4zPXNLWDuD+HRoLanM8NUsLexTVt2EQ9GVT0qYW1EQGgyeou9TouLVfkqPKw==}
     peerDependencies:
-      '@amsterdam/design-system-assets': 0.2.1
-      '@amsterdam/design-system-tokens': 0.11.0
+      '@amsterdam/design-system-assets': 1.0.0
+      '@amsterdam/design-system-tokens': 1.0.1
 
-  '@amsterdam/design-system-react-icons@0.1.12':
-    resolution: {integrity: sha512-pBR7NnX2J8CsKaNbWSf+lxrPHvPqgSmgB2CYuIDD4RL472kUsNjzJNVOhR24QaKkUGCSUaskhVlUPqeJZIX/MA==}
+  '@amsterdam/design-system-react-icons@1.0.0':
+    resolution: {integrity: sha512-rgY7haz069mYWPFJaXqsOFFqZQt+1sMOR9WpxybJB0SmAXevlkdEY5X12CtCCzbeBtzRXgCJxTouYjl+5dZblw==}
     peerDependencies:
-      react: 16 - 18
-      react-dom: 16 - 18
+      react: 16 - 19
+      react-dom: 16 - 19
 
-  '@amsterdam/design-system-react@0.11.0':
-    resolution: {integrity: sha512-LXZMajnhScYqZ1f+Di4Ta9+xXESsBqjVscrw95X49W/SaMr+K8L2CzbhLhAVmTUeqhM7JACcB5Fz+iXe/S8Rbw==}
+  '@amsterdam/design-system-react@1.1.0':
+    resolution: {integrity: sha512-oEu7Jw9QHexhCv7Vl9SIIRIJ6rBxHldcXFURM3dvpD6dNr46yzfb0srnJIuz2lLm4I63XB/QAAigbn9haYloKA==}
     peerDependencies:
-      '@amsterdam/design-system-css': 0.11.0
-      react: 16 - 18
-      react-dom: 16 - 18
+      '@amsterdam/design-system-css': 1.0.1
+      react: 16 - 19
+      react-dom: 16 - 19
 
-  '@amsterdam/design-system-tokens@0.11.0':
-    resolution: {integrity: sha512-LgF8u5EDhNpjdhF4doaojoPV/cLJYWJR0ZPcJpJjjkkfKRsesEtO8cTZIQBCDMpXwvRUIuw7henmipdueLtsww==}
+  '@amsterdam/design-system-tokens@1.0.1':
+    resolution: {integrity: sha512-IPBs09ekJQF6ADYgMNp9rpgbKQTAqbug/HQDlIKJjRu3VWLPFX7X+MBFSsIXZYnkUZJtrOGpisRBYBC/WTZ+HA==}
 
   '@babel/code-frame@7.24.7':
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
@@ -3043,16 +3043,16 @@ packages:
   '@babel/regjsgen@0.8.0':
     resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
 
-  '@babel/runtime@7.24.8':
-    resolution: {integrity: sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.25.0':
     resolution: {integrity: sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.25.7':
     resolution: {integrity: sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.27.4':
+    resolution: {integrity: sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.24.7':
@@ -9551,28 +9551,28 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@amsterdam/design-system-assets@0.2.1': {}
+  '@amsterdam/design-system-assets@1.0.0': {}
 
-  '@amsterdam/design-system-css@0.11.0(@amsterdam/design-system-assets@0.2.1)(@amsterdam/design-system-tokens@0.11.0)':
+  '@amsterdam/design-system-css@1.0.1(@amsterdam/design-system-assets@1.0.0)(@amsterdam/design-system-tokens@1.0.1)':
     dependencies:
-      '@amsterdam/design-system-assets': 0.2.1
-      '@amsterdam/design-system-tokens': 0.11.0
+      '@amsterdam/design-system-assets': 1.0.0
+      '@amsterdam/design-system-tokens': 1.0.1
 
-  '@amsterdam/design-system-react-icons@0.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@amsterdam/design-system-react-icons@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@amsterdam/design-system-react@0.11.0(@amsterdam/design-system-css@0.11.0(@amsterdam/design-system-assets@0.2.1)(@amsterdam/design-system-tokens@0.11.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@amsterdam/design-system-react@1.1.0(@amsterdam/design-system-css@1.0.1(@amsterdam/design-system-assets@1.0.0)(@amsterdam/design-system-tokens@1.0.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@amsterdam/design-system-css': 0.11.0(@amsterdam/design-system-assets@0.2.1)(@amsterdam/design-system-tokens@0.11.0)
-      '@amsterdam/design-system-react-icons': 0.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@babel/runtime': 7.24.8
+      '@amsterdam/design-system-css': 1.0.1(@amsterdam/design-system-assets@1.0.0)(@amsterdam/design-system-tokens@1.0.1)
+      '@amsterdam/design-system-react-icons': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@babel/runtime': 7.27.4
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@amsterdam/design-system-tokens@0.11.0': {}
+  '@amsterdam/design-system-tokens@1.0.1': {}
 
   '@babel/code-frame@7.24.7':
     dependencies:
@@ -10468,10 +10468,6 @@ snapshots:
 
   '@babel/regjsgen@0.8.0': {}
 
-  '@babel/runtime@7.24.8':
-    dependencies:
-      regenerator-runtime: 0.14.1
-
   '@babel/runtime@7.25.0':
     dependencies:
       regenerator-runtime: 0.14.1
@@ -10479,6 +10475,8 @@ snapshots:
   '@babel/runtime@7.25.7':
     dependencies:
       regenerator-runtime: 0.14.1
+
+  '@babel/runtime@7.27.4': {}
 
   '@babel/template@7.24.7':
     dependencies:
@@ -12157,6 +12155,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@utrecht/button-react@2.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@utrecht/calendar-css@1.4.0': {}
 
   '@utrecht/calendar-react@1.0.8(@babel/runtime@7.25.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -12181,6 +12186,17 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@utrecht/calendar-react@1.0.8(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
+      '@utrecht/button-react': 2.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/calendar-css': 1.4.0
+      clsx: 2.1.1
+      date-fns: 2.30.0
+      lodash-es: 4.17.21
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@utrecht/checkbox-css@1.5.0': {}
 
   '@utrecht/checkbox-react@1.0.5(@babel/runtime@7.25.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -12193,6 +12209,13 @@ snapshots:
   '@utrecht/checkbox-react@1.0.5(@babel/runtime@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@utrecht/checkbox-react@1.0.5(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -12215,6 +12238,13 @@ snapshots:
   '@utrecht/combobox-react@0.0.5(@babel/runtime@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@utrecht/combobox-react@0.0.5(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -12269,6 +12299,30 @@ snapshots:
     optionalDependencies:
       date-fns: 2.30.0
 
+  '@utrecht/component-library-react@8.0.3(@babel/runtime@7.27.4)(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
+      '@utrecht/button-react': 2.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/calendar-react': 1.0.8(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/checkbox-react': 1.0.5(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/combobox-react': 0.0.5(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/fieldset-react': 1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/form-field-checkbox-react': 1.0.7(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/form-field-description-react': 1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/form-field-error-message-react': 1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/form-field-react': 1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/form-label-react': 1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/link-react': 1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/listbox-react': 1.0.6(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/radio-button-react': 1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/textbox-react': 1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      lodash.chunk: 4.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      date-fns: 2.30.0
+
   '@utrecht/components@6.1.0':
     dependencies:
       clsx: 2.1.1
@@ -12309,6 +12363,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@utrecht/fieldset-react@1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@utrecht/form-field-checkbox-react@1.0.7(@babel/runtime@7.25.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.0
@@ -12333,6 +12394,18 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@utrecht/form-field-checkbox-react@1.0.7(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
+      '@utrecht/checkbox-react': 1.0.5(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/form-field-description-react': 1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/form-field-error-message-react': 1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/form-field-react': 1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@utrecht/form-label-react': 1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@utrecht/form-field-css@1.5.0': {}
 
   '@utrecht/form-field-description-css@1.5.0': {}
@@ -12347,6 +12420,13 @@ snapshots:
   '@utrecht/form-field-description-react@1.0.4(@babel/runtime@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@utrecht/form-field-description-react@1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -12367,6 +12447,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@utrecht/form-field-error-message-react@1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@utrecht/form-field-react@1.0.4(@babel/runtime@7.25.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.0
@@ -12377,6 +12464,13 @@ snapshots:
   '@utrecht/form-field-react@1.0.4(@babel/runtime@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@utrecht/form-field-react@1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -12395,6 +12489,13 @@ snapshots:
   '@utrecht/form-label-react@1.0.4(@babel/runtime@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@utrecht/form-label-react@1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -12441,6 +12542,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@utrecht/link-react@1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@utrecht/link-social-css@1.4.0': {}
 
   '@utrecht/list-social-css@1.4.0': {}
@@ -12457,6 +12565,13 @@ snapshots:
   '@utrecht/listbox-react@1.0.6(@babel/runtime@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@utrecht/listbox-react@1.0.6(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -12509,6 +12624,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@utrecht/radio-button-react@1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@utrecht/search-bar-css@2.2.0': {}
 
   '@utrecht/separator-css@1.4.0': {}
@@ -12533,6 +12655,13 @@ snapshots:
   '@utrecht/textbox-react@1.0.4(@babel/runtime@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@utrecht/textbox-react@1.0.4(@babel/runtime@7.27.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/proprietary/amsterdam-design-tokens/documentation/typography.mdx
+++ b/proprietary/amsterdam-design-tokens/documentation/typography.mdx
@@ -52,6 +52,7 @@ export const renderScale = (scaleName) => {
   const { scaleProperties = [], objectProperties = [], variants = {} } = settings[scaleName] || {};
 
 return (
+
 <div>
 {Object.entries(scale).map(([sizeName, sizeConfig]) => {
 const style = {

--- a/proprietary/amsterdam-design-tokens/documentation/typography.mdx
+++ b/proprietary/amsterdam-design-tokens/documentation/typography.mdx
@@ -4,29 +4,121 @@ import config from "../src/config.json";
 
 <Meta title="Amsterdam/Typography" />
 
-export const typography = tokens[config.prefix]["text"];
 export const textContent = "Tweede Kamerverkiezingen gaan anders dan anders";
-export const renderScale = (scale) => (
-  <div>
-    {Object.entries(scale).map(([key, size]) => (
-      <div key={key}>
-        <h3>{key}</h3>
-        {size["description"] && <p>{size["description"]}</p>}
-        <div
-          style={{
-            fontFamily: typography["font-family"].value,
-            fontSize: size["font-size"] ? size["font-size"].value : null,
-            fontWeight: typography["font-weight"]["normal"],
-            lineHeight: size["line-height"] ? size["line-height"].value : null,
-          }}
-        >
-          {textContent}
-        </div>
-      </div>
-    ))}
-  </div>
-);
+export const typography = tokens[config.prefix].typography;
+
+export const baseStyle = {
+  fontFamily: typography["font-family"].value,
+  hyphenateLimitChars: typography["hyphenate-limit-chars"].value,
+};
+
+export function kebabToCamel(kebabStr) {
+  return kebabStr.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+export const settings = {
+  heading: {
+    scaleProperties: ["font-weight", "text-wrap"],
+    objectProperties: ["font-size", "line-height"],
+    variants: {},
+  },
+  "body-text": {
+    scaleProperties: ["font-size", "font-weight", "line-height"],
+    objectProperties: ["font-size", "line-height"],
+    variants: {
+      bold: {
+        objectProperties: ["font-weight"],
+      },
+    },
+  },
+};
+
+export const getTypographyForScale = (scaleName) => {
+  const scaleData = typography[scaleName] || {};
+  const { scaleProperties = [], variants = {} } = settings[scaleName] || {};
+  const variantKeys = Object.keys(variants);
+  const exceptions = [...scaleProperties, ...variantKeys];
+
+  return Object.entries(scaleData).reduce((acc, [key, value]) => {
+    if (!exceptions.includes(key)) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+};
+
+export const renderScale = (scaleName) => {
+  const scale = getTypographyForScale(scaleName);
+  const { scaleProperties = [], objectProperties = [], variants = {} } = settings[scaleName] || {};
+
+  return (
+    <div>
+      {Object.entries(scale).map(([sizeName, sizeConfig]) => {
+        const style = {
+          ...baseStyle,
+          paddingInlineStart: "1.5rem",
+        };
+        scaleProperties.forEach((property) => {
+          const propKey = kebabToCamel(property);
+          style[propKey] = typography[scaleName]?.[property]?.value;
+        });
+
+        objectProperties.forEach((property) => {
+          const propKey = kebabToCamel(property);
+          style[propKey] = sizeConfig[property]?.value;
+        });
+
+        return (
+          <div key={`${scaleName}-${sizeName}`} style={{ paddingBlockStart: "2rem" }}>
+            <h3 id={`${scaleName}-${sizeName}`}>
+              {scaleName}: <code>{sizeName}</code>
+            </h3>
+            <p style={style}>{textContent}</p>
+
+            {Object.keys(variants).length > 0 && (
+              <div style={{ paddingInlineStart: "2rem" }}>
+                {Object.entries(variants).map(([variantName, variantConfig]) => {
+                  const variantStyle = { ...style };
+
+                  const variantProperties = Array.isArray(variantConfig?.objectProperties)
+                    ? variantConfig.objectProperties
+                    : [variantConfig.objectProperties];
+
+                  variantProperties.forEach((prop) => {
+                    const propKey = kebabToCamel(prop);
+                    variantStyle[propKey] =
+                      typography[scaleName]?.[variantName]?.[prop]?.value || null;
+                  });
+
+                  return (
+                    <div
+                      key={`${scaleName}-${sizeName}-${variantName}`}
+                      style={{ paddingBlockStart: "1rem" }}
+                    >
+                      <h4 id={`${scaleName}-${sizeName}-${variantName}`}>
+                        variant: <code>{variantName}</code>
+                      </h4>
+                      <p style={variantStyle}>{textContent}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
 
 # Typography
 
-<div>{renderScale(typography["level"])}</div>
+Typography is displayed via a `div` element with an inline style, as the Storybook `<Typeset>` component does not yet support additional properties like `lineHeight` or `fontStyle`.
+
+## Heading
+
+<div>{renderScale("heading")}</div>
+
+## Body text
+
+<div>{renderScale("body-text")}</div>

--- a/proprietary/amsterdam-design-tokens/documentation/typography.mdx
+++ b/proprietary/amsterdam-design-tokens/documentation/typography.mdx
@@ -39,29 +39,29 @@ export const getTypographyForScale = (scaleName) => {
   const variantKeys = Object.keys(variants);
   const exceptions = [...scaleProperties, ...variantKeys];
 
-  return Object.entries(scaleData).reduce((acc, [key, value]) => {
-    if (!exceptions.includes(key)) {
-      acc[key] = value;
-    }
-    return acc;
-  }, {});
+return Object.entries(scaleData).reduce((acc, [key, value]) => {
+if (!exceptions.includes(key)) {
+acc[key] = value;
+}
+return acc;
+}, {});
 };
 
 export const renderScale = (scaleName) => {
   const scale = getTypographyForScale(scaleName);
   const { scaleProperties = [], objectProperties = [], variants = {} } = settings[scaleName] || {};
 
-  return (
-    <div>
-      {Object.entries(scale).map(([sizeName, sizeConfig]) => {
-        const style = {
-          ...baseStyle,
-          paddingInlineStart: "1.5rem",
-        };
-        scaleProperties.forEach((property) => {
-          const propKey = kebabToCamel(property);
-          style[propKey] = typography[scaleName]?.[property]?.value;
-        });
+return (
+<div>
+{Object.entries(scale).map(([sizeName, sizeConfig]) => {
+const style = {
+...baseStyle,
+paddingInlineStart: "1.5rem",
+};
+scaleProperties.forEach((property) => {
+const propKey = kebabToCamel(property);
+style[propKey] = typography[scaleName]?.[property]?.value;
+});
 
         objectProperties.forEach((property) => {
           const propKey = kebabToCamel(property);
@@ -108,7 +108,8 @@ export const renderScale = (scaleName) => {
         );
       })}
     </div>
-  );
+
+);
 };
 
 # Typography

--- a/proprietary/amsterdam-design-tokens/documentation/typography.mdx
+++ b/proprietary/amsterdam-design-tokens/documentation/typography.mdx
@@ -38,37 +38,38 @@ export const getTypographyForScale = (scaleName) => {
   const { scaleProperties = [], variants = {} } = settings[scaleName] || {};
   const variantKeys = Object.keys(variants);
   const exceptions = [...scaleProperties, ...variantKeys];
-
-return Object.entries(scaleData).reduce((acc, [key, value]) => {
-if (!exceptions.includes(key)) {
-acc[key] = value;
-}
-return acc;
-}, {});
+  return Object.entries(scaleData).reduce((acc, [key, value]) => {
+    if (!exceptions.includes(key)) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
 };
 
 export const renderScale = (scaleName) => {
   const scale = getTypographyForScale(scaleName);
   const { scaleProperties = [], objectProperties = [], variants = {} } = settings[scaleName] || {};
-
-return (
-
-<div>
-{Object.entries(scale).map(([sizeName, sizeConfig]) => {
-const style = {
-...baseStyle,
-paddingInlineStart: "1.5rem",
-};
-scaleProperties.forEach((property) => {
-const propKey = kebabToCamel(property);
-style[propKey] = typography[scaleName]?.[property]?.value;
-});
-
+  const scaleStyle = {
+    ...baseStyle,
+  };
+  scaleProperties.forEach((property) => {
+    const propKey = kebabToCamel(property);
+    scaleStyle[propKey] = typography[scaleName]?.[property]?.value;
+  });
+  const sizes = Object.entries(scale);
+  sizes.unshift(["default", {}]);
+  return (
+    <div>
+      {sizes.map(([sizeName, sizeConfig]) => {
+        const style = {
+          ...scaleStyle,
+          paddingInlineStart: "1.5rem",
+        };
         objectProperties.forEach((property) => {
-          const propKey = kebabToCamel(property);
-          style[propKey] = sizeConfig[property]?.value;
+          if (sizeConfig[property]?.value) {
+            style[kebabToCamel(property)] = sizeConfig[property].value;
+          }
         });
-
         return (
           <div key={`${scaleName}-${sizeName}`} style={{ paddingBlockStart: "2rem" }}>
             <h3 id={`${scaleName}-${sizeName}`}>
@@ -81,14 +82,10 @@ style[propKey] = typography[scaleName]?.[property]?.value;
                 {Object.entries(variants).map(([variantName, variantConfig]) => {
                   const variantStyle = { ...style };
 
-                  const variantProperties = Array.isArray(variantConfig?.objectProperties)
-                    ? variantConfig.objectProperties
-                    : [variantConfig.objectProperties];
-
-                  variantProperties.forEach((prop) => {
-                    const propKey = kebabToCamel(prop);
-                    variantStyle[propKey] =
-                      typography[scaleName]?.[variantName]?.[prop]?.value || null;
+                  variantConfig.objectProperties.forEach((prop) => {
+                    if (typography[scaleName]?.[variantName]?.[prop]?.value) {
+                      variantStyle[kebabToCamel(prop)] = typography[scaleName][variantName][prop].value;
+                    }
                   });
 
                   return (

--- a/proprietary/amsterdam-design-tokens/documentation/typography.mdx
+++ b/proprietary/amsterdam-design-tokens/documentation/typography.mdx
@@ -18,11 +18,13 @@ export function kebabToCamel(kebabStr) {
 
 export const settings = {
   heading: {
+    default: false,
     scaleProperties: ["font-weight", "text-wrap"],
     objectProperties: ["font-size", "line-height"],
     variants: {},
   },
   "body-text": {
+    default: "medium (default)",
     scaleProperties: ["font-size", "font-weight", "line-height"],
     objectProperties: ["font-size", "line-height"],
     variants: {
@@ -57,7 +59,9 @@ export const renderScale = (scaleName) => {
     scaleStyle[propKey] = typography[scaleName]?.[property]?.value;
   });
   const sizes = Object.entries(scale);
-  sizes.unshift(["default", {}]);
+  if (settings[scaleName].default) {
+    sizes.unshift([settings[scaleName].default, {}]);
+  }
   return (
     <div>
       {sizes.map(([sizeName, sizeConfig]) => {

--- a/proprietary/amsterdam-design-tokens/package.json
+++ b/proprietary/amsterdam-design-tokens/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {},
   "devDependencies": {
-    "@amsterdam/design-system-tokens": "0.11.0",
+    "@amsterdam/design-system-tokens": "1.0.1",
     "@nl-design-system-unstable/design-tokens-table-react": "workspace:*",
     "@nl-design-system-unstable/theme-toolkit": "workspace:*",
     "@nl-design-system-unstable/tokens-lib": "workspace:*",

--- a/proprietary/purmerend-design-tokens/package.json
+++ b/proprietary/purmerend-design-tokens/package.json
@@ -26,7 +26,7 @@
     "build:style-dictionary": "node ./style-dictionary.mjs"
   },
   "devDependencies": {
-    "@amsterdam/design-system-react": "0.11.0",
+    "@amsterdam/design-system-react": "1.1.0",
     "@fontsource/cantarell": "5.1.0",
     "@fontsource/fira-sans": "5.1.0",
     "@fontsource/source-serif-pro": "5.1.0",


### PR DESCRIPTION
In preparation of using the new available components ie PageFooter.

Before:
- [Color](https://nl-design-system.github.io/themes/?path=/docs/amsterdam-color--docs)
- [Design Tokens](https://nl-design-system.github.io/themes/?path=/docs/amsterdam-design-tokens--docs)
- [README](https://nl-design-system.github.io/themes/?path=/docs/amsterdam-readme--docs)
- [Typography](https://nl-design-system.github.io/themes/?path=/docs/amsterdam-typography--docs)
- [Components](https://nl-design-system.github.io/themes/?path=/story/amsterdam--components)

After:
- [Color](https://themes-git-feat-1070-update-amsterdam-d-b942ad-nl-design-system.vercel.app/?path=/docs/amsterdam-color--docs)
- [Design Tokens](https://themes-git-feat-1070-update-amsterdam-d-b942ad-nl-design-system.vercel.app/?path=/docs/amsterdam-design-tokens--docs)
- [README](https://themes-git-feat-1070-update-amsterdam-d-b942ad-nl-design-system.vercel.app/?path=/docs/amsterdam-readme--docs)
- [Typography](https://themes-git-feat-1070-update-amsterdam-d-b942ad-nl-design-system.vercel.app/?path=/docs/amsterdam-typography--docs)
- [Components](https://themes-git-feat-1070-update-amsterdam-d-b942ad-nl-design-system.vercel.app/?path=/story/amsterdam--components)

Closes: #1070
