### PR TITLE
feat: tokens toegevoegd aan (community) icon component

### DIFF
--- a/.changeset/icon-token-adding.md
+++ b/.changeset/icon-token-adding.md
@@ -1,0 +1,9 @@
+---
+"@nl-design-system-unstable/start-design-tokens": minor
+---
+
+De volgende tokens zijn toegevoegd aan (community) Icon component:
+
+- `utrecht.icon.color`
+- `utrecht.icon.inset-block-start`
+- `utrecht.icon.baseline.inset-block-start`

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -5876,9 +5876,24 @@
   "components/icon": {
     "utrecht": {
       "icon": {
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "inset-block-start": {
+          "$type": "dimension",
+          "$value": "0px"
+        },
         "size": {
           "$type": "dimension",
           "$value": "{basis.size.icon.md}"
+        },
+        "baseline": {
+          "inset-block-start": {
+            "$type": "dimension",
+            "$value": "0px",
+            "$description": "[code-only]"
+          }
         }
       }
     }


### PR DESCRIPTION
De volgende tokens zijn toegevoegd aan (community) Icon component:

- `utrecht.icon.color`
- `utrecht.icon.inset-block-start`
- `utrecht.icon.baseline.inset-block-start`