### PR TITLE
feat: tokens toegevoegd aan (community) icon component

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -6123,9 +6123,24 @@
   "components/icon": {
     "utrecht": {
       "icon": {
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "inset-block-start": {
+          "$type": "dimension",
+          "$value": "0px"
+        },
         "size": {
           "$type": "dimension",
           "$value": "{basis.size.icon.md}"
+        },
+        "baseline": {
+          "inset-block-start": {
+            "$type": "dimension",
+            "$value": "0px",
+            "$description": "[code-only]"
+          }
         }
       }
     }


### PR DESCRIPTION
De volgende tokens zijn toegevoegd aan (community) Icon component:

- `utrecht.icon.color`
- `utrecht.icon.inset-block-start`
- `utrecht.icon.baseline.inset-block-start`