### PR TITLE
Waarde van 'focus-outline-color' en 'box-shadow-color' omgekeerd

### DIFF
--- a/.changeset/focus-swap-color.md
+++ b/.changeset/focus-swap-color.md
@@ -1,0 +1,8 @@
+---
+"@nl-design-system-unstable/start-design-tokens": minor
+---
+
+De waarde van de volgende tokens zijn gewijzigd:
+
+- `basis.focus.outline-color` naar `#0b0c0c`
+- `basis.focus.inverse.outline-color` naar `#ffffff`

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -2363,12 +2363,12 @@
         },
         "outline-color": {
           "$type": "color",
-          "$value": "#ffffff"
+          "$value": "#0b0c0c"
         },
         "inverse": {
           "outline-color": {
             "$type": "color",
-            "$value": "#0b0c0c"
+            "$value": "#ffffff"
           }
         },
         "outline-offset": {


### PR DESCRIPTION
De waarde van de volgende tokens zijn gewijzigd:

- `basis.focus.outline-color` naar `#0b0c0c`
- `basis.focus.inverse.outline-color` naar `#ffffff`