### PR TITLE
Waarde van 'focus-outline-color' en 'box-shadow-color' omgekeerd - Voorbeeld

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -2610,12 +2610,12 @@
         },
         "outline-color": {
           "$type": "color",
-          "$value": "#ffffff"
+          "$value": "#0b0c0c"
         },
         "inverse": {
           "outline-color": {
             "$type": "color",
-            "$value": "#0b0c0c"
+            "$value": "#ffffff"
           }
         },
         "outline-offset": {


### PR DESCRIPTION
De waarde van de volgende tokens zijn gewijzigd:

- `basis.focus.outline-color` naar `#0b0c0c`
- `basis.focus.inverse.outline-color` naar `#ffffff`