### PR TITLE
fix: Link List font-weight token hernoemd

### DIFF
--- a/.changeset/link-list-weight.md
+++ b/.changeset/link-list-weight.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/start-design-tokens": minor
+---
+
+Token `utrecht.link-list.font-weight` is hernoemd naar `utrecht.link-list.link.font-weight` in Link List component.

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6078,9 +6078,19 @@
   "components/link-list": {
     "utrecht": {
       "link-list": {
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{basis.text.font-weight.default}"
+        "link": {
+          "column-gap": {
+            "$type": "dimension",
+            "$value": "{basis.space.text.xs}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{basis.text.font-weight.default}"
+          },
+          "text-decoration": {
+            "$type": "textDecoration",
+            "$value": "None"
+          }
         },
         "row-gap": {
           "$type": "dimension",
@@ -6094,16 +6104,6 @@
           "size": {
             "$type": "dimension",
             "$value": "{basis.size.icon.md}"
-          }
-        },
-        "link": {
-          "column-gap": {
-            "$type": "dimension",
-            "$value": "{basis.space.text.xs}"
-          },
-          "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
           }
         }
       }


### PR DESCRIPTION
Token `utrecht.link-list.font-weight` is hernoemd naar `utrecht.link-list.link.font-weight` in Link List component.