### PR TITLE
fix: Link List font-weight token hernoemd - Voorbeeld

### DIFF
--- a/.changeset/link-list-voorbeeld.md
+++ b/.changeset/link-list-voorbeeld.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+---
+
+Token `utrecht.link-list.font-weight` is hernoemd naar `utrecht.link-list.link.font-weight` in Link List component.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -6325,9 +6325,19 @@
   "components/link-list": {
     "utrecht": {
       "link-list": {
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{basis.text.font-weight.default}"
+        "link": {
+          "column-gap": {
+            "$type": "dimension",
+            "$value": "{basis.space.text.xs}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{basis.text.font-weight.default}"
+          },
+          "text-decoration": {
+            "$type": "textDecoration",
+            "$value": "None"
+          }
         },
         "row-gap": {
           "$type": "dimension",
@@ -6341,16 +6351,6 @@
           "size": {
             "$type": "dimension",
             "$value": "{basis.size.icon.md}"
-          }
-        },
-        "link": {
-          "column-gap": {
-            "$type": "dimension",
-            "$value": "{basis.space.text.xs}"
-          },
-          "text-decoration": {
-            "$type": "textDecoration",
-            "$value": "None"
           }
         }
       }


### PR DESCRIPTION
Token `utrecht.link-list.font-weight` is hernoemd naar `utrecht.link-list.link.font-weight` in Link List component.