### PR TITLE
fix: rename button-group to action-group

### DIFF
--- a/.changeset/button-to-action.md
+++ b/.changeset/button-to-action.md
@@ -1,0 +1,11 @@
+---
+"@nl-design-system-unstable/start-design-tokens": minor
+---
+
+De volgende tokens zijn hernoemd in Action Group component:
+
+- `utrecht.button-group.background-color` naar `utrecht.action-group.background-color`
+- `utrecht.button-group.column-gap` naar `utrecht.action-group.column-gap`
+- `utrecht.button-group.padding-block-end` naar `utrecht.action-group.padding-block-end`
+- `utrecht.button-group.padding-block-start` naar `utrecht.action-group.padding-block-start`
+- `utrecht.button-group.row-gap` naar `utrecht.action-group.row-gap`

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -2786,7 +2786,7 @@
   },
   "components/action-group": {
     "utrecht": {
-      "button-group": {
+      "action-group": {
         "background-color": {
           "$type": "color",
           "$value": "{basis.color.transparent}"


### PR DESCRIPTION
De volgende tokens zijn hernoemd in Action Group component:

- `utrecht.button-group.background-color` naar `utrecht.action-group.background-color`
- `utrecht.button-group.column-gap` naar `utrecht.action-group.column-gap`
- `utrecht.button-group.padding-block-end` naar `utrecht.action-group.padding-block-end`
- `utrecht.button-group.padding-block-start` naar `utrecht.action-group.padding-block-start`
- `utrecht.button-group.row-gap` naar `utrecht.action-group.row-gap`