### PR TITLE
fix: rename button-group to action-group - Voorbeeld

### DIFF
--- a/.changeset/button-action-voorbeeld.md
+++ b/.changeset/button-action-voorbeeld.md
@@ -1,0 +1,11 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+---
+
+De volgende tokens zijn hernoemd in Action Group component:
+
+- `utrecht.button-group.background-color` naar `utrecht.action-group.background-color`
+- `utrecht.button-group.column-gap` naar `utrecht.action-group.column-gap`
+- `utrecht.button-group.padding-block-end` naar `utrecht.action-group.padding-block-end`
+- `utrecht.button-group.padding-block-start` naar `utrecht.action-group.padding-block-start`
+- `utrecht.button-group.row-gap` naar `utrecht.action-group.row-gap`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -3033,7 +3033,7 @@
   },
   "components/action-group": {
     "utrecht": {
-      "button-group": {
+      "action-group": {
         "background-color": {
           "$type": "color",
           "$value": "{basis.color.transparent}"


### PR DESCRIPTION
De volgende tokens zijn hernoemd in Action Group component:

- `utrecht.button-group.background-color` naar `utrecht.action-group.background-color`
- `utrecht.button-group.column-gap` naar `utrecht.action-group.column-gap`
- `utrecht.button-group.padding-block-end` naar `utrecht.action-group.padding-block-end`
- `utrecht.button-group.padding-block-start` naar `utrecht.action-group.padding-block-start`
- `utrecht.button-group.row-gap` naar `utrecht.action-group.row-gap`