### PR TITLE
fix: rename denhaag-sidenav to denhaag-side-navigation

### DIFF
--- a/.changeset/forty-apricots-fail.md
+++ b/.changeset/forty-apricots-fail.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+---
+
+Update `denhaag-sidenav` to `denhaag-side-navigation`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -8824,7 +8824,7 @@
   },
   "components/side-navigation": {
     "denhaag": {
-      "sidenav": {
+      "side-navigation": {
         "min-width": {
           "$type": "dimension",
           "$value": "240px"


### PR DESCRIPTION
Nieuwe token naamgeving voor het Den Haag component, zoals te zien in de css van het component:

https://github.com/nl-design-system/denhaag/blob/main/components/SideNavigation/src/index.scss