### PR TITLE
Waarde van Spotlight Section (Note) border-width aangepast - Voorbeeld

### DIFF
--- a/.changeset/note-border-voorbeeld.md
+++ b/.changeset/note-border-voorbeeld.md
@@ -1,0 +1,11 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+---
+
+De waarde van de volgende tokens zijn gewijzigd:
+
+- `utrecht.spotlight-section.border-width` naar `0px`.
+- `utrecht.spotlight-section.info.border-width` naar component token `utrecht.spotlight-section.border-width`.
+- `utrecht.spotlight-section.error.border-width` naar component token `utrecht.spotlight-section.border-width`.
+- `utrecht.spotlight-section.ok.border-width` naar component token `utrecht.spotlight-section.border-width`.
+- `utrecht.spotlight-section.warning.border-width` naar component token `utrecht.spotlight-section.border-width`.

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -6732,7 +6732,7 @@
         },
         "border-width": {
           "$type": "dimension",
-          "$value": "{basis.border-width.md}"
+          "$value": "0px"
         },
         "border-radius": {
           "$type": "dimension",
@@ -6771,7 +6771,7 @@
         "info": {
           "border-width": {
             "$type": "dimension",
-            "$value": "{basis.border-width.md}"
+            "$value": "{utrecht.spotlight-section.border-width}"
           },
           "background-color": {
             "$type": "color",
@@ -6795,7 +6795,7 @@
         "error": {
           "border-width": {
             "$type": "dimension",
-            "$value": "{basis.border-width.md}"
+            "$value": "{utrecht.spotlight-section.border-width}"
           },
           "background-color": {
             "$type": "color",
@@ -6819,7 +6819,7 @@
         "ok": {
           "border-width": {
             "$type": "dimension",
-            "$value": "{basis.border-width.md}"
+            "$value": "{utrecht.spotlight-section.border-width}"
           },
           "background-color": {
             "$type": "color",
@@ -6843,7 +6843,7 @@
         "warning": {
           "border-width": {
             "$type": "dimension",
-            "$value": "{basis.border-width.md}"
+            "$value": "{utrecht.spotlight-section.border-width}"
           },
           "background-color": {
             "$type": "color",


### PR DESCRIPTION
De waarde van de volgende tokens zijn gewijzigd:

- `utrecht.spotlight-section.border-width` naar `0px`.
- `utrecht.spotlight-section.info.border-width` naar component token `utrecht.spotlight-section.border-width`.
- `utrecht.spotlight-section.error.border-width` naar component token `utrecht.spotlight-section.border-width`.
- `utrecht.spotlight-section.ok.border-width` naar component token `utrecht.spotlight-section.border-width`.
- `utrecht.spotlight-section.warning.border-width` naar component token `utrecht.spotlight-section.border-width`.
