### PR TITLE
feat: add data summary design tokens

### DIFF
--- a/.changeset/data-summary-tokens.md
+++ b/.changeset/data-summary-tokens.md
@@ -1,0 +1,34 @@
+---
+"@nl-design-system-unstable/start-design-tokens": minor
+---
+
+De volgende tokens zijn toegevoegd aan Data List component:
+
+- `denhaag.description-list.border-color`
+- `denhaag.description-list.color`
+- `denhaag.description-list.font-family`
+- `denhaag.description-list.font-size`
+- `denhaag.description-list.font-weight`
+- `denhaag.description-list.line-height`
+- `denhaag.description-list.margin-block-end`
+- `denhaag.description-list.margin-block-start`
+- `denhaag.description-list.padding-inline-end`
+- `denhaag.description-list.padding-inline-start`
+- `denhaag.description-list.caption.color`
+- `denhaag.description-list.caption.line-height`
+- `denhaag.description-list.caption.font-family`
+- `denhaag.description-list.caption.font-size`
+- `denhaag.description-list.caption.font-weight`
+- `denhaag.description-list.caption.margin-block-end`
+- `denhaag.description-list.detail.padding-block-end`
+- `denhaag.description-list.detail.padding-block-start`
+- `denhaag.description-list.title.color`
+- `denhaag.description-list.title.font-weight`
+- `denhaag.description-list.title.padding-block-end`
+- `denhaag.description-list.title.padding-block-start`
+- `denhaag.description-list.lg.padding-inline-end`
+- `denhaag.description-list.lg.padding-inline-start`
+- `denhaag.description-list.lg.detail.padding-block-end`
+- `denhaag.description-list.lg.detail.padding-block-start`
+- `denhaag.description-list.lg.title.padding-block-end`
+- `denhaag.description-list.lg.title.padding-block-start`

--- a/.changeset/data-summary-tokens.md
+++ b/.changeset/data-summary-tokens.md
@@ -2,7 +2,7 @@
 "@nl-design-system-unstable/start-design-tokens": minor
 ---
 
-De volgende tokens zijn toegevoegd aan Data List component:
+De volgende tokens zijn toegevoegd aan Data Summary component:
 
 - `denhaag.description-list.border-color`
 - `denhaag.description-list.color`

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -4801,6 +4801,168 @@
       }
     }
   },
+  "components/data-list": {
+    "denhaag": {
+      "description-list": {
+        "border-color": {
+          "$type": "color",
+          "$value": "{basis.color.default.border-subtle}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "font": {
+          "family": {
+            "$type": "fontFamilies",
+            "$value": "{basis.text.font-family.default}"
+          },
+          "size": {
+            "$type": "fontSizes",
+            "$value": "{basis.text.font-size.md}"
+          },
+          "weight": {
+            "$type": "fontWeights",
+            "$value": "{basis.text.font-weight.default}"
+          }
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{basis.text.line-height.md}"
+        },
+        "margin-block-end": {
+          "$type": "dimension",
+          "$value": "0px",
+          "$description": "[code-only]"
+        },
+        "margin-block-start": {
+          "$type": "dimension",
+          "$value": "0px",
+          "$description": "[code-only]"
+        },
+        "padding": {
+          "inline": {
+            "end": {
+              "$type": "dimension",
+              "$value": "0px"
+            },
+            "start": {
+              "$type": "dimension",
+              "$value": "0px"
+            }
+          }
+        },
+        "caption": {
+          "color": {
+            "$type": "color",
+            "$value": "{basis.heading.color}"
+          },
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{basis.text.line-height.xl}"
+          },
+          "font": {
+            "family": {
+              "$type": "fontFamilies",
+              "$value": "{basis.heading.font-family}"
+            },
+            "size": {
+              "$type": "fontSizes",
+              "$value": "{basis.text.font-size.xl}"
+            },
+            "weight": {
+              "$type": "fontWeights",
+              "$value": "{basis.heading.font-weight}"
+            }
+          },
+          "margin": {
+            "block-end": {
+              "$type": "dimension",
+              "$value": "{basis.space.row.xl}"
+            }
+          }
+        },
+        "detail": {
+          "padding": {
+            "block": {
+              "end": {
+                "$type": "dimension",
+                "$value": "{basis.space.block.lg}"
+              },
+              "start": {
+                "$type": "dimension",
+                "$value": "{basis.space.block.sm}"
+              }
+            }
+          }
+        },
+        "title": {
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.default.color-document}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{basis.text.font-weight.bold}"
+          },
+          "padding": {
+            "block": {
+              "end": {
+                "$type": "dimension",
+                "$value": "{basis.space.block.sm}"
+              },
+              "start": {
+                "$type": "dimension",
+                "$value": "{basis.space.block.lg}"
+              }
+            }
+          }
+        },
+        "lg": {
+          "padding": {
+            "inline": {
+              "end": {
+                "$type": "dimension",
+                "$value": "{basis.space.inline.xl}"
+              },
+              "start": {
+                "$type": "dimension",
+                "$value": "{basis.space.inline.xl}"
+              }
+            }
+          },
+          "detail": {
+            "padding": {
+              "block": {
+                "end": {
+                  "$type": "dimension",
+                  "$value": "{basis.space.block.lg}"
+                },
+                "start": {
+                  "$type": "dimension",
+                  "$value": "{basis.space.block.lg}"
+                }
+              }
+            }
+          },
+          "title": {
+            "padding": {
+              "block": {
+                "end": {
+                  "$type": "dimension",
+                  "$value": "{basis.space.block.lg}"
+                },
+                "start": {
+                  "$type": "dimension",
+                  "$value": "{basis.space.block.lg}"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "components/drawer/utrecht": {
     "utrecht": {
       "drawer": {
@@ -12537,6 +12699,7 @@
       "components/contact-timeline",
       "components/data-badge/nl",
       "components/data-badge/utrecht",
+      "components/data-list",
       "components/drawer/utrecht",
       "components/drawer/todo",
       "components/figure",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -4812,19 +4812,17 @@
           "$type": "color",
           "$value": "{basis.color.default.color-document}"
         },
-        "font": {
-          "family": {
-            "$type": "fontFamilies",
-            "$value": "{basis.text.font-family.default}"
-          },
-          "size": {
-            "$type": "fontSizes",
-            "$value": "{basis.text.font-size.md}"
-          },
-          "weight": {
-            "$type": "fontWeights",
-            "$value": "{basis.text.font-weight.default}"
-          }
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{basis.text.font-family.default}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{basis.text.font-size.md}"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{basis.text.font-weight.default}"
         },
         "line-height": {
           "$type": "lineHeights",
@@ -4840,17 +4838,13 @@
           "$value": "0px",
           "$description": "[code-only]"
         },
-        "padding": {
-          "inline": {
-            "end": {
-              "$type": "dimension",
-              "$value": "0px"
-            },
-            "start": {
-              "$type": "dimension",
-              "$value": "0px"
-            }
-          }
+        "padding-inline-end": {
+          "$type": "dimension",
+          "$value": "0px"
+        },
+        "padding-inline-start": {
+          "$type": "dimension",
+          "$value": "0px"
         },
         "caption": {
           "color": {
@@ -4861,39 +4855,31 @@
             "$type": "lineHeights",
             "$value": "{basis.text.line-height.xl}"
           },
-          "font": {
-            "family": {
-              "$type": "fontFamilies",
-              "$value": "{basis.heading.font-family}"
-            },
-            "size": {
-              "$type": "fontSizes",
-              "$value": "{basis.text.font-size.xl}"
-            },
-            "weight": {
-              "$type": "fontWeights",
-              "$value": "{basis.heading.font-weight}"
-            }
+          "font-family": {
+            "$type": "fontFamilies",
+            "$value": "{basis.heading.font-family}"
           },
-          "margin": {
-            "block-end": {
-              "$type": "dimension",
-              "$value": "{basis.space.row.xl}"
-            }
+          "font-size": {
+            "$type": "fontSizes",
+            "$value": "{basis.text.font-size.xl}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{basis.heading.font-weight}"
+          },
+          "margin-block-end": {
+            "$type": "dimension",
+            "$value": "{basis.space.row.xl}"
           }
         },
         "detail": {
-          "padding": {
-            "block": {
-              "end": {
-                "$type": "dimension",
-                "$value": "{basis.space.block.lg}"
-              },
-              "start": {
-                "$type": "dimension",
-                "$value": "{basis.space.block.sm}"
-              }
-            }
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.lg}"
+          },
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.sm}"
           }
         },
         "title": {
@@ -4905,58 +4891,42 @@
             "$type": "fontWeights",
             "$value": "{basis.text.font-weight.bold}"
           },
-          "padding": {
-            "block": {
-              "end": {
-                "$type": "dimension",
-                "$value": "{basis.space.block.sm}"
-              },
-              "start": {
-                "$type": "dimension",
-                "$value": "{basis.space.block.lg}"
-              }
-            }
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.sm}"
+          },
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.lg}"
           }
         },
         "lg": {
-          "padding": {
-            "inline": {
-              "end": {
-                "$type": "dimension",
-                "$value": "{basis.space.inline.xl}"
-              },
-              "start": {
-                "$type": "dimension",
-                "$value": "{basis.space.inline.xl}"
-              }
-            }
+          "padding-inline-end": {
+            "$type": "dimension",
+            "$value": "{basis.space.inline.xl}"
+          },
+          "padding-inline-start": {
+            "$type": "dimension",
+            "$value": "{basis.space.inline.xl}"
           },
           "detail": {
-            "padding": {
-              "block": {
-                "end": {
-                  "$type": "dimension",
-                  "$value": "{basis.space.block.lg}"
-                },
-                "start": {
-                  "$type": "dimension",
-                  "$value": "{basis.space.block.lg}"
-                }
-              }
+            "padding-block-end": {
+              "$type": "dimension",
+              "$value": "{basis.space.block.lg}"
+            },
+            "padding-block-start": {
+              "$type": "dimension",
+              "$value": "{basis.space.block.lg}"
             }
           },
           "title": {
-            "padding": {
-              "block": {
-                "end": {
-                  "$type": "dimension",
-                  "$value": "{basis.space.block.lg}"
-                },
-                "start": {
-                  "$type": "dimension",
-                  "$value": "{basis.space.block.lg}"
-                }
-              }
+            "padding-block-end": {
+              "$type": "dimension",
+              "$value": "{basis.space.block.lg}"
+            },
+            "padding-block-start": {
+              "$type": "dimension",
+              "$value": "{basis.space.block.lg}"
             }
           }
         }


### PR DESCRIPTION
De volgende tokens zijn toegevoegd aan Data Summary component:

- `denhaag.description-list.border-color`
- `denhaag.description-list.color`
- `denhaag.description-list.font-family`
- `denhaag.description-list.font-size`
- `denhaag.description-list.font-weight`
- `denhaag.description-list.line-height`
- `denhaag.description-list.margin-block-end`
- `denhaag.description-list.margin-block-start`
- `denhaag.description-list.padding-inline-end`
- `denhaag.description-list.padding-inline-start`
- `denhaag.description-list.caption.color`
- `denhaag.description-list.caption.line-height`
- `denhaag.description-list.caption.font-family`
- `denhaag.description-list.caption.font-size`
- `denhaag.description-list.caption.font-weight`
- `denhaag.description-list.caption.margin-block-end`
- `denhaag.description-list.detail.padding-block-end`
- `denhaag.description-list.detail.padding-block-start`
- `denhaag.description-list.title.color`
- `denhaag.description-list.title.font-weight`
- `denhaag.description-list.title.padding-block-end`
- `denhaag.description-list.title.padding-block-start`
- `denhaag.description-list.lg.padding-inline-end`
- `denhaag.description-list.lg.padding-inline-start`
- `denhaag.description-list.lg.detail.padding-block-end`
- `denhaag.description-list.lg.detail.padding-block-start`
- `denhaag.description-list.lg.title.padding-block-end`
- `denhaag.description-list.lg.title.padding-block-start`