### PR TITLE
fix: rename sidenav to side-navigation - Voorbeeld

### DIFF
--- a/.changeset/sidenav-to-side-nav-voorbeeld.md
+++ b/.changeset/sidenav-to-side-nav-voorbeeld.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
 ---
 
 De volgende tokens zijn hernoemd in Side Navigation component:

--- a/.changeset/sidenav-to-side-nav-voorbeeld.md
+++ b/.changeset/sidenav-to-side-nav-voorbeeld.md
@@ -1,0 +1,30 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+---
+
+De volgende tokens zijn hernoemd in Side Navigation component:
+
+- `denhaag.sidenav.min-width` naar `denhaag.side-navigation.min-width`
+- `denhaag.sidenav.row-gap` naar `denhaag.side-navigation.row-gap`
+- `denhaag.sidenav.item.font-family` naar `denhaag.side-navigation.item.font-family`
+- `denhaag.sidenav.item.font-size` naar `denhaag.side-navigation.item.font-size`
+- `denhaag.sidenav.item.font-weight` naar `denhaag.side-navigation.item.font-weight`
+- `denhaag.sidenav.item.line-height` naar `denhaag.side-navigation.item.line-height`
+- `denhaag.sidenav.item.margin-block-end` naar `denhaag.side-navigation.item.margin-block-end`
+- `denhaag.sidenav.item.margin-block-start` naar `denhaag.side-navigation.item.margin-block-start`
+- `denhaag.sidenav.item.margin-inline-end` naar `denhaag.side-navigation.item.margin-inline-end`
+- `denhaag.sidenav.item.margin-inline-start` naar `denhaag.side-navigation.item.margin-inline-start`
+- `denhaag.sidenav.link.color` naar `denhaag.side-navigation.link.color`
+- `denhaag.sidenav.link.column-gap` naar `denhaag.side-navigation.link.column-gap`
+- `denhaag.sidenav.link.padding-block-end` naar `denhaag.side-navigation.link.padding-block-end`
+- `denhaag.sidenav.link.padding-block-start` naar `denhaag.side-navigation.link.padding-block-start`
+- `denhaag.sidenav.link.active.color` naar `denhaag.side-navigation.link.active.color`
+- `denhaag.sidenav.link.active.font-weight` naar `denhaag.side-navigation.link.active.font-weight`
+- `denhaag.sidenav.link.current.color` naar `denhaag.side-navigation.link.current.color`
+- `denhaag.sidenav.link.current.font-weight` naar `denhaag.side-navigation.link.current.font-weight`
+- `denhaag.sidenav.link.hover.color` naar `denhaag.side-navigation.link.hover.color`
+- `denhaag.sidenav.list.padding-block-end` naar `denhaag.side-navigation.list.padding-block-end`
+- `denhaag.sidenav.list.padding-block-start` naar `denhaag.side-navigation.list.padding-block-start`
+- `denhaag.sidenav.list.padding-inline-start` naar `denhaag.side-navigation.list.padding-inline-start`
+- `todo.sidenav.link.hover.text-decoration` naar `todo.side-navigation.link.hover.text-decoration`
+- `todo.sidenav.link.icon.size` naar `todo.side-navigation.link.icon.size`

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -9166,7 +9166,7 @@
   },
   "components/side-navigation": {
     "denhaag": {
-      "sidenav": {
+      "side-navigation": {
         "min-width": {
           "$type": "dimension",
           "$value": "240px"
@@ -9274,7 +9274,7 @@
       }
     },
     "todo": {
-      "sidenav": {
+      "side-navigation": {
         "link": {
           "hover": {
             "text-decoration": {


### PR DESCRIPTION
De volgende tokens zijn hernoemd in Side Navigation component:

- `denhaag.sidenav.min-width` naar `denhaag.side-navigation.min-width`
- `denhaag.sidenav.row-gap` naar `denhaag.side-navigation.row-gap`
- `denhaag.sidenav.item.font-family` naar `denhaag.side-navigation.item.font-family`
- `denhaag.sidenav.item.font-size` naar `denhaag.side-navigation.item.font-size`
- `denhaag.sidenav.item.font-weight` naar `denhaag.side-navigation.item.font-weight`
- `denhaag.sidenav.item.line-height` naar `denhaag.side-navigation.item.line-height`
- `denhaag.sidenav.item.margin-block-end` naar `denhaag.side-navigation.item.margin-block-end`
- `denhaag.sidenav.item.margin-block-start` naar `denhaag.side-navigation.item.margin-block-start`
- `denhaag.sidenav.item.margin-inline-end` naar `denhaag.side-navigation.item.margin-inline-end`
- `denhaag.sidenav.item.margin-inline-start` naar `denhaag.side-navigation.item.margin-inline-start`
- `denhaag.sidenav.link.color` naar `denhaag.side-navigation.link.color`
- `denhaag.sidenav.link.column-gap` naar `denhaag.side-navigation.link.column-gap`
- `denhaag.sidenav.link.padding-block-end` naar `denhaag.side-navigation.link.padding-block-end`
- `denhaag.sidenav.link.padding-block-start` naar `denhaag.side-navigation.link.padding-block-start`
- `denhaag.sidenav.link.active.color` naar `denhaag.side-navigation.link.active.color`
- `denhaag.sidenav.link.active.font-weight` naar `denhaag.side-navigation.link.active.font-weight`
- `denhaag.sidenav.link.current.color` naar `denhaag.side-navigation.link.current.color`
- `denhaag.sidenav.link.current.font-weight` naar `denhaag.side-navigation.link.current.font-weight`
- `denhaag.sidenav.link.hover.color` naar `denhaag.side-navigation.link.hover.color`
- `denhaag.sidenav.list.padding-block-end` naar `denhaag.side-navigation.list.padding-block-end`
- `denhaag.sidenav.list.padding-block-start` naar `denhaag.side-navigation.list.padding-block-start`
- `denhaag.sidenav.list.padding-inline-start` naar `denhaag.side-navigation.list.padding-inline-start`
- `todo.sidenav.link.hover.text-decoration` naar `todo.side-navigation.link.hover.text-decoration`
- `todo.sidenav.link.icon.size` naar `todo.side-navigation.link.icon.size`