### PR TITLE
fix: consistent casing with website

### DIFF
--- a/packages/theme-toolkit/src/component-stories-ams.tsx
+++ b/packages/theme-toolkit/src/component-stories-ams.tsx
@@ -200,7 +200,7 @@ export const AMS_COMPONENT_STORIES: ComponentStory[] = [
     storyId: 'react-ams-skip-link',
     component: 'ams-skip-link',
     // group: ...,
-    name: 'Amsterdam Skip link',
+    name: 'Amsterdam Skip Link',
     render: () => (
       <SkipLink
         href="#"

--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -1601,7 +1601,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     storyId: 'react-utrecht-unordered-list--default',
     component: 'utrecht-unordered-list',
     group: STORY_GROUPS['LISTS'],
-    name: 'Utrecht Unordered list',
+    name: 'Utrecht Unordered List',
     render: () => (
       <UnorderedList>
         <UnorderedListItem>The Quick Brown Fox Jumps Over The Lazy Dog</UnorderedListItem>
@@ -1622,7 +1622,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     storyId: 'react-utrecht-unordered-list--item',
     component: 'utrecht-unordered-list',
     group: STORY_GROUPS['LISTS'],
-    name: 'Utrecht Unordered list: Item',
+    name: 'Utrecht Unordered List: Item',
     render: () => (
       <UnorderedList>
         <UnorderedListItem>The Quick Brown Fox Jumps Over The Lazy Dog</UnorderedListItem>
@@ -1641,7 +1641,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     storyId: 'react-utrecht-unordered-list--marker',
     component: 'utrecht-unordered-list',
     group: STORY_GROUPS['LISTS'],
-    name: 'Utrecht Unordered list: Marker',
+    name: 'Utrecht Unordered List: Marker',
     render: () => (
       <UnorderedList>
         <UnorderedListItem>The Quick Brown Fox Jumps Over The Lazy Dog</UnorderedListItem>
@@ -1656,7 +1656,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     storyId: 'react-utrecht-ordered-list--default',
     component: 'utrecht-ordered-list',
     group: STORY_GROUPS['LISTS'],
-    name: 'Utrecht Ordered list',
+    name: 'Utrecht Ordered List',
     render: () => (
       <OrderedList>
         <OrderedListItem>The Quick Brown Fox Jumps Over The Lazy Dog</OrderedListItem>
@@ -2914,7 +2914,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
   {
     storyId: 'react-utrecht-form-field-description--default',
     group: STORY_GROUPS['FORM_FIELD_DESCRIPTION'],
-    name: 'Utrecht Form field description',
+    name: 'Utrecht Form Field Description',
     render: () => <FormFieldDescription>The Quick Brown Fox Jumps Over The Lazy Dog</FormFieldDescription>,
     detectTokens: {
       anyOf: [
@@ -2931,7 +2931,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
   {
     storyId: 'react-utrecht-form-field-error-message--default',
     group: STORY_GROUPS['FORM_FIELD_ERROR_MESSAGE'],
-    name: 'Utrecht Form field Error Message',
+    name: 'Utrecht Form Field Error Message',
     render: () => <FormFieldErrorMessage>The Quick Brown Fox Jumps Over The Lazy Dog</FormFieldErrorMessage>,
     detectTokens: {
       anyOf: [

--- a/packages/voorbeeld-design-tokens/documentation/breadcrumb-navigation/ams-breadcrumb.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/breadcrumb-navigation/ams-breadcrumb.stories.tsx
@@ -3,7 +3,7 @@ import { Breadcrumb } from '@amsterdam/design-system-react';
 
 const meta = {
   id: 'ams-breadcrumb',
-  title: 'Components/Breadcrumb navigation/Amsterdam',
+  title: 'Components/Breadcrumb Navigation/Amsterdam',
   component: Breadcrumb,
   parameters: { actions: { disable: true } },
   args: {},

--- a/packages/voorbeeld-design-tokens/documentation/breadcrumb-navigation/utrecht-breadcrumb-nav.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/breadcrumb-navigation/utrecht-breadcrumb-nav.stories.tsx
@@ -13,7 +13,7 @@ const items = [
 
 const meta = {
   id: 'utrecht-breadcrumb-nav',
-  title: 'Components/Breadcrumb navigation/Utrecht',
+  title: 'Components/Breadcrumb Navigation/Utrecht',
   component: BreadcrumbNav,
   parameters: { actions: { disable: true } },
   args: { label: 'kruimelpad' },

--- a/packages/voorbeeld-design-tokens/documentation/form-field/utrecht-form-field.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/form-field/utrecht-form-field.stories.tsx
@@ -3,7 +3,7 @@ import { FormField, Paragraph, Textbox } from '@utrecht/component-library-react/
 
 const meta = {
   id: 'utrecht-form-field',
-  title: 'Components/Form field/Utrecht',
+  title: 'Components/Form Field/Utrecht',
   component: FormField,
   render: (args) => {
     const { description, invalid, label } = args;

--- a/packages/voorbeeld-design-tokens/documentation/heading-group/utrecht-heading-group.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/heading-group/utrecht-heading-group.stories.tsx
@@ -3,7 +3,7 @@ import { Heading1, HeadingGroup, Paragraph } from '@utrecht/component-library-re
 
 const meta = {
   id: 'utrecht-heading-group',
-  title: 'Components/Heading group/Utrecht',
+  title: 'Components/Heading Group/Utrecht',
   component: HeadingGroup,
   args: {
     children: (

--- a/packages/voorbeeld-design-tokens/documentation/number-badge/utrecht-badge-counter.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/number-badge/utrecht-badge-counter.stories.tsx
@@ -3,7 +3,7 @@ import { BadgeCounter } from '@utrecht/component-library-react/dist/css-module';
 
 const meta = {
   id: 'utrecht-badge-counter',
-  title: 'Components/Number badge/Utrecht',
+  title: 'Components/Number Badge/Utrecht',
   component: BadgeCounter,
   args: {
     children: '9',

--- a/packages/voorbeeld-design-tokens/documentation/ordered-list/utrecht-ordered-list.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/ordered-list/utrecht-ordered-list.stories.tsx
@@ -3,7 +3,7 @@ import { OrderedList, OrderedListItem } from '@utrecht/component-library-react/d
 
 const meta = {
   id: 'utrecht-ordered-list',
-  title: 'Components/Ordered list/Utrecht',
+  title: 'Components/Ordered List/Utrecht',
   component: OrderedList,
   parameters: { actions: { disable: true } },
   args: {

--- a/packages/voorbeeld-design-tokens/documentation/radio-button/utrecht-radio-button.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/radio-button/utrecht-radio-button.stories.tsx
@@ -3,7 +3,7 @@ import { RadioButton } from '@utrecht/component-library-react/dist/css-module';
 
 const meta = {
   id: 'utrecht-radio-button',
-  title: 'Components/Radio button/Utrecht',
+  title: 'Components/Radio Button/Utrecht',
   component: RadioButton,
   args: { disabled: false, invalid: false, name: 'radio' },
   render: (args) => (

--- a/packages/voorbeeld-design-tokens/documentation/skip-link/utrecht-skip-link.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/skip-link/utrecht-skip-link.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { SkipLink } from '@utrecht/component-library-react/dist/css-module';
 
 const meta = {
-  title: 'Components/Skip link/Utrecht',
+  title: 'Components/Skip Link/Utrecht',
   id: 'utrecht-skip-link',
   component: SkipLink,
   argTypes: {

--- a/packages/voorbeeld-design-tokens/documentation/status-badge/utrecht-badge-status.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/status-badge/utrecht-badge-status.stories.tsx
@@ -3,7 +3,7 @@ import { StatusBadge } from '@utrecht/component-library-react/dist/css-module';
 
 const meta = {
   id: 'utrecht-badge-status',
-  title: 'Components/Status badge/Utrecht',
+  title: 'Components/Status Badge/Utrecht',
   component: StatusBadge,
   parameters: { actions: { disable: true } },
   args: {

--- a/packages/voorbeeld-design-tokens/documentation/text-input/utrecht-textbox.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/text-input/utrecht-textbox.stories.tsx
@@ -3,7 +3,7 @@ import { Textbox } from '@utrecht/component-library-react/dist/css-module';
 
 const meta = {
   id: 'utrecht-textbox',
-  title: 'Components/Text input/Utrecht',
+  title: 'Components/Text Input/Utrecht',
   component: Textbox,
   args: { disabled: false, readOnly: false, required: false },
   argTypes: {

--- a/packages/voorbeeld-design-tokens/documentation/unordered-list/utrecht-unordered-list.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/unordered-list/utrecht-unordered-list.stories.tsx
@@ -3,7 +3,7 @@ import { UnorderedList, UnorderedListItem } from '@utrecht/component-library-rea
 
 const meta = {
   id: 'utrecht-unordered-list',
-  title: 'Components/Unordered list/Utrecht',
+  title: 'Components/Unordered List/Utrecht',
   component: UnorderedList,
   parameters: {
     controls: { disable: true },


### PR DESCRIPTION
Follows the casing of components according to the NL Design System website, and consistently across the themes repo.