### PR TITLE
style: placeholder for Candidate Text Input design tokens

### DIFF
--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -11011,7 +11011,7 @@
         },
         "column-gap": {
           "$type": "dimension",
-          "$value": "{basis.space.text.xs}"
+          "$value": "{basis.space.text.lg}"
         },
         "font-family": {
           "$type": "fontFamilies",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -10986,7 +10986,189 @@
       }
     }
   },
-  "components/text-input": {
+  "components/text-input/nl": {
+    "nl": {
+      "text-input": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{basis.form-control.background-color}"
+        },
+        "border-color": {
+          "$type": "color",
+          "$value": "{basis.form-control.border-color}"
+        },
+        "border-radius": {
+          "$type": "dimension",
+          "$value": "{basis.form-control.border-radius}"
+        },
+        "border-width": {
+          "$type": "dimension",
+          "$value": "{basis.form-control.border-width}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{basis.form-control.color}"
+        },
+        "column-gap": {
+          "$type": "dimension",
+          "$value": "{basis.space.text.xs}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{basis.form-control.font-family}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{basis.form-control.font-size}"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{basis.form-control.font-weight}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{basis.form-control.line-height}"
+        },
+        "min-block-size": {
+          "$type": "dimension",
+          "$value": "{basis.pointer-target.min-block-size}"
+        },
+        "min-inline-size": {
+          "$type": "dimension",
+          "$value": "{basis.pointer-target.min-inline-size}"
+        },
+        "outline-offset": {
+          "$type": "other",
+          "$value": "0px",
+          "$description": "[code-only]"
+        },
+        "padding-block-end": {
+          "$type": "dimension",
+          "$value": "{basis.form-control.padding-block-end}"
+        },
+        "padding-block-start": {
+          "$type": "dimension",
+          "$value": "{basis.form-control.padding-block-start}"
+        },
+        "padding-inline-end": {
+          "$type": "dimension",
+          "$value": "{basis.form-control.padding-inline-end}"
+        },
+        "padding-inline-start": {
+          "$type": "dimension",
+          "$value": "{basis.form-control.padding-inline-start}"
+        },
+        "icon": {
+          "color": {
+            "$type": "color",
+            "$value": "{basis.form-control.color}"
+          },
+          "size": {
+            "$type": "dimension",
+            "$value": "{basis.size.icon.md}"
+          }
+        },
+        "placeholder": {
+          "color": {
+            "$type": "color",
+            "$value": "{basis.form-control.placeholder.color}"
+          }
+        },
+        "disabled": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.form-control.disabled.background-color}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.form-control.disabled.border-color}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.form-control.disabled.color}"
+          }
+        },
+        "focus": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.form-control.focus.background-color}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.form-control.focus.border-color}"
+          },
+          "box-shadow": {
+            "$type": "boxShadow",
+            "$value": {
+              "x": "0",
+              "y": "0",
+              "blur": "0",
+              "spread": "{basis.border-width.md}",
+              "color": "{nl.text-input.focus.border-color}",
+              "type": "innerShadow"
+            }
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.form-control.focus.color}"
+          }
+        },
+        "hover": {
+          "box-shadow": {
+            "$type": "boxShadow",
+            "$value": {
+              "x": "0",
+              "y": "0",
+              "blur": "0",
+              "spread": "{basis.border-width.md}",
+              "color": "{nl.text-input.border-color}",
+              "type": "innerShadow"
+            }
+          }
+        },
+        "invalid": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.form-control.invalid.background-color}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.form-control.invalid.border-color}"
+          },
+          "box-shadow": {
+            "$type": "boxShadow",
+            "$value": {
+              "x": "0",
+              "y": "0",
+              "blur": "0",
+              "spread": "{basis.border-width.md}",
+              "color": "{nl.text-input.invalid.border-color}",
+              "type": "innerShadow"
+            }
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.form-control.color}"
+          }
+        },
+        "read-only": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.form-control.read-only.background-color}"
+          },
+          "border-color": {
+            "$type": "color",
+            "$value": "{basis.form-control.read-only.border-color}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.form-control.read-only.color}"
+          }
+        }
+      }
+    }
+  },
+  "components/text-input/utrecht": {
     "utrecht": {
       "textbox": {
         "background-color": {
@@ -10995,7 +11177,7 @@
         },
         "border-block-end-width": {
           "$type": "dimension",
-          "$value": "{utrecht.textbox.border-width}"
+          "$value": "{nl.text-input.border-width}"
         },
         "border-color": {
           "$type": "color",
@@ -11094,7 +11276,7 @@
           },
           "border-block-end-width": {
             "$type": "dimension",
-            "$value": "{utrecht.textbox.invalid.border-width}"
+            "$value": "{nl.text-input.invalid.border-width}"
           },
           "border-color": {
             "$type": "color",
@@ -13545,7 +13727,8 @@
       "components/task-list",
       "components/task-navigation",
       "components/text-area",
-      "components/text-input",
+      "components/text-input/nl",
+      "components/text-input/utrecht",
       "components/toolbar-button",
       "components/unordered-list",
       "components/root",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -11058,16 +11058,6 @@
           "$type": "dimension",
           "$value": "{basis.form-control.padding-inline-start}"
         },
-        "icon": {
-          "color": {
-            "$type": "color",
-            "$value": "{basis.form-control.color}"
-          },
-          "size": {
-            "$type": "dimension",
-            "$value": "{basis.size.icon.md}"
-          }
-        },
         "placeholder": {
           "color": {
             "$type": "color",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -11029,6 +11029,14 @@
           "$type": "lineHeights",
           "$value": "{basis.form-control.line-height}"
         },
+        "margin-block-end": {
+          "$type": "dimension",
+          "$value": "{basis.space.block.lg}"
+        },
+        "margin-block-start": {
+          "$type": "dimension",
+          "$value": "{basis.space.block.lg}"
+        },
         "min-block-size": {
           "$type": "dimension",
           "$value": "{basis.pointer-target.min-block-size}"
@@ -11087,7 +11095,7 @@
             "$type": "color",
             "$value": "{basis.form-control.focus.border-color}"
           },
-          "box-shadow": {
+          "border-width": {
             "$type": "boxShadow",
             "$value": {
               "x": "0",
@@ -11104,7 +11112,7 @@
           }
         },
         "hover": {
-          "box-shadow": {
+          "border-width": {
             "$type": "boxShadow",
             "$value": {
               "x": "0",
@@ -11125,7 +11133,7 @@
             "$type": "color",
             "$value": "{basis.form-control.invalid.border-color}"
           },
-          "box-shadow": {
+          "border-width": {
             "$type": "boxShadow",
             "$value": {
               "x": "0",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -11175,7 +11175,7 @@
         },
         "border-block-end-width": {
           "$type": "dimension",
-          "$value": "{nl.text-input.border-width}"
+          "$value": "{utrecht.textbox.border-width}"
         },
         "border-color": {
           "$type": "color",
@@ -11274,7 +11274,7 @@
           },
           "border-block-end-width": {
             "$type": "dimension",
-            "$value": "{nl.text-input.invalid.border-width}"
+            "$value": "{utrecht.textbox.invalid.border-width}"
           },
           "border-color": {
             "$type": "color",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -11162,6 +11162,38 @@
             "$type": "color",
             "$value": "{basis.form-control.read-only.color}"
           }
+        },
+        "width": {
+          "xs": {
+            "$type": "dimension",
+            "$value": "96px",
+            "$description": "10ch"
+          },
+          "sm": {
+            "$type": "dimension",
+            "$value": "134px",
+            "$description": "14ch"
+          },
+          "md": {
+            "$type": "dimension",
+            "$value": "192px",
+            "$description": "20ch"
+          },
+          "lg": {
+            "$type": "dimension",
+            "$value": "307px",
+            "$description": "32ch"
+          },
+          "xl": {
+            "$type": "dimension",
+            "$value": "460px",
+            "$description": "48ch"
+          },
+          "full": {
+            "$type": "dimension",
+            "$value": "328px",
+            "$description": "100%"
+          }
         }
       }
     }

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -11066,7 +11066,7 @@
           "$type": "dimension",
           "$value": "{basis.form-control.padding-inline-start}"
         },
-        "width": {
+        "value-size": {
           "xs": {
             "$type": "dimension",
             "$value": "96px",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -11066,6 +11066,38 @@
           "$type": "dimension",
           "$value": "{basis.form-control.padding-inline-start}"
         },
+        "width": {
+          "xs": {
+            "$type": "dimension",
+            "$value": "96px",
+            "$description": "10ch"
+          },
+          "sm": {
+            "$type": "dimension",
+            "$value": "134px",
+            "$description": "14ch"
+          },
+          "md": {
+            "$type": "dimension",
+            "$value": "192px",
+            "$description": "20ch"
+          },
+          "lg": {
+            "$type": "dimension",
+            "$value": "307px",
+            "$description": "32ch"
+          },
+          "xl": {
+            "$type": "dimension",
+            "$value": "460px",
+            "$description": "48ch"
+          },
+          "full": {
+            "$type": "dimension",
+            "$value": "328px",
+            "$description": "100%"
+          }
+        },
         "placeholder": {
           "color": {
             "$type": "color",
@@ -11161,38 +11193,6 @@
           "color": {
             "$type": "color",
             "$value": "{basis.form-control.read-only.color}"
-          }
-        },
-        "width": {
-          "xs": {
-            "$type": "dimension",
-            "$value": "96px",
-            "$description": "10ch"
-          },
-          "sm": {
-            "$type": "dimension",
-            "$value": "134px",
-            "$description": "14ch"
-          },
-          "md": {
-            "$type": "dimension",
-            "$value": "192px",
-            "$description": "20ch"
-          },
-          "lg": {
-            "$type": "dimension",
-            "$value": "307px",
-            "$description": "32ch"
-          },
-          "xl": {
-            "$type": "dimension",
-            "$value": "460px",
-            "$description": "48ch"
-          },
-          "full": {
-            "$type": "dimension",
-            "$value": "328px",
-            "$description": "100%"
           }
         }
       }

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -11029,14 +11029,6 @@
           "$type": "lineHeights",
           "$value": "{basis.form-control.line-height}"
         },
-        "margin-block-end": {
-          "$type": "dimension",
-          "$value": "{basis.space.block.lg}"
-        },
-        "margin-block-start": {
-          "$type": "dimension",
-          "$value": "{basis.space.block.lg}"
-        },
         "min-block-size": {
           "$type": "dimension",
           "$value": "{basis.pointer-target.min-block-size}"
@@ -11044,11 +11036,6 @@
         "min-inline-size": {
           "$type": "dimension",
           "$value": "{basis.pointer-target.min-inline-size}"
-        },
-        "outline-offset": {
-          "$type": "other",
-          "$value": "0px",
-          "$description": "[code-only]"
         },
         "padding-block-end": {
           "$type": "dimension",
@@ -11066,33 +11053,43 @@
           "$type": "dimension",
           "$value": "{basis.form-control.padding-inline-start}"
         },
-        "value-size": {
-          "xs": {
+        "xs": {
+          "inline-size": {
             "$type": "dimension",
             "$value": "96px",
             "$description": "10ch"
-          },
-          "sm": {
+          }
+        },
+        "sm": {
+          "inline-size": {
             "$type": "dimension",
             "$value": "134px",
             "$description": "14ch"
-          },
-          "md": {
+          }
+        },
+        "md": {
+          "inline-size": {
             "$type": "dimension",
             "$value": "192px",
             "$description": "20ch"
-          },
-          "lg": {
+          }
+        },
+        "lg": {
+          "inline-size": {
             "$type": "dimension",
             "$value": "307px",
             "$description": "32ch"
-          },
-          "xl": {
+          }
+        },
+        "xl": {
+          "inline-size": {
             "$type": "dimension",
             "$value": "460px",
             "$description": "48ch"
-          },
-          "stretch": {
+          }
+        },
+        "stretch": {
+          "inline-size": {
             "$type": "dimension",
             "$value": "328px",
             "$description": "100%"
@@ -11127,33 +11124,13 @@
             "$type": "color",
             "$value": "{basis.form-control.focus.border-color}"
           },
-          "border-width": {
-            "$type": "boxShadow",
-            "$value": {
-              "x": "0",
-              "y": "0",
-              "blur": "0",
-              "spread": "{basis.border-width.md}",
-              "color": "{nl.text-input.focus.border-color}",
-              "type": "innerShadow"
-            }
-          },
           "color": {
             "$type": "color",
             "$value": "{basis.form-control.focus.color}"
-          }
-        },
-        "hover": {
+          },
           "border-width": {
-            "$type": "boxShadow",
-            "$value": {
-              "x": "0",
-              "y": "0",
-              "blur": "0",
-              "spread": "{basis.border-width.md}",
-              "color": "{nl.text-input.border-color}",
-              "type": "innerShadow"
-            }
+            "$type": "dimension",
+            "$value": "{basis.border-width.md}"
           }
         },
         "invalid": {
@@ -11165,20 +11142,13 @@
             "$type": "color",
             "$value": "{basis.form-control.invalid.border-color}"
           },
-          "border-width": {
-            "$type": "boxShadow",
-            "$value": {
-              "x": "0",
-              "y": "0",
-              "blur": "0",
-              "spread": "{basis.border-width.md}",
-              "color": "{nl.text-input.invalid.border-color}",
-              "type": "innerShadow"
-            }
-          },
           "color": {
             "$type": "color",
             "$value": "{basis.form-control.color}"
+          },
+          "border-width": {
+            "$type": "dimension",
+            "$value": "{basis.border-width.md}"
           }
         },
         "read-only": {
@@ -11193,6 +11163,12 @@
           "color": {
             "$type": "color",
             "$value": "{basis.form-control.read-only.color}"
+          }
+        },
+        "hover": {
+          "border-width": {
+            "$type": "dimension",
+            "$value": "{basis.border-width.md}"
           }
         }
       }

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -11092,7 +11092,7 @@
             "$value": "460px",
             "$description": "48ch"
           },
-          "full": {
+          "stretch": {
             "$type": "dimension",
             "$value": "328px",
             "$description": "100%"


### PR DESCRIPTION
Placeholder om eerste voorstel Candidate Text Input design tokens te bewaren.

Niet blind mergen! Bij een Figma-release de set aan design tokens kopiëren en toevoegen aan de meest recente branch. Daarna nog 1 keer Apply to Selection op alle benodigde frames.