### PR TITLE
chore: add NL Design System to trusted packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,19 @@ engineStrict: true
 # malicious versions. Keep this in sync with npm-check-updates's `cooldown` configuration.
 minimumReleaseAge: 1440
 
+# Make an exception for trusted packages, notably our own
+minimumReleaseAgeExclude:
+  - "@amsterdam/*"
+  - "@gemeente-denhaag/*"
+  - "@gemeente-rotterdam/*"
+  - "@nl-design-system/*"
+  - "@nl-design-system-candidate/*"
+  - "@nl-design-system-community/*"
+  - "@nl-design-system-unstable/*"
+  - "@nl-rvo/*"
+  - "@rijkshuisstijl-community/*"
+  - "@utrecht/*"
+
 saveExact: true
 
 savePrefix: ""


### PR DESCRIPTION
This is not strictly needed in this repo, but keeping the pnpm-workspace.yaml synchronized makes maintenance easier