### PR TITLE
fix(start-design-tokens): wrap token ref path in curly braces

### DIFF
--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -8106,7 +8106,7 @@
             },
             "color": {
               "$type": "color",
-              "$value": "basis.color.disabled.color-subtle"
+              "$value": "{basis.color.disabled.color-subtle}"
             }
           }
         }


### PR DESCRIPTION
Noticed a reference to a token that wasn't correctly replaced with either the value of the token, or a CSS custom property and found missing curly braces around the token reference.