### PR TITLE
ci: ensure that the lockfile is present and up-to-date

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           pnpm audit --audit-level critical
 
       - name: Install dependencies specified in package.json
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run the lint script in package.json scripts
         run: pnpm run --if-present lint
@@ -116,7 +116,7 @@ jobs:
           pnpm audit --audit-level critical
 
       - name: Install dependencies specified in package.json
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run the build script in package.json
         run: pnpm run --if-present build


### PR DESCRIPTION
Frozen lockfiles are a [best practice](https://medium.com/dev-simplified/frozen-lockfile-in-projects-why-you-shouldnt-ignore-it-2d6b7a9ebf2e).

Even though pnpm tries to pass the right value for `--frozen-lockfile` in CI, there are still situations where this is bypassed (setting CI to false or removing the lockfile), so passing the argument explicitly is just safer in general.
