### PR TITLE
fix: assets werken op productie niet (#1236)

### DIFF
--- a/packages/theme-toolkit/src/component-stories-ams.tsx
+++ b/packages/theme-toolkit/src/component-stories-ams.tsx
@@ -481,7 +481,7 @@ export const AMS_COMPONENT_STORIES: ComponentStory[] = [
     name: 'Amsterdam Figure',
     render: () => (
       <Figure>
-        <Image alt="Utrecht stadskantoor" height={830} src="/images/stadskantoor.jpg" width={1040} />
+        <Image alt="Utrecht stadskantoor" height={830} src="images/stadskantoor.jpg" width={1040} />
         <Figure.Caption>Utrecht stadskantoor</Figure.Caption>
       </Figure>
     ),

--- a/packages/theme-toolkit/src/component-stories-utrecht.tsx
+++ b/packages/theme-toolkit/src/component-stories-utrecht.tsx
@@ -3229,7 +3229,7 @@ export const UTRECHT_COMPONENT_STORIES: ComponentStory[] = [
     group: STORY_GROUPS['IMAGE'],
     name: 'Utrecht Image',
     render: () => (
-      <Image alt="Utrecht stadskantoor" height={830} photo={true} src="/images/stadskantoor.jpg" width={1040} />
+      <Image alt="Utrecht stadskantoor" height={830} photo={true} src="images/stadskantoor.jpg" width={1040} />
     ),
   },
   {

--- a/packages/voorbeeld-design-tokens/documentation/figure/ams-figure.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/figure/ams-figure.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   },
   render: ({ children, ...args }) => (
     <Figure>
-      <Image alt="Utrecht stadskantoor" height={830} src="/images/stadskantoor.jpg" width={1040} />
+      <Image alt="Utrecht stadskantoor" height={830} src="images/stadskantoor.jpg" width={1040} />
       <Figure.Caption {...args}>{children}</Figure.Caption>
     </Figure>
   ),

--- a/packages/voorbeeld-design-tokens/documentation/image/utrecht-img.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/image/utrecht-img.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
     alt: 'Utrecht stadskantoor',
     height: 830,
     photo: true,
-    src: '/images/stadskantoor.jpg',
+    src: 'images/stadskantoor.jpg',
     width: 1040,
   },
 } satisfies Meta<typeof Image>;


### PR DESCRIPTION
Closes #1236

Works! Niet te previewen in de preview omdat daar het probleem niet voorkomt. Maar wel als je naar [prod](https://nl-design-system.github.io/themes/?path=/story/ams-figure--voorbeeld-theme) gaat en daar het pad aanpast van `/images/stadskantoor.jpg` naar `images/stadskantoor.jpg`.