### PR TITLE
style: placeholder for Candidate Form Field Description design tokens

### DIFF
--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6152,7 +6152,47 @@
       }
     }
   },
-  "components/form-field-description": {
+  "components/form-field-description/nl": {
+    "nl": {
+      "form-field-description": {
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-subtle}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{basis.text.font-family.default}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{basis.text.font-size.md}"
+        },
+        "font-style": {
+          "$type": "other",
+          "$value": "normal"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{basis.text.font-weight.default}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{basis.text.line-height.md}"
+        },
+        "margin-block-end": {
+          "$type": "dimension",
+          "$value": "0px",
+          "$description": "[code-only]"
+        },
+        "margin-block-start": {
+          "$type": "dimension",
+          "$value": "0px",
+          "$description": "[code-only]"
+        }
+      }
+    }
+  },
+  "components/form-field-description/utrecht": {
     "utrecht": {
       "form-field-description": {
         "color": {
@@ -13793,7 +13833,8 @@
       "components/file",
       "components/form-field",
       "components/form-field-checkbox-option",
-      "components/form-field-description",
+      "components/form-field-description/nl",
+      "components/form-field-description/utrecht",
       "components/form-field-error-message",
       "components/form-field-label/utrecht",
       "components/form-field-label/todo",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6169,7 +6169,8 @@
         },
         "font-style": {
           "$type": "other",
-          "$value": "normal"
+          "$value": "normal",
+          "$description": "[code-only]"
         },
         "font-weight": {
           "$type": "fontWeights",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6167,11 +6167,6 @@
           "$type": "fontSizes",
           "$value": "{basis.text.font-size.md}"
         },
-        "font-style": {
-          "$type": "other",
-          "$value": "normal",
-          "$description": "[code-only]"
-        },
         "font-weight": {
           "$type": "fontWeights",
           "$value": "{basis.text.font-weight.default}"

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6184,6 +6184,12 @@
           "$type": "dimension",
           "$value": "0px",
           "$description": "[code-only]"
+        },
+        "disabled": {
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.color-subtle}"
+          }
         }
       }
     }


### PR DESCRIPTION
Placeholder om voorstel Candidate Form Field Description design tokens te bewaren.

Niet blind mergen! Bij een Figma-release de set aan design tokens kopiëren en toevoegen aan de meest recente branch. Daarna nog 1 keer Apply to Selection op alle benodigde frames.