### PR TITLE
style: placeholder for Candidate Form Field Error Message design tokens

### DIFF
--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6724,7 +6724,58 @@
       }
     }
   },
-  "components/form-field-error-message": {
+  "components/form-field-error-message/nl": {
+    "nl": {
+      "form-field-error-message": {
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.negative.color-default}"
+        },
+        "column-gap": {
+          "$type": "dimension",
+          "$value": "{basis.space.text.xs}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{basis.text.font-family.default}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{basis.text.font-size.md}"
+        },
+        "font-style": {
+          "$type": "other",
+          "$value": "normal",
+          "$description": "[code-only]"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{basis.text.font-weight.default}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{basis.text.line-height.md}"
+        },
+        "margin-block-end": {
+          "$type": "dimension",
+          "$value": "0px",
+          "$description": "[code-only]"
+        },
+        "margin-block-start": {
+          "$type": "dimension",
+          "$value": "0px",
+          "$description": "[code-only]"
+        },
+        "icon": {
+          "size": {
+            "$type": "dimension",
+            "$value": "{basis.size.icon.md}"
+          }
+        }
+      }
+    }
+  },
+  "components/form-field-error-message/utrecht": {
     "utrecht": {
       "form-field-error-message": {
         "background-color": {
@@ -14337,7 +14388,8 @@
       "components/form-field",
       "components/form-field-checkbox-option",
       "components/form-field-description",
-      "components/form-field-error-message",
+      "components/form-field-error-message/nl",
+      "components/form-field-error-message/utrecht",
       "components/form-field-label/utrecht",
       "components/form-field-label/todo",
       "components/form-field-label-suffix",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6750,7 +6750,7 @@
         },
         "font-weight": {
           "$type": "fontWeights",
-          "$value": "{basis.text.font-weight.bold}"
+          "$value": "{basis.text.font-weight.default}"
         },
         "line-height": {
           "$type": "lineHeights",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6750,7 +6750,7 @@
         },
         "font-weight": {
           "$type": "fontWeights",
-          "$value": "{basis.text.font-weight.default}"
+          "$value": "{basis.text.font-weight.bold}"
         },
         "line-height": {
           "$type": "lineHeights",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6731,16 +6731,6 @@
           "$type": "color",
           "$value": "{basis.color.negative.color-default}"
         },
-        "icon": {
-          "color": {
-            "$type": "color",
-            "$value": "{basis.color.negative.color-default}"
-          },
-          "size": {
-            "$type": "dimension",
-            "$value": "{basis.size.icon.md}"
-          }
-        },
         "column-gap": {
           "$type": "dimension",
           "$value": "{basis.space.text.xs}"
@@ -6770,6 +6760,16 @@
           "$type": "dimension",
           "$value": "0px",
           "$description": "[code-only]"
+        },
+        "icon": {
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.negative.color-default}"
+          },
+          "size": {
+            "$type": "dimension",
+            "$value": "{basis.size.icon.md}"
+          }
         }
       }
     }

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6743,11 +6743,6 @@
           "$type": "fontSizes",
           "$value": "{basis.text.font-size.md}"
         },
-        "font-style": {
-          "$type": "other",
-          "$value": "normal",
-          "$description": "[code-only]"
-        },
         "font-weight": {
           "$type": "fontWeights",
           "$value": "{basis.text.font-weight.default}"

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6731,6 +6731,16 @@
           "$type": "color",
           "$value": "{basis.color.negative.color-default}"
         },
+        "icon": {
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.negative.color-default}"
+          },
+          "size": {
+            "$type": "dimension",
+            "$value": "{basis.size.icon.md}"
+          }
+        },
         "column-gap": {
           "$type": "dimension",
           "$value": "{basis.space.text.xs}"
@@ -6760,12 +6770,6 @@
           "$type": "dimension",
           "$value": "0px",
           "$description": "[code-only]"
-        },
-        "icon": {
-          "size": {
-            "$type": "dimension",
-            "$value": "{basis.size.icon.md}"
-          }
         }
       }
     }


### PR DESCRIPTION
Placeholder om voorstel Candidate Form Field Error Message design tokens te bewaren.

Niet blind mergen! Bij een Figma-release de set aan design tokens kopiëren en toevoegen aan de meest recente branch. Daarna nog 1 keer Apply to Selection op alle benodigde frames.