### PR TITLE
Change cursor value from 'disabled' to 'not-allowed'

### DIFF
--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -6920,7 +6920,7 @@
           },
           "cursor": {
             "$type": "other",
-            "$value": "disabled",
+            "$value": "not-allowed",
             "$description": "[code-only]"
           }
         },
@@ -6975,7 +6975,7 @@
             },
             "cursor": {
               "$type": "other",
-              "$value": "disabled",
+              "$value": "not-allowed",
               "$description": "[code-only]"
             }
           },
@@ -8021,7 +8021,7 @@
           },
           "cursor": {
             "$type": "other",
-            "$value": "disabled",
+            "$value": "not-allowed",
             "$description": "[code-only]"
           }
         },


### PR DESCRIPTION
`not-allowed` is the CSS value for this, `disabled` does not exist

See: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/cursor