### PR TITLE
style: placeholder for Candidate Form Field Label design tokens

### DIFF
--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6967,6 +6967,32 @@
       }
     }
   },
+  "components/form-field-label/nl": {
+    "nl": {
+      "form-field-label": {
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{basis.text.font-family.default}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{basis.text.font-size.md}"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{basis.text.font-weight.bold}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{basis.text.line-height.md}"
+        }
+      }
+    }
+  },
   "components/form-field-label/utrecht": {
     "utrecht": {
       "form-label": {
@@ -14854,6 +14880,7 @@
       "components/form-field-checkbox-option",
       "components/form-field-description",
       "components/form-field-error-message",
+      "components/form-field-label/nl",
       "components/form-field-label/utrecht",
       "components/form-field-label/todo",
       "components/form-field-label-suffix",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6989,6 +6989,22 @@
         "line-height": {
           "$type": "lineHeights",
           "$value": "{basis.text.line-height.md}"
+        },
+        "option": {
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.default.color-document}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{basis.text.font-weight.default}"
+          }
+        },
+        "disabled": {
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.color-subtle}"
+          }
         }
       }
     }


### PR DESCRIPTION
Placeholder om eerste voorstel Candidate Form Field Label design tokens te bewaren.

Niet blind mergen! Bij een Figma-release de set aan design tokens kopiëren en toevoegen aan de meest recente branch. Daarna nog 1 keer Apply to Selection op alle benodigde frames.