### PR TITLE
ci: fix slow codecov upload step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,10 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: coverage-report
-          path: "**/coverage/"
+          path: |
+            packages/*/coverage/
+            packages/components-react/*/coverage/
+            proprietary/*/coverage/
           retention-days: 1
 
       - name: Publish to Chromatic


### PR DESCRIPTION
This fixes a very slow upload-artifact step that takes >10 minutes but should take seconds.  I suspect it is traversing `node\_modules`.

Update: it did traverse `node\_modules`.  I tried adding it to the ignored files, but that only prevented upload, not path traversal.  So the solution is to choose a glob that doesn't match `node\_modules`, with the downside that if new packages are added in a different place then this glob needs to be updated.
