### PR TITLE
style: page body tokens utrecht community component

### DIFF
--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6908,6 +6908,36 @@
       }
     }
   },
+  "components/document": {
+    "utrecht": {
+      "document": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{basis.color.default.bg-document}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{basis.text.font-family.default}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{basis.text.font-size.md}"
+        },
+        "font-weight": {
+          "$type": "fontWeights",
+          "$value": "{basis.text.font-weight.default}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{basis.text.line-height.md}"
+        }
+      }
+    }
+  },
   "components/dot-badge": {
     "rhc": {
       "dot-badge": {
@@ -9193,6 +9223,50 @@
           "padding-inline-start": {
             "$type": "dimension",
             "$value": "{basis.space.inline.md}"
+          }
+        }
+      }
+    }
+  },
+  "components/page-body": {
+    "utrecht": {
+      "page-body": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{basis.color.default.bg-document}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "content": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.default.bg-document}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.default.color-document}"
+          },
+          "max-inline-size": {
+            "$type": "dimension",
+            "$value": "{basis.page.max-inline-size}"
+          },
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.4xl}"
+          },
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.4xl}"
+          },
+          "padding-inline-end": {
+            "$type": "dimension",
+            "$value": "{basis.space.inline.xl}"
+          },
+          "padding-inline-start": {
+            "$type": "dimension",
+            "$value": "{basis.space.inline.xl}"
           }
         }
       }
@@ -13074,36 +13148,6 @@
       }
     }
   },
-  "components/document": {
-    "utrecht": {
-      "document": {
-        "background-color": {
-          "$type": "color",
-          "$value": "{basis.color.default.bg-document}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{basis.color.default.color-document}"
-        },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{basis.text.font-family.default}"
-        },
-        "font-size": {
-          "$type": "fontSizes",
-          "$value": "{basis.text.font-size.md}"
-        },
-        "font-weight": {
-          "$type": "fontWeights",
-          "$value": "{basis.text.font-weight.default}"
-        },
-        "line-height": {
-          "$type": "lineHeights",
-          "$value": "{basis.text.line-height.md}"
-        }
-      }
-    }
-  },
   "components/root": {
     "utrecht": {
       "root": {
@@ -13316,38 +13360,6 @@
         "padding-inline": {
           "$type": "dimension",
           "$value": "{basis.space.inline.4xl}"
-        },
-        "content": {
-          "max-inline-size": {
-            "$type": "dimension",
-            "$value": "{basis.page.max-inline-size}"
-          },
-          "padding-block-end": {
-            "$type": "dimension",
-            "$value": "{basis.space.block.4xl}"
-          },
-          "padding-block-start": {
-            "$type": "dimension",
-            "$value": "{basis.space.block.4xl}"
-          },
-          "padding-inline": {
-            "$type": "dimension",
-            "$value": "{basis.space.inline.4xl}"
-          }
-        }
-      }
-    }
-  },
-  "components/page-body": {
-    "utrecht": {
-      "page-body": {
-        "background-color": {
-          "$type": "color",
-          "$value": "{basis.color.default.bg-document}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{basis.color.default.color-document}"
         },
         "content": {
           "max-inline-size": {
@@ -15424,6 +15436,7 @@
       "components/number-badge/nl",
       "components/number-badge/utrecht",
       "components/ordered-list",
+      "components/page-body",
       "components/page-number-navigation/utrecht",
       "components/page-number-navigation/todo",
       "components/paragraph/nl",
@@ -15456,7 +15469,6 @@
       "components/body",
       "components/page-header/amsterdam",
       "components/page-header/utrecht",
-      "components/page-body",
       "components/page-footer/amsterdam",
       "components/page-footer/utrecht",
       "components/article",


### PR DESCRIPTION
Nieuwe design tokens voor Page Body toegevoegd:

- `utrecht.page-body.content.background-color`
- `utrecht.page-body.content.color`
- `utrecht.page-body.content.padding-inline-end`
- `utrecht.page-body.content.padding-inline-start`

Verwijderd/vervangen:
 - `utrecht.page-body.content.padding-inline`

Positie Page Body component tokens binnen JSON op juiste plek. En op een of andere manier komt Document ook weer mee qua positiewijziging. Maar dat zou met https://github.com/nl-design-system/themes/pull/1404 ook al gebeuren.