### PR TITLE
style: root and page body tokens utrecht community component (MA en Voorbeeld)

### DIFF
--- a/.changeset/root-body-layout-voor.md
+++ b/.changeset/root-body-layout-voor.md
@@ -1,0 +1,21 @@
+---
+"@nl-design-system-unstable/voorbeeld-design-tokens": major
+"@nl-design-system-community/ma-design-tokens": major
+---
+
+De volgende tokens zijn toegevoegd aan Root component:
+
+- `utrecht.root.font-size`
+- `utrecht.root.font-size-adjust`
+- `utrecht.root.line-height`
+
+De volgende tokens zijn toegevoegd aan Page Body component:
+
+- `utrecht.page-body.content.background-color`
+- `utrecht.page-body.content.color`
+- `utrecht.page-body.content.padding-inline-end`
+- `utrecht.page-body.content.padding-inline-start`
+
+Token `utrecht.page-body.content.padding-inline` is verwijderd uit Page Body component.
+
+Positie Root and Page Body tokenset binnen JSON op juiste plek.

--- a/.changeset/root-body-layout-voor.md
+++ b/.changeset/root-body-layout-voor.md
@@ -18,4 +18,4 @@ De volgende tokens zijn toegevoegd aan Page Body component:
 
 Token `utrecht.page-body.content.padding-inline` is verwijderd uit Page Body component.
 
-Positie Root and Page Body tokenset binnen JSON op juiste plek.
+Root en Page Body tokenset binnen JSON op juiste positie.

--- a/packages/ma-design-tokens/src/tokens.json
+++ b/packages/ma-design-tokens/src/tokens.json
@@ -9795,6 +9795,50 @@
       }
     }
   },
+  "components/page-body": {
+    "utrecht": {
+      "page-body": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{basis.color.default.bg-document}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "content": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.default.bg-document}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.default.color-document}"
+          },
+          "max-inline-size": {
+            "$type": "dimension",
+            "$value": "{basis.page.max-inline-size}"
+          },
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.4xl}"
+          },
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{basis.space.none}"
+          },
+          "padding-inline-end": {
+            "$type": "dimension",
+            "$value": "{basis.space.inline.xl}"
+          },
+          "padding-inline-start": {
+            "$type": "dimension",
+            "$value": "{basis.space.inline.xl}"
+          }
+        }
+      }
+    }
+  },
   "components/page-number-navigation/utrecht": {
     "utrecht": {
       "pagination": {
@@ -11579,6 +11623,37 @@
               "$value": "{basis.form-control.disabled.color}"
             }
           }
+        }
+      }
+    }
+  },
+  "components/root": {
+    "utrecht": {
+      "root": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{basis.color.default.bg-document}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{basis.text.font-family.default}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{basis.text.font-size.md}"
+        },
+        "font-size-adjust": {
+          "$type": "other",
+          "$value": "0.515",
+          "$description": "[code-only]"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{basis.text.line-height.md}"
         }
       }
     }
@@ -13827,24 +13902,6 @@
       }
     }
   },
-  "components/root": {
-    "utrecht": {
-      "root": {
-        "background-color": {
-          "$type": "color",
-          "$value": "{basis.color.default.bg-document}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{basis.color.default.color-document}"
-        },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{basis.text.font-family.default}"
-        }
-      }
-    }
-  },
   "components/body": {
     "utrecht": {
       "body": {
@@ -14097,38 +14154,6 @@
         "padding-inline": {
           "$type": "dimension",
           "$value": "{basis.space.inline.4xl}"
-        },
-        "content": {
-          "max-inline-size": {
-            "$type": "dimension",
-            "$value": "{basis.page.max-inline-size}"
-          },
-          "padding-block-end": {
-            "$type": "dimension",
-            "$value": "{basis.space.block.4xl}"
-          },
-          "padding-block-start": {
-            "$type": "dimension",
-            "$value": "{basis.space.block.4xl}"
-          },
-          "padding-inline": {
-            "$type": "dimension",
-            "$value": "{basis.space.inline.4xl}"
-          }
-        }
-      }
-    }
-  },
-  "components/page-body": {
-    "utrecht": {
-      "page-body": {
-        "background-color": {
-          "$type": "color",
-          "$value": "{basis.color.default.bg-document}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{basis.color.default.color-document}"
         },
         "content": {
           "max-inline-size": {
@@ -16390,6 +16415,7 @@
       "components/number-badge/nl",
       "components/number-badge/utrecht",
       "components/ordered-list",
+      "components/page-body",
       "components/page-number-navigation/utrecht",
       "components/page-number-navigation/todo",
       "components/paragraph/nl",
@@ -16399,6 +16425,7 @@
       "components/progress-list/den-haag",
       "components/progress-list/todo",
       "components/radio-button",
+      "components/root",
       "components/select",
       "components/separator",
       "components/side-navigation",
@@ -16420,12 +16447,10 @@
       "components/text-input",
       "components/toolbar-button",
       "components/unordered-list",
-      "components/root",
       "components/body",
       "components/page-header/ma",
       "components/page-header/amsterdam",
       "components/page-header/utrecht",
-      "components/page-body",
       "components/page-footer/ma",
       "components/page-footer/amsterdam",
       "components/page-footer/utrecht",

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -9449,6 +9449,50 @@
       }
     }
   },
+  "components/page-body": {
+    "utrecht": {
+      "page-body": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{basis.color.default.bg-document}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "content": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.default.bg-document}"
+          },
+          "color": {
+            "$type": "color",
+            "$value": "{basis.color.default.color-document}"
+          },
+          "max-inline-size": {
+            "$type": "dimension",
+            "$value": "{basis.page.max-inline-size}"
+          },
+          "padding-block-end": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.4xl}"
+          },
+          "padding-block-start": {
+            "$type": "dimension",
+            "$value": "{basis.space.none}"
+          },
+          "padding-inline-end": {
+            "$type": "dimension",
+            "$value": "{basis.space.inline.xl}"
+          },
+          "padding-inline-start": {
+            "$type": "dimension",
+            "$value": "{basis.space.inline.xl}"
+          }
+        }
+      }
+    }
+  },
   "components/page-number-navigation/utrecht": {
     "utrecht": {
       "pagination": {
@@ -11233,6 +11277,37 @@
               "$value": "{basis.form-control.disabled.color}"
             }
           }
+        }
+      }
+    }
+  },
+  "components/root": {
+    "utrecht": {
+      "root": {
+        "background-color": {
+          "$type": "color",
+          "$value": "{basis.color.default.bg-document}"
+        },
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{basis.text.font-family.default}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{basis.text.font-size.md}"
+        },
+        "font-size-adjust": {
+          "$type": "other",
+          "$value": "0.515",
+          "$description": "[code-only]"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{basis.text.line-height.md}"
         }
       }
     }
@@ -13325,24 +13400,6 @@
       }
     }
   },
-  "components/root": {
-    "utrecht": {
-      "root": {
-        "background-color": {
-          "$type": "color",
-          "$value": "{basis.color.default.bg-document}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{basis.color.default.color-document}"
-        },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{basis.text.font-family.default}"
-        }
-      }
-    }
-  },
   "components/body": {
     "utrecht": {
       "body": {
@@ -13537,38 +13594,6 @@
         "padding-inline": {
           "$type": "dimension",
           "$value": "{basis.space.inline.4xl}"
-        },
-        "content": {
-          "max-inline-size": {
-            "$type": "dimension",
-            "$value": "{basis.page.max-inline-size}"
-          },
-          "padding-block-end": {
-            "$type": "dimension",
-            "$value": "{basis.space.block.4xl}"
-          },
-          "padding-block-start": {
-            "$type": "dimension",
-            "$value": "{basis.space.block.4xl}"
-          },
-          "padding-inline": {
-            "$type": "dimension",
-            "$value": "{basis.space.inline.4xl}"
-          }
-        }
-      }
-    }
-  },
-  "components/page-body": {
-    "utrecht": {
-      "page-body": {
-        "background-color": {
-          "$type": "color",
-          "$value": "{basis.color.default.bg-document}"
-        },
-        "color": {
-          "$type": "color",
-          "$value": "{basis.color.default.color-document}"
         },
         "content": {
           "max-inline-size": {
@@ -15644,6 +15669,7 @@
       "components/number-badge/nl",
       "components/number-badge/utrecht",
       "components/ordered-list",
+      "components/page-body",
       "components/page-number-navigation/utrecht",
       "components/page-number-navigation/todo",
       "components/paragraph/nl",
@@ -15653,6 +15679,7 @@
       "components/progress-list/den-haag",
       "components/progress-list/todo",
       "components/radio-button",
+      "components/root",
       "components/select",
       "components/separator",
       "components/side-navigation",
@@ -15672,11 +15699,9 @@
       "components/text-input",
       "components/toolbar-button",
       "components/unordered-list",
-      "components/root",
       "components/body",
       "components/page-header/amsterdam",
       "components/page-header/utrecht",
-      "components/page-body",
       "components/page-footer/amsterdam",
       "components/page-footer/utrecht",
       "components/article",


### PR DESCRIPTION
De volgende tokens zijn toegevoegd aan Root component:

- `utrecht.root.font-size`
- `utrecht.root.font-size-adjust`
- `utrecht.root.line-height`

De volgende tokens zijn toegevoegd aan Page Body component:

- `utrecht.page-body.content.background-color`
- `utrecht.page-body.content.color`
- `utrecht.page-body.content.padding-inline-end`
- `utrecht.page-body.content.padding-inline-start`

Token `utrecht.page-body.content.padding-inline` is verwijderd uit Page Body component.

Root en Page Body tokenset binnen JSON op juiste positie.