### PR TITLE
style: rename modal dialog tokens amsterdam community component

### DIFF
--- a/.changeset/tokens-modal-dialog.md
+++ b/.changeset/tokens-modal-dialog.md
@@ -1,0 +1,10 @@
+---
+"@nl-design-system-unstable/start-design-tokens": minor
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+"@nl-design-system-community/ma-design-tokens": minor
+---
+
+De volgende tokens zijn hernoemd in Modal Dialog component:
+
+- `todo.dialog.border-radius` naar `ams.dialog.border-radius`
+- `todo.dialog.box-shadow` naar `ams.dialog.box-shadow`

--- a/packages/ma-design-tokens/src/tokens.json
+++ b/packages/ma-design-tokens/src/tokens.json
@@ -8849,6 +8849,10 @@
           "$type": "color",
           "$value": "{basis.color.default.border-subtle}"
         },
+        "border-radius": {
+          "$type": "dimension",
+          "$value": "{basis.border-radius.lg}"
+        },
         "border-style": {
           "$type": "other",
           "$value": "solid",
@@ -8857,6 +8861,10 @@
         "border-width": {
           "$type": "dimension",
           "$value": "{basis.border-width.sm}"
+        },
+        "box-shadow": {
+          "$type": "boxShadow",
+          "$value": "{basis.box-shadow.lg}"
         },
         "gap": {
           "$type": "dimension",
@@ -8951,18 +8959,6 @@
               "$value": "{basis.space.inline.xl}"
             }
           }
-        }
-      }
-    },
-    "todo": {
-      "dialog": {
-        "border-radius": {
-          "$type": "dimension",
-          "$value": "{basis.border-radius.lg}"
-        },
-        "box-shadow": {
-          "$type": "boxShadow",
-          "$value": "{basis.box-shadow.lg}"
         }
       }
     }

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -8634,6 +8634,10 @@
           "$type": "color",
           "$value": "{basis.color.default.border-subtle}"
         },
+        "border-radius": {
+          "$type": "dimension",
+          "$value": "{basis.border-radius.lg}"
+        },
         "border-style": {
           "$type": "other",
           "$value": "solid",
@@ -8642,6 +8646,10 @@
         "border-width": {
           "$type": "dimension",
           "$value": "{basis.border-width.sm}"
+        },
+        "box-shadow": {
+          "$type": "boxShadow",
+          "$value": "{basis.box-shadow.lg}"
         },
         "gap": {
           "$type": "dimension",
@@ -8736,18 +8744,6 @@
               "$value": "{basis.space.inline.xl}"
             }
           }
-        }
-      }
-    },
-    "todo": {
-      "dialog": {
-        "border-radius": {
-          "$type": "dimension",
-          "$value": "{basis.border-radius.lg}"
-        },
-        "box-shadow": {
-          "$type": "boxShadow",
-          "$value": "{basis.box-shadow.lg}"
         }
       }
     }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -8855,6 +8855,10 @@
           "$type": "color",
           "$value": "{basis.color.default.border-subtle}"
         },
+        "border-radius": {
+          "$type": "dimension",
+          "$value": "{basis.border-radius.lg}"
+        },
         "border-style": {
           "$type": "other",
           "$value": "solid",
@@ -8863,6 +8867,10 @@
         "border-width": {
           "$type": "dimension",
           "$value": "{basis.border-width.sm}"
+        },
+        "box-shadow": {
+          "$type": "boxShadow",
+          "$value": "{basis.box-shadow.lg}"
         },
         "gap": {
           "$type": "dimension",
@@ -8957,18 +8965,6 @@
               "$value": "{basis.space.inline.xl}"
             }
           }
-        }
-      }
-    },
-    "todo": {
-      "dialog": {
-        "border-radius": {
-          "$type": "dimension",
-          "$value": "{basis.border-radius.lg}"
-        },
-        "box-shadow": {
-          "$type": "boxShadow",
-          "$value": "{basis.box-shadow.lg}"
         }
       }
     }


### PR DESCRIPTION
De volgende tokens zijn hernoemd in Modal Dialog component:

- `todo.dialog.border-radius` naar `ams.dialog.border-radius`
- `todo.dialog.box-shadow` naar `ams.dialog.box-shadow`