### PR TITLE
fix: change values of switch `color` tokens

### DIFF
--- a/.changeset/switch-color-tokens.md
+++ b/.changeset/switch-color-tokens.md
@@ -1,0 +1,8 @@
+---
+"@nl-design-system-unstable/start-design-tokens": minor
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+"@nl-design-system-community/ma-design-tokens": minor
+---
+
+- Waarde van token `utrecht.form-toggle.color` is gewijzigd van `basis.color.default.color-document` naar `basis.color.default-inverse.color-default`.
+- Waarde van token `utrecht.form-toggle.hover.color` is gewijzigd van `basis.color.default.color-document` naar `basis.color.default-inverse.color-hover`.

--- a/packages/ma-design-tokens/src/tokens.json
+++ b/packages/ma-design-tokens/src/tokens.json
@@ -12689,7 +12689,7 @@
         },
         "color": {
           "$type": "color",
-          "$value": "{basis.color.default.color-document}"
+          "$value": "{basis.color.default-inverse.color-default}"
         },
         "height": {
           "$type": "dimension",
@@ -12747,7 +12747,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{basis.color.default.color-document}"
+            "$value": "{basis.color.default-inverse.color-hover}"
           }
         },
         "focus": {

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -12122,7 +12122,7 @@
         },
         "color": {
           "$type": "color",
-          "$value": "{basis.color.default.color-document}"
+          "$value": "{basis.color.default-inverse.color-default}"
         },
         "height": {
           "$type": "dimension",
@@ -12180,7 +12180,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{basis.color.default.color-document}"
+            "$value": "{basis.color.default-inverse.color-hover}"
           }
         },
         "focus": {

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -12343,7 +12343,7 @@
         },
         "color": {
           "$type": "color",
-          "$value": "{basis.color.default.color-document}"
+          "$value": "{basis.color.default-inverse.color-default}"
         },
         "height": {
           "$type": "dimension",
@@ -12401,7 +12401,7 @@
           },
           "color": {
             "$type": "color",
-            "$value": "{basis.color.default.color-document}"
+            "$value": "{basis.color.default-inverse.color-hover}"
           }
         },
         "focus": {


### PR DESCRIPTION
De waarde van de volgende tokens zijn gewijzigd:

- Waarde van token `utrecht.form-toggle.color` is gewijzigd van `basis.color.default.color-document` naar `basis.color.default-inverse.color-default`.
- Waarde van token `utrecht.form-toggle.hover.color` is gewijzigd van `basis.color.default.color-document` naar `basis.color.default-inverse.color-hover`.