### PR TITLE
Doubly ensure packages are published with provenance

### DIFF
--- a/packages/basis-design-tokens/package.json
+++ b/packages/basis-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "EUPL-1.2",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/components-react/design-tokens-table-react/package.json
+++ b/packages/components-react/design-tokens-table-react/package.json
@@ -26,7 +26,8 @@
     "directory": "packages/components-react/design-tokens-table-react"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",

--- a/packages/design-tokens-definition/package.json
+++ b/packages/design-tokens-definition/package.json
@@ -9,7 +9,8 @@
   "type": "module",
   "license": "EUPL-1.2",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/ma-design-tokens/package.json
+++ b/packages/ma-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "EUPL-1.2",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/start-design-tokens/package.json
+++ b/packages/start-design-tokens/package.json
@@ -8,7 +8,8 @@
     "nl-design-system"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/theme-logo/package.json
+++ b/packages/theme-logo/package.json
@@ -9,7 +9,8 @@
   "license": "EUPL-1.2",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "src/index.js"

--- a/packages/theme-switcher/package.json
+++ b/packages/theme-switcher/package.json
@@ -9,7 +9,8 @@
   "license": "EUPL-1.2",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "src/index.js"

--- a/packages/theme-toolkit/package.json
+++ b/packages/theme-toolkit/package.json
@@ -9,7 +9,8 @@
   "type": "module",
   "license": "EUPL-1.2",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/tokens-lib/package.json
+++ b/packages/tokens-lib/package.json
@@ -9,7 +9,8 @@
   "type": "module",
   "license": "EUPL-1.2",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/voorbeeld-design-tokens/package.json
+++ b/packages/voorbeeld-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "EUPL-1.2",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/bodegraven-reeuwijk-design-tokens/package.json
+++ b/proprietary/bodegraven-reeuwijk-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/borne-design-tokens/package.json
+++ b/proprietary/borne-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/buren-design-tokens/package.json
+++ b/proprietary/buren-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/demodam-design-tokens/package.json
+++ b/proprietary/demodam-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/dinkelland-design-tokens/package.json
+++ b/proprietary/dinkelland-design-tokens/package.json
@@ -11,7 +11,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/drechterland-design-tokens/package.json
+++ b/proprietary/drechterland-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/duiven-design-tokens/package.json
+++ b/proprietary/duiven-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/duo-design-tokens/package.json
+++ b/proprietary/duo-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/enkhuizen-design-tokens/package.json
+++ b/proprietary/enkhuizen-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/epe-design-tokens/package.json
+++ b/proprietary/epe-design-tokens/package.json
@@ -11,7 +11,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/example-design-tokens/package.json
+++ b/proprietary/example-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/groningen-design-tokens/package.json
+++ b/proprietary/groningen-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/haarlem-design-tokens/package.json
+++ b/proprietary/haarlem-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/haarlemmermeer-design-tokens/package.json
+++ b/proprietary/haarlemmermeer-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/hoeksche-waard-design-tokens/package.json
+++ b/proprietary/hoeksche-waard-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/hoorn-design-tokens/package.json
+++ b/proprietary/hoorn-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/horstaandemaas-design-tokens/package.json
+++ b/proprietary/horstaandemaas-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/leiden-design-tokens/package.json
+++ b/proprietary/leiden-design-tokens/package.json
@@ -11,7 +11,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/leidschendam-voorburg-design-tokens/package.json
+++ b/proprietary/leidschendam-voorburg-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/nijmegen-design-tokens/package.json
+++ b/proprietary/nijmegen-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/noaberkracht-design-tokens/package.json
+++ b/proprietary/noaberkracht-design-tokens/package.json
@@ -11,7 +11,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/noordoostpolder-design-tokens/package.json
+++ b/proprietary/noordoostpolder-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/noordwijk-design-tokens/package.json
+++ b/proprietary/noordwijk-design-tokens/package.json
@@ -11,7 +11,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/nora-design-tokens/package.json
+++ b/proprietary/nora-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/provincie-zuid-holland-design-tokens/package.json
+++ b/proprietary/provincie-zuid-holland-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/purmerend-design-tokens/package.json
+++ b/proprietary/purmerend-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/ridderkerk-design-tokens/package.json
+++ b/proprietary/ridderkerk-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/stedebroec-design-tokens/package.json
+++ b/proprietary/stedebroec-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/tilburg-design-tokens/package.json
+++ b/proprietary/tilburg-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/tubbergen-design-tokens/package.json
+++ b/proprietary/tubbergen-design-tokens/package.json
@@ -11,7 +11,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/venray-design-tokens/package.json
+++ b/proprietary/venray-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/voorne-aan-zee-design-tokens/package.json
+++ b/proprietary/voorne-aan-zee-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/vught-design-tokens/package.json
+++ b/proprietary/vught-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/westervoort-design-tokens/package.json
+++ b/proprietary/westervoort-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/xxllnc-design-tokens/package.json
+++ b/proprietary/xxllnc-design-tokens/package.json
@@ -11,7 +11,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/zaanstad-design-tokens/package.json
+++ b/proprietary/zaanstad-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/zevenaar-design-tokens/package.json
+++ b/proprietary/zevenaar-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/proprietary/zwolle-design-tokens/package.json
+++ b/proprietary/zwolle-design-tokens/package.json
@@ -10,7 +10,8 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",


### PR DESCRIPTION
This is not strictly necessary, because there are other ways to configure provenance (notably .npmrc), but it helps with automated scripts and gives extra peace of mind.
