### PR TITLE
fix: revert ref naar `basis.space.none` voor `$type=other` tokens

### DIFF
--- a/.changeset/gorgeous-chicken-serve.md
+++ b/.changeset/gorgeous-chicken-serve.md
@@ -1,0 +1,6 @@
+---
+"@nl-design-system-unstable/start-design-tokens": patch
+"@nl-design-system-community/ma-design-tokens": patch
+---
+
+fix: revert ref naar `basis.space.none` voor `$type=other` tokens

--- a/packages/ma-design-tokens/src/tokens.json
+++ b/packages/ma-design-tokens/src/tokens.json
@@ -13003,7 +13003,7 @@
           },
           "outline-offset": {
             "$type": "other",
-            "$value": "{basis.space.none}",
+            "$value": "0px",
             "$description": "[code-only]"
           },
           "padding-block": {
@@ -13145,7 +13145,7 @@
           },
           "outline": {
             "$type": "other",
-            "$value": "{basis.space.none}",
+            "$value": "0px",
             "$description": "[code-only]"
           },
           "hover": {
@@ -13182,14 +13182,14 @@
           },
           "bottom": {
             "$type": "other",
-            "$value": "{basis.space.none}",
+            "$value": "0px",
             "$description": "[code-only]"
           }
         },
         "tab-panel": {
           "outline": {
             "$type": "other",
-            "$value": "{basis.space.none}",
+            "$value": "0px",
             "$description": "[code-only]"
           },
           "padding-block-end": {

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -12436,7 +12436,7 @@
           },
           "outline-offset": {
             "$type": "other",
-            "$value": "{basis.space.none}",
+            "$value": "0px",
             "$description": "[code-only]"
           },
           "padding-block": {
@@ -12578,7 +12578,7 @@
           },
           "outline": {
             "$type": "other",
-            "$value": "{basis.space.none}",
+            "$value": "0px",
             "$description": "[code-only]"
           },
           "hover": {
@@ -12615,14 +12615,14 @@
           },
           "bottom": {
             "$type": "other",
-            "$value": "{basis.space.none}",
+            "$value": "0px",
             "$description": "[code-only]"
           }
         },
         "tab-panel": {
           "outline": {
             "$type": "other",
-            "$value": "{basis.space.none}",
+            "$value": "0px",
             "$description": "[code-only]"
           },
           "padding-block-end": {


### PR DESCRIPTION
Gedeelte revert van #1386

Validatie in de theme wizard gaat hierop stuk:

- `basis.space.none` heeft `$type=dimension`
- `denhaag.tabs.tab.outline` heeft `$type=other` en de `$value` refereert naar `basis.space.none`
- Strikt genomen mag die verwijzing niet omdat dat `$types` niet overeen komen.

Oplossing: voor nu ervoor gekozen om de `$value` terug te zetten naar `0px` voor:

- `ams.tabs.button.outline-offset`
- `denhaag.tabs.tab.outline`
- `denhaag.tabs.tab-indicator.bottom`
- `denhaag.tab-panel.outline`

Een andere oplossing is om de `$type` van bovenstaande te veranderen naar `'dimension'`, maar ik weet niet wat daarvan de verdere gevolgen zijn, dus dit leek me de veiligste optie.

Deze PR unblockt https://github.com/nl-design-system/theme-wizard/issues/696 en https://github.com/nl-design-system/theme-wizard/issues/722