### PR TITLE
feat/add-rhc-alert-to-themes-and-visual-regression-test

### DIFF
--- a/packages/components-react/design-tokens-table-react/package.json
+++ b/packages/components-react/design-tokens-table-react/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./tmp/ ./.rollup.cache/",
     "config": "tsc --showConfig",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "typecheck": "tsc"

--- a/packages/components-react/design-tokens-table-react/tsconfig.build.json
+++ b/packages/components-react/design-tokens-table-react/tsconfig.build.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "composite": false,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./tmp/tsconfig.dist.tsbuildinfo"
   },
   "include": ["src/*.ts", "src/*.tsx"],
   "exclude": ["src/**/*.test.*"]

--- a/packages/design-tokens-definition/src/collection.ts
+++ b/packages/design-tokens-definition/src/collection.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import merge from 'lodash-es/merge';
 
 const tokenPackages = ['@utrecht/component-library-design-tokens/dist/tokens.json'];
@@ -6,9 +7,12 @@ const tokenPackages = ['@utrecht/component-library-design-tokens/dist/tokens.jso
 export const getCommunityTokens = async () => {
   const tokens = await Promise.all(
     tokenPackages.map(async (tokensPath) => {
-      const path = new URL(import.meta.resolve(tokensPath)).pathname;
+      const url = import.meta.resolve(tokensPath);
+      const path = fileURLToPath(url);
+
       return JSON.parse(await readFile(path, 'utf-8'));
     }),
   );
+
   return merge({}, ...tokens);
 };

--- a/packages/theme-switcher/package.json
+++ b/packages/theme-switcher/package.json
@@ -22,7 +22,7 @@
     "directory": "packages/theme-switcher"
   },
   "scripts": {
-    "build": "mkdir -p dist/ && node src/generate-json.mjs",
+    "build": "mkdirp dist && node src/generate-json.mjs",
     "clean": "rimraf dist/"
   },
   "devDependencies": {
@@ -47,6 +47,7 @@
     "@nl-design-system-unstable/westervoort-design-tokens": "workspace:*",
     "@nl-design-system-unstable/zevenaar-design-tokens": "workspace:*",
     "@nl-design-system-unstable/zwolle-design-tokens": "workspace:*",
+    "mkdirp": "3.0.1",
     "rimraf": "6.0.1"
   }
 }

--- a/packages/theme-toolkit/src/component-stories-rhc.tsx
+++ b/packages/theme-toolkit/src/component-stories-rhc.tsx
@@ -1,5 +1,5 @@
 import { STORY_GROUPS } from './component-stories-util';
-import { DotBadge, Logo } from '@rijkshuisstijl-community/components-react';
+import { DotBadge, Alert, Heading, Logo, Paragraph } from '@rijkshuisstijl-community/components-react';
 
 export const RHC_COMPONENT_STORIES = [
   {
@@ -15,5 +15,17 @@ export const RHC_COMPONENT_STORIES = [
     group: STORY_GROUPS['LOGO'],
     name: 'Rijkshuisstijl Logo',
     render: () => <Logo organisation="Rijkshuisstijl-community" />,
+  },
+  {
+    storyId: 'react-rhc-alert--default',
+    component: 'rhc-alert',
+    group: STORY_GROUPS['ALERTS'],
+    name: 'Rijkshuisstijl Alert',
+    render: () => (
+      <Alert type="info">
+        <Heading level={3}>Heading</Heading>
+        <Paragraph>Lorem ipsum dolor sit amet, consectetur ad isicing elit, sed do eiusmod</Paragraph>
+      </Alert>
+    ),
   },
 ];

--- a/packages/voorbeeld-design-tokens/documentation/alert/rhc-alert.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/alert/rhc-alert.stories.tsx
@@ -1,0 +1,49 @@
+import { Alert, Heading, Paragraph } from '@rijkshuisstijl-community/components-react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  id: 'rhc-alert',
+  title: 'Components/Alert/Rijkshuisstijl Community',
+  component: Alert,
+  parameters: { actions: { disable: true } },
+  argTypes: {
+    children: {
+      description: 'HTML content of the alert',
+    },
+    type: {
+      description: 'Type',
+      control: { type: 'select' },
+      options: ['', 'error', 'info', 'ok', 'warning'],
+    },
+  },
+  args: {
+    children: (
+      <>
+        <Heading level={2}>Lorem ipsum</Heading>
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </Paragraph>
+      </>
+    ),
+  },
+} satisfies Meta<typeof Alert>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+// Een story met het voorbeeld thema
+export const VoorbeeldTheme: Story = {
+  name: 'Voorbeeld theme',
+  parameters: { theme: 'voorbeeld-theme' },
+};
+
+// Een story met het thema van de organisatie die de component bijdraagt
+export const RijkshuisstijlTheme: Story = {
+  name: 'Rijkshuisstijl Community theme',
+  parameters: { theme: 'rhc-theme' },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,7 +229,7 @@ importers:
         version: 3.20.0(react@19.2.3)
       '@testing-library/jest-dom':
         specifier: 6.4.5
-        version: 6.4.5(@jest/globals@29.7.0)(jest@29.7.0(@types/node@24.10.4)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.5.4)))
+        version: 6.4.5(@jest/globals@29.7.0)(jest@29.7.0(@types/node@24.10.4))
       '@testing-library/react':
         specifier: 15.0.7
         version: 15.0.7(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -628,6 +628,9 @@ importers:
       '@nl-design-system-unstable/zwolle-design-tokens':
         specifier: workspace:*
         version: link:../../proprietary/zwolle-design-tokens
+      mkdirp:
+        specifier: 3.0.1
+        version: 3.0.1
       rimraf:
         specifier: 6.0.1
         version: 6.0.1
@@ -757,7 +760,7 @@ importers:
         version: 15.2.3(rollup@4.19.2)
       '@testing-library/jest-dom':
         specifier: 6.4.5
-        version: 6.4.5(@jest/globals@29.7.0)(jest@29.7.0(@types/node@24.10.4)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.5.4)))
+        version: 6.4.5(@jest/globals@29.7.0)(jest@29.7.0(@types/node@24.10.4))
       '@testing-library/react':
         specifier: 15.0.7
         version: 15.0.7(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1054,7 +1057,7 @@ importers:
         version: 4.0.1
       ts-jest:
         specifier: 29.2.4
-        version: 29.2.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@24.10.4)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@24.10.4))(typescript@5.5.4)
       tsx:
         specifier: 4.17.0
         version: 4.17.0
@@ -1124,7 +1127,7 @@ importers:
         version: 3.20.0(react@19.2.3)
       '@testing-library/jest-dom':
         specifier: 6.4.5
-        version: 6.4.5(@jest/globals@29.7.0)(jest@29.7.0(@types/node@24.10.4)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.5.4)))
+        version: 6.4.5(@jest/globals@29.7.0)(jest@29.7.0(@types/node@24.10.4))
       '@types/prop-types':
         specifier: 15.7.12
         version: 15.7.12
@@ -1154,7 +1157,7 @@ importers:
         version: 4.0.1
       ts-jest:
         specifier: 29.2.4
-        version: 29.2.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@24.10.4)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@24.10.4))(typescript@5.5.4)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@types/node@24.10.4)(typescript@5.5.4)
@@ -7820,6 +7823,11 @@ packages:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
 
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -11712,7 +11720,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.5(@jest/globals@29.7.0)(jest@29.7.0(@types/node@24.10.4)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.5.4)))':
+  '@testing-library/jest-dom@6.4.5(@jest/globals@29.7.0)(jest@29.7.0(@types/node@24.10.4))':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.25.7
@@ -16966,6 +16974,8 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
+  mkdirp@3.0.1: {}
+
   mri@1.2.0: {}
 
   ms@2.1.2: {}
@@ -18484,7 +18494,7 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.2.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@24.10.4)(ts-node@10.9.2(@types/node@24.10.4)(typescript@5.5.4)))(typescript@5.5.4):
+  ts-jest@29.2.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@24.10.4))(typescript@5.5.4):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10


### PR DESCRIPTION
inlcudes a small change to run theme-switcher on for windows system

[preview](https://themes-git-feat-add-rhc-alert-to-themes-0c55a1-nl-design-system.vercel.app/?path=/story/rhc-alert--rijkshuisstijl-theme)