### PR TITLE
style: add `border-radius` token and mark `border-style` as code-only for file den haag community component

### DIFF
--- a/.changeset/file-border-tokens.md
+++ b/.changeset/file-border-tokens.md
@@ -1,0 +1,11 @@
+---
+"@nl-design-system-unstable/start-design-tokens": minor
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+"@nl-design-system-community/ma-design-tokens": minor
+---
+
+De volgende updates zijn gedaan in Community component 'File' van Den Haag:
+
+- Token `denhaag.file.border-radius` is toegevoegd aan File component.
+- Description `[code-only]` is toegevoegd aan token `denhaag.file.border-style`.
+- Tokens zijn in de juiste volgorde gezet.

--- a/packages/ma-design-tokens/src/tokens.json
+++ b/packages/ma-design-tokens/src/tokens.json
@@ -7330,13 +7330,18 @@
           "$type": "color",
           "$value": "{basis.color.default.border-subtle}"
         },
-        "border-width": {
+        "border-radius": {
           "$type": "dimension",
-          "$value": "{basis.border-width.sm}"
+          "$value": "{basis.border-radius.none}"
         },
         "border-style": {
           "$type": "other",
-          "$value": "solid"
+          "$value": "solid",
+          "$description": "[code-only]"
+        },
+        "border-width": {
+          "$type": "dimension",
+          "$value": "{basis.border-width.sm}"
         },
         "left": {
           "background-color": {

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -7119,13 +7119,18 @@
           "$type": "color",
           "$value": "{basis.color.default.border-subtle}"
         },
-        "border-width": {
+        "border-radius": {
           "$type": "dimension",
-          "$value": "{basis.border-width.sm}"
+          "$value": "{basis.border-radius.none}"
         },
         "border-style": {
           "$type": "other",
-          "$value": "solid"
+          "$value": "solid",
+          "$description": "[code-only]"
+        },
+        "border-width": {
+          "$type": "dimension",
+          "$value": "{basis.border-width.sm}"
         },
         "left": {
           "background-color": {

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -7336,13 +7336,18 @@
           "$type": "color",
           "$value": "{basis.color.default.border-subtle}"
         },
-        "border-width": {
+        "border-radius": {
           "$type": "dimension",
-          "$value": "{basis.border-width.sm}"
+          "$value": "{basis.border-radius.none}"
         },
         "border-style": {
           "$type": "other",
-          "$value": "solid"
+          "$value": "solid",
+          "$description": "[code-only]"
+        },
+        "border-width": {
+          "$type": "dimension",
+          "$value": "{basis.border-width.sm}"
         },
         "left": {
           "background-color": {


### PR DESCRIPTION
De volgende updates zijn gedaan in Community component 'File' van Den Haag:

- Token `denhaag.file.border-radius` is toegevoegd aan File component.
- Description `[code-only]` is toegevoegd aan token `denhaag.file.border-style`.
- Tokens zijn in de juiste volgorde gezet.