### PR TITLE
Fix/invalid letter spacing ref

### DIFF
--- a/.changeset/nine-spiders-hunt.md
+++ b/.changeset/nine-spiders-hunt.md
@@ -1,0 +1,6 @@
+---
+"@nl-design-system-unstable/start-design-tokens": patch
+"@nl-design-system-community/ma-design-tokens": patch
+---
+
+fix onjuiste referentie in utrecht.status-badge.letter-spacing

--- a/packages/ma-design-tokens/src/tokens.json
+++ b/packages/ma-design-tokens/src/tokens.json
@@ -12189,7 +12189,7 @@
         },
         "letter-spacing": {
           "$type": "letterSpacing",
-          "$value": "{basis.space.none}"
+          "$value": "0px"
         },
         "min-block-size": {
           "$type": "dimension",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -11622,7 +11622,7 @@
         },
         "letter-spacing": {
           "$type": "letterSpacing",
-          "$value": "{basis.space.none}"
+          "$value": "0px"
         },
         "min-block-size": {
           "$type": "dimension",


### PR DESCRIPTION
type=letterSpacing mag niet verwijzen naar een type=dimension. 

Lokaal getest met [design-tokens-lint](https://github.com/nl-design-system/theme-wizard/tree/main/packages/design-tokens-lint).

blocks https://github.com/nl-design-system/theme-wizard/pull/743