### PR TITLE
fix: shadow values for dark-mode

### DIFF
--- a/.changeset/dark-side-shadow.md
+++ b/.changeset/dark-side-shadow.md
@@ -1,0 +1,11 @@
+---
+"@nl-design-system-unstable/start-design-tokens": patch
+"@nl-design-system-unstable/voorbeeld-design-tokens": patch
+"@nl-design-system-community/ma-design-tokens": patch
+---
+
+- Token `basis.box-shadow.none` is toegevoegd voor dark-mode.
+- De waarde van de volgende basis-tokens is gewijzigd voor dark-mode:
+  - `basis.box-shadow.sm`
+  - `basis.box-shadow.md`
+  - `basis.box-shadow.lg`

--- a/packages/ma-design-tokens/src/tokens.json
+++ b/packages/ma-design-tokens/src/tokens.json
@@ -16834,6 +16834,10 @@
         }
       },
       "box-shadow": {
+        "none": {
+          "$type": "boxShadow",
+          "$value": "none"
+        },
         "sm": {
           "$type": "boxShadow",
           "$value": [
@@ -16842,7 +16846,15 @@
               "y": "1",
               "blur": "2",
               "spread": "0",
-              "color": "rgba(0,0,0,0.6)",
+              "color": "rgba(0,0,0,0.66)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "2",
+              "blur": "4",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.64)",
               "type": "dropShadow"
             },
             {
@@ -16850,7 +16862,7 @@
               "y": "0",
               "blur": "0",
               "spread": "1",
-              "color": "rgba(255,255,255,0.06)",
+              "color": "rgba(255,255,255,0.08)",
               "type": "dropShadow"
             }
           ]
@@ -16860,10 +16872,18 @@
           "$value": [
             {
               "x": "0",
-              "y": "4",
-              "blur": "8",
+              "y": "2",
+              "blur": "4",
               "spread": "0",
-              "color": "rgba(0,0,0,0.65)",
+              "color": "rgba(0,0,0,0.68)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "8",
+              "blur": "16",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.66)",
               "type": "dropShadow"
             },
             {
@@ -16881,10 +16901,18 @@
           "$value": [
             {
               "x": "0",
-              "y": "8",
-              "blur": "16",
+              "y": "4",
+              "blur": "8",
               "spread": "0",
-              "color": "rgba(0,0,0,0.7)",
+              "color": "rgba(0,0,0,0.70)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "16",
+              "blur": "32",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.68)",
               "type": "dropShadow"
             },
             {
@@ -16892,7 +16920,7 @@
               "y": "0",
               "blur": "0",
               "spread": "1",
-              "color": "rgba(255,255,255,0.10)",
+              "color": "rgba(255,255,255,0.08)",
               "type": "dropShadow"
             }
           ]

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -15295,38 +15295,72 @@
         }
       },
       "box-shadow": {
+        "none": {
+          "$type": "boxShadow",
+          "$value": "none"
+        },
         "sm": {
           "$type": "boxShadow",
-          "$value": {
-            "x": "0",
-            "y": "2",
-            "blur": "6",
-            "spread": "0",
-            "color": "{basis.color.default.bg-document}",
-            "type": "dropShadow"
-          }
+          "$value": [
+            {
+              "x": "0",
+              "y": "1",
+              "blur": "2",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.66)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "2",
+              "blur": "4",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.64)",
+              "type": "dropShadow"
+            }
+          ]
         },
         "md": {
           "$type": "boxShadow",
-          "$value": {
-            "x": "0",
-            "y": "8",
-            "blur": "16",
-            "spread": "0",
-            "color": "{basis.color.default.bg-document}",
-            "type": "dropShadow"
-          }
+          "$value": [
+            {
+              "x": "0",
+              "y": "2",
+              "blur": "4",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.68)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "8",
+              "blur": "16",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.66)",
+              "type": "dropShadow"
+            }
+          ]
         },
         "lg": {
           "$type": "boxShadow",
-          "$value": {
-            "x": "0",
-            "y": "16",
-            "blur": "48",
-            "spread": "0",
-            "color": "{basis.color.default.bg-document}",
-            "type": "dropShadow"
-          }
+          "$value": [
+            {
+              "x": "0",
+              "y": "4",
+              "blur": "8",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.70)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "16",
+              "blur": "32",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.68)",
+              "type": "dropShadow"
+            }
+          ]
         }
       },
       "focus": {

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -15317,6 +15317,14 @@
               "spread": "0",
               "color": "rgba(0,0,0,0.64)",
               "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "0",
+              "blur": "0",
+              "spread": "1",
+              "color": "rgba(255,255,255,0.08)",
+              "type": "dropShadow"
             }
           ]
         },
@@ -15338,6 +15346,14 @@
               "spread": "0",
               "color": "rgba(0,0,0,0.66)",
               "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "0",
+              "blur": "0",
+              "spread": "1",
+              "color": "rgba(255,255,255,0.08)",
+              "type": "dropShadow"
             }
           ]
         },
@@ -15358,6 +15374,14 @@
               "blur": "32",
               "spread": "0",
               "color": "rgba(0,0,0,0.68)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "0",
+              "blur": "0",
+              "spread": "1",
+              "color": "rgba(255,255,255,0.08)",
               "type": "dropShadow"
             }
           ]

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -15538,6 +15538,14 @@
               "spread": "0",
               "color": "rgba(0,0,0,0.64)",
               "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "0",
+              "blur": "0",
+              "spread": "1",
+              "color": "rgba(255,255,255,0.08)",
+              "type": "dropShadow"
             }
           ]
         },
@@ -15559,6 +15567,14 @@
               "spread": "0",
               "color": "rgba(0,0,0,0.66)",
               "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "0",
+              "blur": "0",
+              "spread": "1",
+              "color": "rgba(255,255,255,0.08)",
+              "type": "dropShadow"
             }
           ]
         },
@@ -15579,6 +15595,14 @@
               "blur": "32",
               "spread": "0",
               "color": "rgba(0,0,0,0.68)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "0",
+              "blur": "0",
+              "spread": "1",
+              "color": "rgba(255,255,255,0.08)",
               "type": "dropShadow"
             }
           ]

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -15516,38 +15516,72 @@
         }
       },
       "box-shadow": {
+        "none": {
+          "$type": "boxShadow",
+          "$value": "none"
+        },
         "sm": {
           "$type": "boxShadow",
-          "$value": {
-            "x": "0",
-            "y": "2",
-            "blur": "6",
-            "spread": "0",
-            "color": "{basis.color.default.bg-document}",
-            "type": "dropShadow"
-          }
+          "$value": [
+            {
+              "x": "0",
+              "y": "1",
+              "blur": "2",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.66)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "2",
+              "blur": "4",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.64)",
+              "type": "dropShadow"
+            }
+          ]
         },
         "md": {
           "$type": "boxShadow",
-          "$value": {
-            "x": "0",
-            "y": "8",
-            "blur": "16",
-            "spread": "0",
-            "color": "{basis.color.default.bg-document}",
-            "type": "dropShadow"
-          }
+          "$value": [
+            {
+              "x": "0",
+              "y": "2",
+              "blur": "4",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.68)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "8",
+              "blur": "16",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.66)",
+              "type": "dropShadow"
+            }
+          ]
         },
         "lg": {
           "$type": "boxShadow",
-          "$value": {
-            "x": "0",
-            "y": "16",
-            "blur": "48",
-            "spread": "0",
-            "color": "{basis.color.default.bg-document}",
-            "type": "dropShadow"
-          }
+          "$value": [
+            {
+              "x": "0",
+              "y": "4",
+              "blur": "8",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.70)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "16",
+              "blur": "32",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.68)",
+              "type": "dropShadow"
+            }
+          ]
         }
       },
       "focus": {


### PR DESCRIPTION
Nieuw toegevoegde basis-token `basis.box-shadow.none` ontbrak nog voor dark-mode. En de waarde van de box-shadow design tokens die wel al bestonden was achterhaald.

- Token `basis.box-shadow.none` is toegevoegd voor dark-mode.
- De waarde van de volgende basis-tokens is gewijzigd voor dark-mode:
  - `basis.box-shadow.sm`
  - `basis.box-shadow.md`
  - `basis.box-shadow.lg`

Controleer of deze wijzigingen ook wenselijk zijn voor het thema van jouw organisatie. Zo niet, dan hoef je deze niet over te nemen.