### PR TITLE
Placeholder for Candidate Ordered List design tokens

### DIFF
--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -9302,7 +9302,53 @@
       }
     }
   },
-  "components/ordered-list": {
+  "components/ordered-list/nl": {
+    "nl": {
+      "ordered-list": {
+        "color": {
+          "$type": "color",
+          "$value": "{basis.color.default.color-document}"
+        },
+        "font-family": {
+          "$type": "fontFamilies",
+          "$value": "{basis.text.font-family.default}"
+        },
+        "font-size": {
+          "$type": "fontSizes",
+          "$value": "{basis.text.font-size.md}"
+        },
+        "line-height": {
+          "$type": "lineHeights",
+          "$value": "{basis.text.line-height.md}"
+        },
+        "padding-inline-start": {
+          "$type": "dimension",
+          "$value": "{basis.space.inline.3xl}"
+        },
+        "item": {
+          "margin-block-end": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.sm}"
+          },
+          "margin-block-start": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.sm}"
+          },
+          "padding-inline-start": {
+            "$type": "dimension",
+            "$value": "{basis.space.inline.md}"
+          }
+        },
+        "marker": {
+          "color": {
+            "$type": "color",
+            "$value": "{nl.ordered-list.color}"
+          }
+        }
+      }
+    }
+  },
+  "components/ordered-list/utrecht": {
     "utrecht": {
       "ordered-list": {
         "font-size": {
@@ -15621,7 +15667,8 @@
       "components/note",
       "components/number-badge/nl",
       "components/number-badge/utrecht",
-      "components/ordered-list",
+      "components/ordered-list/nl",
+      "components/ordered-list/utrecht",
       "components/page-body",
       "components/page-number-navigation/utrecht",
       "components/page-number-navigation/todo",

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -9321,6 +9321,14 @@
           "$type": "lineHeights",
           "$value": "{basis.text.line-height.md}"
         },
+        "margin-block-end": {
+          "$type": "dimension",
+          "$value": "{basis.space.none}"
+        },
+        "margin-block-start": {
+          "$type": "dimension",
+          "$value": "{basis.space.none}"
+        },
         "padding-inline-start": {
           "$type": "dimension",
           "$value": "{basis.space.inline.3xl}"


### PR DESCRIPTION
Placeholder om eerste voorstel Candidate Ordered List design tokens te bewaren.

Niet blind mergen! Bij een Figma-release de set aan design tokens kopiëren en toevoegen aan de meest recente branch. Daarna nog 1 keer Apply to Selection op alle benodigde frames.