### PR TITLE
style: grid tokens Amsterdam community component

### DIFF
--- a/.changeset/grid-grid-grid.md
+++ b/.changeset/grid-grid-grid.md
@@ -1,0 +1,23 @@
+---
+"@nl-design-system-unstable/start-design-tokens": minor
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+---
+
+De volgende tokens zijn toegevoegd aan grid component:
+
+- `ams.grid.column-count`
+- `ams.grid.column-gap`
+- `ams.grid.padding-block.l`
+- `ams.grid.padding-block.xl`
+- `ams.grid.padding-block.2xl`
+- `ams.grid.padding-inline`
+- `ams.grid.row-gap.l`
+- `ams.grid.row-gap.xl`
+- `ams.grid.row-gap.2xl`
+- `ams.grid.vi-medium.column-count`
+- `ams.grid.vi-medium.padding-inline`
+- `ams.grid.vi-wide.column-count`
+- `ams.grid.vi-wide.padding-inline`
+- `ams.grid.cell.background-color`
+- `ams.grid.cell.padding-block`
+- `ams.grid.cell.padding-inline`

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -7703,6 +7703,86 @@
       }
     }
   },
+  "components/grid": {
+    "ams": {
+      "grid": {
+        "column-count": {
+          "$type": "number",
+          "$value": 12
+        },
+        "column-gap": {
+          "$type": "dimension",
+          "$value": "{basis.space.column.xl}"
+        },
+        "padding-block": {
+          "l": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.xl}"
+          },
+          "xl": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.3xl}"
+          },
+          "2xl": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.6xl}"
+          }
+        },
+        "padding-inline": {
+          "$type": "dimension",
+          "$value": "{basis.space.none}"
+        },
+        "row-gap": {
+          "l": {
+            "$type": "dimension",
+            "$value": "{basis.space.row.xl}"
+          },
+          "xl": {
+            "$type": "dimension",
+            "$value": "{basis.space.row.3xl}"
+          },
+          "2xl": {
+            "$type": "dimension",
+            "$value": "{basis.space.row.5xl}"
+          }
+        },
+        "vi-medium": {
+          "column-count": {
+            "$type": "number",
+            "$value": 12
+          },
+          "padding-inline": {
+            "$type": "dimension",
+            "$value": "{basis.space.none}"
+          }
+        },
+        "vi-wide": {
+          "column-count": {
+            "$type": "number",
+            "$value": 12
+          },
+          "padding-inline": {
+            "$type": "dimension",
+            "$value": "{basis.space.none}"
+          }
+        },
+        "cell": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.transparent}"
+          },
+          "padding-block": {
+            "$type": "dimension",
+            "$value": "{basis.space.none}"
+          },
+          "padding-inline": {
+            "$type": "dimension",
+            "$value": "{basis.space.none}"
+          }
+        }
+      }
+    }
+  },
   "components/heading/nl": {
     "nl": {
       "heading": {
@@ -15596,6 +15676,7 @@
       "components/form-field-label",
       "components/form-field-label-suffix",
       "components/form-summary",
+      "components/grid",
       "components/heading/nl",
       "components/heading/amsterdam",
       "components/heading-1",

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -7920,6 +7920,86 @@
       }
     }
   },
+  "components/grid": {
+    "ams": {
+      "grid": {
+        "column-count": {
+          "$type": "number",
+          "$value": 12
+        },
+        "column-gap": {
+          "$type": "dimension",
+          "$value": "{basis.space.column.xl}"
+        },
+        "padding-block": {
+          "l": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.xl}"
+          },
+          "xl": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.3xl}"
+          },
+          "2xl": {
+            "$type": "dimension",
+            "$value": "{basis.space.block.6xl}"
+          }
+        },
+        "padding-inline": {
+          "$type": "dimension",
+          "$value": "{basis.space.none}"
+        },
+        "row-gap": {
+          "l": {
+            "$type": "dimension",
+            "$value": "{basis.space.row.xl}"
+          },
+          "xl": {
+            "$type": "dimension",
+            "$value": "{basis.space.row.3xl}"
+          },
+          "2xl": {
+            "$type": "dimension",
+            "$value": "{basis.space.row.5xl}"
+          }
+        },
+        "vi-medium": {
+          "column-count": {
+            "$type": "number",
+            "$value": 12
+          },
+          "padding-inline": {
+            "$type": "dimension",
+            "$value": "{basis.space.none}"
+          }
+        },
+        "vi-wide": {
+          "column-count": {
+            "$type": "number",
+            "$value": 12
+          },
+          "padding-inline": {
+            "$type": "dimension",
+            "$value": "{basis.space.none}"
+          }
+        },
+        "cell": {
+          "background-color": {
+            "$type": "color",
+            "$value": "{basis.color.transparent}"
+          },
+          "padding-block": {
+            "$type": "dimension",
+            "$value": "{basis.space.none}"
+          },
+          "padding-inline": {
+            "$type": "dimension",
+            "$value": "{basis.space.none}"
+          }
+        }
+      }
+    }
+  },
   "components/heading/nl": {
     "nl": {
       "heading": {
@@ -15816,6 +15896,7 @@
       "components/form-field-label",
       "components/form-field-label-suffix",
       "components/form-summary",
+      "components/grid",
       "components/heading/nl",
       "components/heading/amsterdam",
       "components/heading-1",


### PR DESCRIPTION
De volgende tokens zijn toegevoegd aan grid component:

- `ams.grid.column-count`
- `ams.grid.column-gap`
- `ams.grid.padding-block.l`
- `ams.grid.padding-block.xl`
- `ams.grid.padding-block.2xl`
- `ams.grid.padding-inline`
- `ams.grid.row-gap.l`
- `ams.grid.row-gap.xl`
- `ams.grid.row-gap.2xl`
- `ams.grid.vi-medium.column-count`
- `ams.grid.vi-medium.padding-inline`
- `ams.grid.vi-wide.column-count`
- `ams.grid.vi-wide.padding-inline`
- `ams.grid.cell.background-color`
- `ams.grid.cell.padding-block`
- `ams.grid.cell.padding-inline`