### PR TITLE
Add Den Haag Progress List story

### DIFF
--- a/packages/theme-toolkit/src/component-stories-denhaag.tsx
+++ b/packages/theme-toolkit/src/component-stories-denhaag.tsx
@@ -7,8 +7,56 @@ import { CaseCard } from '@gemeente-denhaag/card';
 import { ActionSingle } from '@gemeente-denhaag/action';
 import { File } from '@gemeente-denhaag/file';
 import { Status } from '@gemeente-denhaag/process-steps';
+import type { StatusProps } from '@gemeente-denhaag/process-steps';
 import { StatusBadge } from '@utrecht/component-library-react/dist/css-module';
 // eslint-disable-next-line no-unused-vars
+
+export const DENHAAG_PROGRESS_LIST_STEPS: StatusProps['steps'] = [
+  {
+    id: 'deelname',
+    marker: 1,
+    status: 'checked',
+    steps: [
+      {
+        id: '04aabddd-5234-44d1-a6aa-753c5bd6f7c5',
+        status: 'checked',
+        title: 'Aanmelding ontvangen',
+      },
+    ],
+    title: 'Deelname aan geluidsonderzoek',
+  },
+  {
+    id: 'onderzoek',
+    marker: 2,
+    status: 'current',
+    steps: [
+      {
+        id: '09c4568b-828c-4656-aae2-c14ba6d51a2d',
+        status: 'checked',
+        title: 'Afspraak meten geluidsoverlast gemaakt',
+      },
+      {
+        id: 'd73a140a-64c4-4414-b003-5bc4f6d3ee8c',
+        title: 'Geluidsoverlast gemeten',
+      },
+      {
+        id: 'f8444469-0b19-43fe-bb97-4e50764119c1',
+        title: 'Onderzoek resultaten verwerkt',
+      },
+    ],
+    title: 'Onderzoek naar geluidsoverlast',
+  },
+  {
+    id: 'uitvoeren',
+    marker: 3,
+    title: 'Uitvoeren van maatregelen',
+  },
+  {
+    id: 'klaar',
+    marker: 4,
+    title: 'Maatregelen zijn uitgevoerd',
+  },
+];
 
 export const DENHAAG_COMPONENT_STORIES: ComponentStory[] = [
   {
@@ -16,56 +64,7 @@ export const DENHAAG_COMPONENT_STORIES: ComponentStory[] = [
     component: 'denhaag-steps',
     group: STORY_GROUPS['STEPS'],
     name: 'Den Haag Status',
-    render: () => (
-      <Status
-        steps={[
-          {
-            id: 'deelname',
-            marker: 1,
-            status: 'checked',
-            steps: [
-              {
-                id: '04aabddd-5234-44d1-a6aa-753c5bd6f7c5',
-                status: 'checked',
-                title: 'Aanmelding ontvangen',
-              },
-            ],
-            title: 'Deelname aan geluidsonderzoek',
-          },
-          {
-            id: 'onderzoek',
-            marker: 2,
-            status: 'current',
-            steps: [
-              {
-                id: '09c4568b-828c-4656-aae2-c14ba6d51a2d',
-                status: 'checked',
-                title: 'Afspraak meten geluidsoverlast gemaakt',
-              },
-              {
-                id: 'd73a140a-64c4-4414-b003-5bc4f6d3ee8c',
-                title: 'Geluidsoverlast gemeten',
-              },
-              {
-                id: 'f8444469-0b19-43fe-bb97-4e50764119c1',
-                title: 'Onderzoek resultaten verwerkt',
-              },
-            ],
-            title: 'Onderzoek naar geluidsoverlast',
-          },
-          {
-            id: 'uitvoeren',
-            marker: 3,
-            title: 'Uitvoeren van maatregelen',
-          },
-          {
-            id: 'klaar',
-            marker: 4,
-            title: 'Maatregelen zijn uitgevoerd',
-          },
-        ]}
-      ></Status>
-    ),
+    render: () => <Status steps={DENHAAG_PROGRESS_LIST_STEPS}></Status>,
   },
   {
     storyId: 'react-denhaag-side-navigation--default',

--- a/packages/voorbeeld-design-tokens/documentation/progress-list/denhaag-progress-list.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/progress-list/denhaag-progress-list.stories.tsx
@@ -1,58 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Status } from '@gemeente-denhaag/process-steps';
 import '@gemeente-denhaag/process-steps/index.css';
+import { DENHAAG_PROGRESS_LIST_STEPS } from '@nl-design-system-unstable/theme-toolkit/src/component-stories-denhaag';
 
 const meta = {
   id: 'denhaag-progress-list',
   title: 'Components/Progress List/Den Haag',
   component: Status,
   args: {
-    steps: [
-      {
-        id: 'deelname',
-        marker: 1,
-        status: 'checked',
-        steps: [
-          {
-            id: '04aabddd-5234-44d1-a6aa-753c5bd6f7c5',
-            status: 'checked',
-            title: 'Aanmelding ontvangen',
-          },
-        ],
-        title: 'Deelname aan geluidsonderzoek',
-      },
-      {
-        id: 'onderzoek',
-        marker: 2,
-        status: 'current',
-        steps: [
-          {
-            id: '09c4568b-828c-4656-aae2-c14ba6d51a2d',
-            status: 'checked',
-            title: 'Afspraak meten geluidsoverlast gemaakt',
-          },
-          {
-            id: 'd73a140a-64c4-4414-b003-5bc4f6d3ee8c',
-            title: 'Geluidsoverlast gemeten',
-          },
-          {
-            id: 'f8444469-0b19-43fe-bb97-4e50764119c1',
-            title: 'Onderzoek resultaten verwerkt',
-          },
-        ],
-        title: 'Onderzoek naar geluidsoverlast',
-      },
-      {
-        id: 'uitvoeren',
-        marker: 3,
-        title: 'Uitvoeren van maatregelen',
-      },
-      {
-        id: 'klaar',
-        marker: 4,
-        title: 'Maatregelen zijn uitgevoerd',
-      },
-    ],
+    steps: DENHAAG_PROGRESS_LIST_STEPS,
   },
 } satisfies Meta<typeof Status>;
 

--- a/packages/voorbeeld-design-tokens/documentation/progress-list/denhaag-progress-list.stories.tsx
+++ b/packages/voorbeeld-design-tokens/documentation/progress-list/denhaag-progress-list.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Status } from '@gemeente-denhaag/process-steps';
+import '@gemeente-denhaag/process-steps/index.css';
+
+const meta = {
+  id: 'denhaag-progress-list',
+  title: 'Components/Progress List/Den Haag',
+  component: Status,
+  args: {
+    steps: [
+      {
+        id: 'deelname',
+        marker: 1,
+        status: 'checked',
+        steps: [
+          {
+            id: '04aabddd-5234-44d1-a6aa-753c5bd6f7c5',
+            status: 'checked',
+            title: 'Aanmelding ontvangen',
+          },
+        ],
+        title: 'Deelname aan geluidsonderzoek',
+      },
+      {
+        id: 'onderzoek',
+        marker: 2,
+        status: 'current',
+        steps: [
+          {
+            id: '09c4568b-828c-4656-aae2-c14ba6d51a2d',
+            status: 'checked',
+            title: 'Afspraak meten geluidsoverlast gemaakt',
+          },
+          {
+            id: 'd73a140a-64c4-4414-b003-5bc4f6d3ee8c',
+            title: 'Geluidsoverlast gemeten',
+          },
+          {
+            id: 'f8444469-0b19-43fe-bb97-4e50764119c1',
+            title: 'Onderzoek resultaten verwerkt',
+          },
+        ],
+        title: 'Onderzoek naar geluidsoverlast',
+      },
+      {
+        id: 'uitvoeren',
+        marker: 3,
+        title: 'Uitvoeren van maatregelen',
+      },
+      {
+        id: 'klaar',
+        marker: 4,
+        title: 'Maatregelen zijn uitgevoerd',
+      },
+    ],
+  },
+} satisfies Meta<typeof Status>;
+
+type Story = StoryObj<typeof meta>;
+export default meta;
+
+export const DenHaagTheme: Story = {
+  name: 'Den Haag theme',
+  parameters: { theme: 'denhaag-theme' },
+};


### PR DESCRIPTION
## In deze PR 

Deze PR voegt een nieuwe story toe: `documentation/progress-list/denhaag-progress-list.stories.tsx`, zichtbaar onder `Components/Progress List/Den Haag`.

Voor nu is de huidige DH Process Steps component gebruikt (`Status` uit `@gemeente-denhaag/process-steps`). Er wordt momenteel gewerkt aan Progress List verbetringen. Mocht daar een nieuwe Progress List component uit komen, dan kunnen we de Process Steps component vervangen voor de nieuwe variant en gelijk zien of er breaking changes zijn (Chromatic).

## Waarom

Progress List toevoegen aan Theme's repository is de laatste stap voor Community status (zie [NL Design System Progress List](https://nldesignsystem.nl/progress-list/) en [Community Components - Den Haag project board](https://github.com/orgs/nl-design-system/projects/55?reload=1)).