### PR TITLE
chore: configure prettier to format pnpm-workspace.yaml the same as pnpm CLI does

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,15 +4,15 @@ packages:
   - proprietary/*
 
 allowBuilds:
-  "@bundled-es-modules/glob": true
+  '@bundled-es-modules/glob': true
   esbuild: true
   style-dictionary: true
 
 patchedDependencies:
-  "@dynamize/color-utilities@1.0.11": "patches/@dynamize__color-utilities@1.0.11.patch"
+  '@dynamize/color-utilities@1.0.11': 'patches/@dynamize__color-utilities@1.0.11.patch'
 
 overrides:
-  form-data@>=4.0.0 <4.0.4: ">=4.0.4"
+  form-data@>=4.0.0 <4.0.4: '>=4.0.4'
   shell-quote@>=1.1.0 <=1.8.3: ^1.8.4
 
 autoInstallPeers: false
@@ -26,19 +26,19 @@ minimumReleaseAge: 1440
 
 # Make an exception for trusted packages, notably our own
 minimumReleaseAgeExclude:
-  - "@amsterdam/*"
-  - "@gemeente-denhaag/*"
-  - "@gemeente-rotterdam/*"
-  - "@nl-design-system/*"
-  - "@nl-design-system-candidate/*"
-  - "@nl-design-system-community/*"
-  - "@nl-design-system-unstable/*"
-  - "@nl-rvo/*"
-  - "@rijkshuisstijl-community/*"
-  - "@utrecht/*"
+  - '@amsterdam/*'
+  - '@gemeente-denhaag/*'
+  - '@gemeente-rotterdam/*'
+  - '@nl-design-system/*'
+  - '@nl-design-system-candidate/*'
+  - '@nl-design-system-community/*'
+  - '@nl-design-system-unstable/*'
+  - '@nl-rvo/*'
+  - '@rijkshuisstijl-community/*'
+  - '@utrecht/*'
 
 saveExact: true
 
-savePrefix: ""
+savePrefix: ''
 
 provenance: true

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -31,5 +31,12 @@ module.exports = {
         proseWrap: 'always',
       },
     },
+    {
+      // match pnpm CLI-driven changes behavior
+      files: ['pnpm-workspace.yaml'],
+      options: {
+        singleQuote: true,
+      },
+    },
   ],
 };

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,7 +1,7 @@
 /**
  * @type {import('prettier').Config}
  */
-module.exports = {
+export default {
   printWidth: 120,
   singleQuote: true,
   // Remove `trailingComma` after we switch to Prettier 3 where this is the default


### PR DESCRIPTION
For YAML files, we use double quotes for strings.  We make an exception for the `pnpm-workspace.yaml` file, because the pnpm CLI uses single quotes.
