### PR TITLE
build: fix pnpm pack/pnpm publish behavior so dist folder is included in packages again

### DIFF
--- a/.changeset/tough-parrots-glow.md
+++ b/.changeset/tough-parrots-glow.md
@@ -1,0 +1,7 @@
+---
+"@nl-design-system-community/ma-design-tokens": patch
+"@nl-design-system-unstable/groningen-design-tokens": patch
+"@nl-design-system-community/losser-design-tokens": patch
+---
+
+Republish package with dist folder (the previous release omitted it due to a change in pnpm behavior)

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# Files listed here are excluded from the published package.
+# Keep this file even when empty; otherwise npm uses .gitignore during publish.


### PR DESCRIPTION
- **build: don't fall back to .gitignore when publishing by including an empty .npmignore**
- **chore: republish packages with missing dist folder**
