### PR TITLE
chore: fix typo in changeset

### DIFF
--- a/.changeset/card-as-link.md
+++ b/.changeset/card-as-link.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/start-design-tokens": marjor
+"@nl-design-system-unstable/start-design-tokens": major
 "@nl-design-system-unstable/voorbeeld-design-tokens": major
 "@nl-design-system-community/ma-design-tokens": major
 ---


### PR DESCRIPTION
This typo prevents the release PR from being generated.
