### PR TITLE
style: update Accordion tokens Utrecht community component

### DIFF
--- a/.changeset/accordion-todo-utrecht.md
+++ b/.changeset/accordion-todo-utrecht.md
@@ -1,0 +1,12 @@
+---
+"@nl-design-system-unstable/start-design-tokens": minor
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+"@nl-design-system-community/ma-design-tokens": minor
+---
+
+De volgende tokens zijn hernoemd in Accordion component:
+
+- `todo.accordion.button.font-family` naar `utrecht.accordion.button.font-family` 
+- `todo.accordion.button.font-size` naar `utrecht.accordion.button.font-size` 
+- `todo.accordion.button.font-weight` naar `utrecht.accordion.button.font-weight` 
+- `todo.accordion.button.line-height` naar `utrecht.accordion.button.line-height` 

--- a/packages/ma-design-tokens/src/tokens.json
+++ b/packages/ma-design-tokens/src/tokens.json
@@ -2911,9 +2911,25 @@
             "$type": "color",
             "$value": "{basis.color.action-2.color-default}"
           },
+          "font-family": {
+            "$type": "fontFamilies",
+            "$value": "{basis.text.font-family.default}"
+          },
+          "font-size": {
+            "$type": "fontSizes",
+            "$value": "{basis.text.font-size.md}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{basis.text.font-weight.bold}"
+          },
           "gap": {
             "$type": "dimension",
             "$value": "{basis.space.text.md}"
+          },
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{basis.text.line-height.md}"
           },
           "padding-block-end": {
             "$type": "dimension",
@@ -3034,28 +3050,6 @@
             "$type": "dimension",
             "$value": "{basis.space.none}",
             "$description": "[code-only]"
-          }
-        }
-      }
-    },
-    "todo": {
-      "accordion": {
-        "button": {
-          "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{basis.text.font-family.default}"
-          },
-          "font-size": {
-            "$type": "fontSizes",
-            "$value": "{basis.text.font-size.md}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{basis.text.font-weight.bold}"
-          },
-          "line-height": {
-            "$type": "lineHeights",
-            "$value": "{basis.text.line-height.md}"
           }
         }
       }

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -2693,9 +2693,25 @@
             "$type": "color",
             "$value": "{basis.color.action-2.color-default}"
           },
+          "font-family": {
+            "$type": "fontFamilies",
+            "$value": "{basis.text.font-family.default}"
+          },
+          "font-size": {
+            "$type": "fontSizes",
+            "$value": "{basis.text.font-size.md}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{basis.text.font-weight.bold}"
+          },
           "gap": {
             "$type": "dimension",
             "$value": "{basis.space.text.md}"
+          },
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{basis.text.line-height.md}"
           },
           "padding-block-end": {
             "$type": "dimension",
@@ -2816,28 +2832,6 @@
             "$type": "dimension",
             "$value": "{basis.space.none}",
             "$description": "[code-only]"
-          }
-        }
-      }
-    },
-    "todo": {
-      "accordion": {
-        "button": {
-          "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{basis.text.font-family.default}"
-          },
-          "font-size": {
-            "$type": "fontSizes",
-            "$value": "{basis.text.font-size.md}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{basis.text.font-weight.bold}"
-          },
-          "line-height": {
-            "$type": "lineHeights",
-            "$value": "{basis.text.line-height.md}"
           }
         }
       }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -2940,9 +2940,25 @@
             "$type": "color",
             "$value": "{basis.color.action-2.color-default}"
           },
+          "font-family": {
+            "$type": "fontFamilies",
+            "$value": "{basis.text.font-family.default}"
+          },
+          "font-size": {
+            "$type": "fontSizes",
+            "$value": "{basis.text.font-size.md}"
+          },
+          "font-weight": {
+            "$type": "fontWeights",
+            "$value": "{basis.text.font-weight.bold}"
+          },
           "gap": {
             "$type": "dimension",
             "$value": "{basis.space.text.md}"
+          },
+          "line-height": {
+            "$type": "lineHeights",
+            "$value": "{basis.text.line-height.md}"
           },
           "padding-block-end": {
             "$type": "dimension",
@@ -3063,28 +3079,6 @@
             "$type": "dimension",
             "$value": "0px",
             "$description": "[code-only]"
-          }
-        }
-      }
-    },
-    "todo": {
-      "accordion": {
-        "button": {
-          "font-family": {
-            "$type": "fontFamilies",
-            "$value": "{basis.text.font-family.default}"
-          },
-          "font-size": {
-            "$type": "fontSizes",
-            "$value": "{basis.text.font-size.md}"
-          },
-          "font-weight": {
-            "$type": "fontWeights",
-            "$value": "{basis.text.font-weight.bold}"
-          },
-          "line-height": {
-            "$type": "lineHeights",
-            "$value": "{basis.text.line-height.md}"
           }
         }
       }


### PR DESCRIPTION
De volgende tokens zijn hernoemd in Accordion component:

- `todo.accordion.button.font-family` naar `utrecht.accordion.button.font-family` 
- `todo.accordion.button.font-size` naar `utrecht.accordion.button.font-size` 
- `todo.accordion.button.font-weight` naar `utrecht.accordion.button.font-weight` 
- `todo.accordion.button.line-height` naar `utrecht.accordion.button.line-height` 