### PR TITLE
style: update Checkbox tokens Utrecht community component

### DIFF
--- a/.changeset/checkbox-todo-utrecht.md
+++ b/.changeset/checkbox-todo-utrecht.md
@@ -1,0 +1,24 @@
+---
+"@nl-design-system-unstable/start-design-tokens": minor
+"@nl-design-system-unstable/voorbeeld-design-tokens": minor
+"@nl-design-system-community/ma-design-tokens": minor
+---
+
+De volgende tokens zijn hernoemd in Checkbox component:
+
+- `todo.checkbox.checked.active.background-color` naar `utrecht.checkbox.checked.active.background-color`
+- `todo.checkbox.checked.active.border-color` naar `utrecht.checkbox.checked.active.border-color`
+- `todo.checkbox.checked.active.border-width` naar `utrecht.checkbox.checked.active.border-width`
+- `todo.checkbox.checked.active.color` naar `utrecht.checkbox.checked.active.color`
+- `todo.checkbox.checked.hover.background-color` naar `utrecht.checkbox.checked.hover.background-color`
+- `todo.checkbox.checked.hover.border-color` naar `utrecht.checkbox.checked.hover.border-color`
+- `todo.checkbox.checked.hover.border-width` naar `utrecht.checkbox.checked.hover.border-width`
+- `todo.checkbox.checked.hover.color` naar `utrecht.checkbox.checked.hover.color`
+- `todo.checkbox.indeterminate.active.background-color` naar `utrecht.checkbox.indeterminate.active.background-color`
+- `todo.checkbox.indeterminate.active.border-color` naar `utrecht.checkbox.indeterminate.active.border-color`
+- `todo.checkbox.indeterminate.active.border-width` naar `utrecht.checkbox.indeterminate.active.border-width`
+- `todo.checkbox.indeterminate.active.color` naar `utrecht.checkbox.indeterminate.active.color`
+- `todo.checkbox.indeterminate.hover.background-color` utrecht `todo.checkbox.indeterminate.hover.background-color`
+- `todo.checkbox.indeterminate.hover.border-color` naar `utrecht.checkbox.indeterminate.hover.border-color`
+- `todo.checkbox.indeterminate.hover.border-width` naar `utrecht.checkbox.indeterminate.hover.border-width`
+- `todo.checkbox.indeterminate.hover.color` naar `utrecht.checkbox.indeterminate.hover.color`

--- a/packages/ma-design-tokens/src/tokens.json
+++ b/packages/ma-design-tokens/src/tokens.json
@@ -6921,6 +6921,42 @@
           "color": {
             "$type": "color",
             "$value": "{basis.color.action-1-inverse.color-default}"
+          },
+          "active": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.form-control.active.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "border-width": {
+              "$type": "dimension",
+              "$value": "{basis.form-control.active.border-width}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.action-1-inverse.color-active}"
+            }
+          },
+          "hover": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.form-control.hover.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "border-width": {
+              "$type": "dimension",
+              "$value": "{basis.form-control.hover.border-width}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.action-1-inverse.color-hover}"
+            }
           }
         },
         "indeterminate": {
@@ -6939,6 +6975,42 @@
           "color": {
             "$type": "color",
             "$value": "{basis.color.action-1-inverse.color-default}"
+          },
+          "active": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.form-control.active.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "border-width": {
+              "$type": "dimension",
+              "$value": "{basis.form-control.active.border-width}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.action-1-inverse.color-active}"
+            }
+          },
+          "hover": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.form-control.hover.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "border-width": {
+              "$type": "dimension",
+              "$value": "{basis.form-control.hover.border-width}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.action-1-inverse.color-hover}"
+            }
           }
         }
       }
@@ -6946,24 +7018,6 @@
     "todo": {
       "checkbox": {
         "checked": {
-          "active": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{basis.form-control.active.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "border-width": {
-              "$type": "dimension",
-              "$value": "{basis.form-control.active.border-width}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.action-1-inverse.color-active}"
-            }
-          },
           "disabled": {
             "background-color": {
               "$type": "color",
@@ -6994,46 +7048,10 @@
             "color": {
               "$type": "color",
               "$value": "{basis.form-control.focus.color}"
-            }
-          },
-          "hover": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{basis.form-control.hover.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "border-width": {
-              "$type": "dimension",
-              "$value": "{basis.form-control.hover.border-width}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.action-1-inverse.color-hover}"
             }
           }
         },
         "indeterminate": {
-          "active": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{basis.form-control.active.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "border-width": {
-              "$type": "dimension",
-              "$value": "{basis.form-control.active.border-width}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.action-1-inverse.color-active}"
-            }
-          },
           "disabled": {
             "background-color": {
               "$type": "color",
@@ -7064,24 +7082,6 @@
             "color": {
               "$type": "color",
               "$value": "{basis.form-control.focus.color}"
-            }
-          },
-          "hover": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{basis.form-control.hover.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "border-width": {
-              "$type": "dimension",
-              "$value": "{basis.form-control.hover.border-width}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.action-1-inverse.color-hover}"
             }
           }
         }

--- a/packages/start-design-tokens/figma/start.tokens.json
+++ b/packages/start-design-tokens/figma/start.tokens.json
@@ -6234,6 +6234,42 @@
           "color": {
             "$type": "color",
             "$value": "{basis.color.action-1-inverse.color-default}"
+          },
+          "active": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.form-control.active.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "border-width": {
+              "$type": "dimension",
+              "$value": "{basis.form-control.active.border-width}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.action-1-inverse.color-active}"
+            }
+          },
+          "hover": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.form-control.hover.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "border-width": {
+              "$type": "dimension",
+              "$value": "{basis.form-control.hover.border-width}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.action-1-inverse.color-hover}"
+            }
           }
         },
         "indeterminate": {
@@ -6252,6 +6288,42 @@
           "color": {
             "$type": "color",
             "$value": "{basis.color.action-1-inverse.color-default}"
+          },
+          "active": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.form-control.active.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "border-width": {
+              "$type": "dimension",
+              "$value": "{basis.form-control.active.border-width}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.action-1-inverse.color-active}"
+            }
+          },
+          "hover": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.form-control.hover.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "border-width": {
+              "$type": "dimension",
+              "$value": "{basis.form-control.hover.border-width}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.action-1-inverse.color-hover}"
+            }
           }
         }
       }
@@ -6259,24 +6331,6 @@
     "todo": {
       "checkbox": {
         "checked": {
-          "active": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{basis.form-control.active.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "border-width": {
-              "$type": "dimension",
-              "$value": "{basis.form-control.active.border-width}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.action-1-inverse.color-active}"
-            }
-          },
           "disabled": {
             "background-color": {
               "$type": "color",
@@ -6307,46 +6361,10 @@
             "color": {
               "$type": "color",
               "$value": "{basis.form-control.focus.color}"
-            }
-          },
-          "hover": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{basis.form-control.hover.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "border-width": {
-              "$type": "dimension",
-              "$value": "{basis.form-control.hover.border-width}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.action-1-inverse.color-hover}"
             }
           }
         },
         "indeterminate": {
-          "active": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{basis.form-control.active.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "border-width": {
-              "$type": "dimension",
-              "$value": "{basis.form-control.active.border-width}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.action-1-inverse.color-active}"
-            }
-          },
           "disabled": {
             "background-color": {
               "$type": "color",
@@ -6377,24 +6395,6 @@
             "color": {
               "$type": "color",
               "$value": "{basis.form-control.focus.color}"
-            }
-          },
-          "hover": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{basis.form-control.hover.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "border-width": {
-              "$type": "dimension",
-              "$value": "{basis.form-control.hover.border-width}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.action-1-inverse.color-hover}"
             }
           }
         }

--- a/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
+++ b/packages/voorbeeld-design-tokens/figma/voorbeeld.tokens.json
@@ -6481,6 +6481,42 @@
           "color": {
             "$type": "color",
             "$value": "{basis.color.action-1-inverse.color-default}"
+          },
+          "active": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.form-control.active.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "border-width": {
+              "$type": "dimension",
+              "$value": "{basis.form-control.active.border-width}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.action-1-inverse.color-active}"
+            }
+          },
+          "hover": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.form-control.hover.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "border-width": {
+              "$type": "dimension",
+              "$value": "{basis.form-control.hover.border-width}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.action-1-inverse.color-hover}"
+            }
           }
         },
         "indeterminate": {
@@ -6499,6 +6535,42 @@
           "color": {
             "$type": "color",
             "$value": "{basis.color.action-1-inverse.color-default}"
+          },
+          "active": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.form-control.active.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "border-width": {
+              "$type": "dimension",
+              "$value": "{basis.form-control.active.border-width}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.action-1-inverse.color-active}"
+            }
+          },
+          "hover": {
+            "background-color": {
+              "$type": "color",
+              "$value": "{basis.form-control.hover.accent-color}"
+            },
+            "border-color": {
+              "$type": "color",
+              "$value": "{basis.color.transparent}"
+            },
+            "border-width": {
+              "$type": "dimension",
+              "$value": "{basis.form-control.hover.border-width}"
+            },
+            "color": {
+              "$type": "color",
+              "$value": "{basis.color.action-1-inverse.color-hover}"
+            }
           }
         }
       }
@@ -6506,24 +6578,6 @@
     "todo": {
       "checkbox": {
         "checked": {
-          "active": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{basis.form-control.active.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "border-width": {
-              "$type": "dimension",
-              "$value": "{basis.form-control.active.border-width}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.action-1-inverse.color-active}"
-            }
-          },
           "disabled": {
             "background-color": {
               "$type": "color",
@@ -6554,46 +6608,10 @@
             "color": {
               "$type": "color",
               "$value": "{basis.form-control.focus.color}"
-            }
-          },
-          "hover": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{basis.form-control.hover.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "border-width": {
-              "$type": "dimension",
-              "$value": "{basis.form-control.hover.border-width}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.action-1-inverse.color-hover}"
             }
           }
         },
         "indeterminate": {
-          "active": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{basis.form-control.active.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "border-width": {
-              "$type": "dimension",
-              "$value": "{basis.form-control.active.border-width}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.action-1-inverse.color-active}"
-            }
-          },
           "disabled": {
             "background-color": {
               "$type": "color",
@@ -6624,24 +6642,6 @@
             "color": {
               "$type": "color",
               "$value": "{basis.form-control.focus.color}"
-            }
-          },
-          "hover": {
-            "background-color": {
-              "$type": "color",
-              "$value": "{basis.form-control.hover.accent-color}"
-            },
-            "border-color": {
-              "$type": "color",
-              "$value": "{basis.color.transparent}"
-            },
-            "border-width": {
-              "$type": "dimension",
-              "$value": "{basis.form-control.hover.border-width}"
-            },
-            "color": {
-              "$type": "color",
-              "$value": "{basis.color.action-1-inverse.color-hover}"
             }
           }
         }


### PR DESCRIPTION
De volgende tokens zijn hernoemd in Accordion component:

- `todo.checkbox.checked.active.background-color` naar `utrecht.checkbox.checked.active.background-color`
- `todo.checkbox.checked.active.border-color` naar `utrecht.checkbox.checked.active.border-color`
- `todo.checkbox.checked.active.border-width` naar `utrecht.checkbox.checked.active.border-width`
- `todo.checkbox.checked.active.color` naar `utrecht.checkbox.checked.active.color`
- `todo.checkbox.checked.hover.background-color` naar `utrecht.checkbox.checked.hover.background-color`
- `todo.checkbox.checked.hover.border-color` naar `utrecht.checkbox.checked.hover.border-color`
- `todo.checkbox.checked.hover.border-width` naar `utrecht.checkbox.checked.hover.border-width`
- `todo.checkbox.checked.hover.color` naar `utrecht.checkbox.checked.hover.color`
- `todo.checkbox.indeterminate.active.background-color` naar `utrecht.checkbox.indeterminate.active.background-color`
- `todo.checkbox.indeterminate.active.border-color` naar `utrecht.checkbox.indeterminate.active.border-color`
- `todo.checkbox.indeterminate.active.border-width` naar `utrecht.checkbox.indeterminate.active.border-width`
- `todo.checkbox.indeterminate.active.color` naar `utrecht.checkbox.indeterminate.active.color`
- `todo.checkbox.indeterminate.hover.background-color` utrecht `todo.checkbox.indeterminate.hover.background-color`
- `todo.checkbox.indeterminate.hover.border-color` naar `utrecht.checkbox.indeterminate.hover.border-color`
- `todo.checkbox.indeterminate.hover.border-width` naar `utrecht.checkbox.indeterminate.hover.border-width`
- `todo.checkbox.indeterminate.hover.color` naar `utrecht.checkbox.indeterminate.hover.color`